### PR TITLE
Fix MiniPlayer artwork fallbacks

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/MiniPlayerBar.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/MiniPlayerBar.kt
@@ -20,10 +20,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
 import coil.compose.AsyncImage
+import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.PlayerState
 import com.podcastplayer.app.domain.model.PlaybackState
@@ -62,8 +64,12 @@ fun MiniPlayerBar(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 AsyncImage(
-                    model = artworkUrl ?: episode.localPath ?: episode.audioUrl,
+                    // Only ever pass image URLs to Coil. Never pass audio URLs or local audio file paths.
+                    model = episode.imageUrl ?: artworkUrl,
                     contentDescription = episode.title,
+                    placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                    error = painterResource(R.drawable.ic_artwork_placeholder),
+                    fallback = painterResource(R.drawable.ic_artwork_placeholder),
                     modifier = Modifier.size(48.dp)
                 )
                 Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/res/drawable/ic_artwork_placeholder.xml
+++ b/app/src/main/res/drawable/ic_artwork_placeholder.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Simple generic artwork placeholder: box + play glyph -->
+    <path
+        android:fillColor="#FFB0B0B0"
+        android:pathData="M4,4h16v16h-16z" />
+
+    <path
+        android:fillColor="#FF6D6D6D"
+        android:pathData="M10,8 L16,12 L10,16 Z" />
+</vector>


### PR DESCRIPTION
- MiniPlayerBar now uses only image URLs (episode.imageUrl or podcast artworkUrl) for artwork\n- Adds a simple placeholder drawable for loading/error/fallback\n- Prevents Coil from being given audio URLs or local audio file paths