### PR TITLE
Spec 001: JDK 17 toolchain hint (.tool-versions)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+# Used by asdf/mise. Ensures a compatible Gradle runtime.
+java 17

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ app/src/main/java/com/podcastplayer/app/
 ./gradlew assembleDebug
 ```
 
+### JDK
+
+This project expects **JDK 17**. If your system `java` is newer and Gradle fails early, set `JAVA_HOME` to a JDK 17 install (or use a version manager like mise/asdf via `.tool-versions`).
+
+
 ### Install
 
 ```bash

--- a/docs/specs/001-build-jdk17.md
+++ b/docs/specs/001-build-jdk17.md
@@ -1,0 +1,35 @@
+# Spec 001: Ensure Gradle runs on JDK 17
+
+## Context
+The project targets Java 17 (`compileOptions` + `kotlinOptions`). However, Gradle itself runs on whatever JDK is selected by the environment.
+
+On machines where `java` points at a very new JDK (e.g. **JDK 25**), Gradle/Kotlin DSL can fail early during settings/build script compilation (example seen on this dev machine):
+
+- `java.lang.IllegalArgumentException: 25.0.1` (from Kotlin/IntelliJ `JavaVersion.parse`)
+
+This makes the repo effectively **not buildable out-of-the-box** for some environments.
+
+## Goals
+- Make it easy/obvious to use **JDK 17** locally.
+- Keep CI pinned to **JDK 17**.
+
+## Non-goals
+- Upgrading Gradle/AGP/Kotlin as part of this change.
+- Trying to support every local setup automatically.
+
+## Proposal
+1. Add a repo-level toolchain hint file so common version managers (asdf/mise) can select a compatible JDK.
+2. Document the requirement in README.
+
+### Implementation
+- Add `.tool-versions` with:
+  - `java 17`
+- README: note that the project expects JDK 17 and how to set `JAVA_HOME` accordingly.
+
+## Acceptance criteria
+- CI uses JDK 17 (already true).
+- Local dev can run `mise install` (or equivalent) and then `./gradlew assembleDebug` successfully.
+
+## Testing checklist
+- [ ] With system `java` pointing at a newer JDK (>= 21), set JDK 17 via mise/asdf or `JAVA_HOME`.
+- [ ] `./gradlew assembleDebug` succeeds.


### PR DESCRIPTION
Adds a repo-level JDK 17 hint for mise/asdf and documents the requirement. Also introduces docs/specs/ with Spec 001.\n\n- Adds .tool-versions (java 17)\n- README: JDK 17 note\n- docs/specs/001-build-jdk17.md