### PR TITLE
Spec 003: Migrate navigation to Navigation Compose routes

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -1,9 +1,17 @@
 package com.podcastplayer.app.presentation.ui
 
+import android.net.Uri
 import androidx.activity.compose.BackHandler
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
 import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
@@ -15,9 +23,24 @@ import com.podcastplayer.app.presentation.viewmodel.PlayerViewModel
 import com.podcastplayer.app.presentation.viewmodel.PodcastViewModel
 import com.podcastplayer.app.service.PlayerController
 
+private object Routes {
+    const val Search = "search"
+    const val Queue = "queue"
+    const val Player = "player"
+
+    const val EpisodesBase = "episodes"
+    const val PodcastIdArg = "podcastId"
+
+    const val EpisodesPattern = "$EpisodesBase/{$PodcastIdArg}"
+
+    fun episodes(podcastId: String): String = "$EpisodesBase/${Uri.encode(podcastId)}"
+}
+
 @Composable
 fun PodcastNavHost() {
     val context = LocalContext.current
+
+    // Keep ViewModel scoping identical to the previous implementation (created once at the top level).
     val podcastViewModel: PodcastViewModel = viewModel(
         factory = PodcastViewModelFactory(
             PodcastRepository(iTunesApi.create(), RssParser()),
@@ -31,50 +54,58 @@ fun PodcastNavHost() {
         )
     )
 
-    var currentScreen by remember { mutableStateOf("search") }
-    var selectedPodcast by remember { mutableStateOf<Podcast?>(null) }
+    val navController = rememberNavController()
 
-    BackHandler(enabled = currentScreen != "search") {
-        when (currentScreen) {
-            "player" -> currentScreen = "episodes"
-            "episodes" -> {
-                currentScreen = "search"
-                selectedPodcast = null
-            }
-            "queue" -> currentScreen = "search"
-        }
-    }
-
-    when (currentScreen) {
-        "search" -> {
+    NavHost(
+        navController = navController,
+        startDestination = Routes.Search
+    ) {
+        composable(Routes.Search) {
             PodcastListScreen(
                 viewModel = podcastViewModel,
                 playerViewModel = playerViewModel,
-                onPodcastSelected = { podcast ->
-                    selectedPodcast = podcast
+                onPodcastSelected = { podcast: Podcast ->
                     podcastViewModel.selectPodcast(podcast)
-                    currentScreen = "episodes"
+                    navController.navigate(Routes.episodes(podcast.id))
                 },
-                onOpenPlayer = { currentScreen = "player" },
-                onOpenQueue = { currentScreen = "queue" }
+                onOpenPlayer = { navController.navigate(Routes.Player) },
+                onOpenQueue = { navController.navigate(Routes.Queue) }
             )
         }
-        "episodes" -> {
+
+        composable(
+            route = Routes.EpisodesPattern,
+            arguments = listOf(
+                navArgument(Routes.PodcastIdArg) { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            // Ensure the ViewModel is aligned with the route arg (e.g., when navigating here from Queue).
+            val podcastId = backStackEntry.arguments?.getString(Routes.PodcastIdArg)
+            val selectedPodcast by podcastViewModel.selectedPodcast.collectAsState()
+            val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
+
+            val podcastForScreen = when {
+                selectedPodcast?.id == podcastId -> selectedPodcast
+                podcastId != null -> savedPodcasts.firstOrNull { it.id == podcastId }?.also {
+                    podcastViewModel.selectPodcast(it)
+                }
+                else -> selectedPodcast
+            }
+
             EpisodeListScreen(
-                podcast = selectedPodcast,
+                podcast = podcastForScreen,
                 podcastViewModel = podcastViewModel,
                 playerViewModel = playerViewModel,
                 onBack = {
-                    currentScreen = "search"
-                    selectedPodcast = null
+                    // Match previous behavior: Episodes back always returns to Search.
+                    navController.popBackStack(route = Routes.Search, inclusive = false)
                 },
-                onPlayEpisode = {
-                    currentScreen = "player"
-                },
-                onOpenPlayer = { currentScreen = "player" }
+                onPlayEpisode = { navController.navigate(Routes.Player) },
+                onOpenPlayer = { navController.navigate(Routes.Player) }
             )
         }
-        "queue" -> {
+
+        composable(Routes.Queue) {
             val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
             val currentEpisode by playerViewModel.currentEpisode.collectAsState()
             val playerState by playerViewModel.playerState.collectAsState()
@@ -86,25 +117,51 @@ fun PodcastNavHost() {
                 currentArtworkUrl = currentArtworkUrl,
                 playerState = playerState,
                 onPlayPause = { playerViewModel.togglePlayPause() },
-                onOpenPlayer = { currentScreen = "player" },
+                onOpenPlayer = { navController.navigate(Routes.Player) },
                 onSeek = { playerViewModel.seekTo(it) },
                 onMove = { from, to -> podcastViewModel.moveSavedPodcast(from, to) },
                 onRemove = { podcastId -> podcastViewModel.removeSavedPodcast(podcastId) },
                 onPlayQueue = {
                     savedPodcasts.firstOrNull()?.let { first ->
-                        selectedPodcast = first
                         podcastViewModel.selectPodcast(first)
-                        currentScreen = "episodes"
+                        navController.navigate(Routes.episodes(first.id)) {
+                            // Match previous behavior: Queue -> Episodes should not return to Queue on back.
+                            popUpTo(Routes.Search) { inclusive = false }
+                            launchSingleTop = true
+                        }
                     }
                 },
-                onBack = { currentScreen = "search" }
+                onBack = {
+                    // Match previous behavior: Queue back always returns to Search.
+                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                }
             )
         }
-        "player" -> {
+
+        composable(Routes.Player) {
             val currentEpisode by playerViewModel.currentEpisode.collectAsState()
             val playerState by playerViewModel.playerState.collectAsState()
             val sleepTimerRemaining by playerViewModel.sleepTimerRemaining.collectAsState()
             val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
+            val selectedPodcast by podcastViewModel.selectedPodcast.collectAsState()
+
+            fun goToEpisodesOrSearch() {
+                val podcastId = selectedPodcast?.id
+                if (podcastId == null) {
+                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                } else {
+                    navController.navigate(Routes.episodes(podcastId)) {
+                        // Match previous behavior: Player back always returns to Episodes (and then to Search).
+                        popUpTo(Routes.Search) { inclusive = false }
+                        launchSingleTop = true
+                    }
+                }
+            }
+
+            BackHandler {
+                goToEpisodesOrSearch()
+            }
+
             PlayerScreen(
                 episode = currentEpisode ?: Episode("", "", "", null, null, "", null, null),
                 playerState = playerState,
@@ -115,7 +172,7 @@ fun PodcastNavHost() {
                 onSpeedChange = { playerViewModel.setPlaybackSpeed(it) },
                 onSetSleepTimer = { playerViewModel.setSleepTimer(it) },
                 onCancelSleepTimer = { playerViewModel.cancelSleepTimer() },
-                onDismiss = { currentScreen = "episodes" }
+                onDismiss = { goToEpisodesOrSearch() }
             )
         }
     }


### PR DESCRIPTION
Implements Spec 003 by replacing manual currentScreen routing with Navigation Compose NavHost routes:\n\n- search\n- episodes/{podcastId}\n- queue\n- player\n\nViewModel scoping remains at the top-level (same instances across destinations). Back behavior matches the previous implementation (player -> episodes -> search; queue -> search).