### PR TITLE
Play Queue from Home + play unplayed episodes across subscriptions

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -92,11 +92,6 @@ fun PodcastListScreen(
                 Box(
                     modifier = Modifier
                         .weight(1f, fill = true)
-                        .pointerInput(isSearchFocused) {
-                            if (isSearchFocused) {
-                                detectTapGestures(onTap = { focusManager.clearFocus() })
-                            }
-                        }
                 ) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
@@ -120,7 +115,10 @@ fun PodcastListScreen(
                                 items(savedPodcasts) { podcast ->
                                     PodcastItem(
                                         podcast = podcast,
-                                        onClick = { onPodcastSelected(podcast) },
+                                        onClick = {
+                                            focusManager.clearFocus()
+                                            onPodcastSelected(podcast)
+                                        },
                                         onSaveToggle = { viewModel.removeSavedPodcast(podcast.id) },
                                         isSaved = true
                                     )
@@ -165,7 +163,10 @@ fun PodcastListScreen(
                                     val alreadySaved = savedPodcasts.any { it.id == podcast.id }
                                     PodcastItem(
                                         podcast = podcast,
-                                        onClick = { onPodcastSelected(podcast) },
+                                        onClick = {
+                                            focusManager.clearFocus()
+                                            onPodcastSelected(podcast)
+                                        },
                                         onSaveToggle = {
                                             if (alreadySaved) viewModel.removeSavedPodcast(podcast.id) else viewModel.savePodcast(podcast)
                                         },

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -241,6 +241,7 @@ fun SavedEmptyStateCard(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PodcastItem(
     podcast: Podcast,
@@ -249,6 +250,7 @@ fun PodcastItem(
     isSaved: Boolean = false,
 ) {
     Card(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth(),
         shape = RoundedCornerShape(12.dp)

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BookmarkAdd
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -31,6 +32,7 @@ fun PodcastListScreen(
     onPodcastSelected: (Podcast) -> Unit,
     onOpenPlayer: () -> Unit,
     onOpenQueue: () -> Unit,
+    onPlayQueue: () -> Unit,
 ) {
     var searchQuery by remember { mutableStateOf("") }
     var isSearchFocused by remember { mutableStateOf(false) }
@@ -53,6 +55,9 @@ fun PodcastListScreen(
                 title = { Text("Podcast Player") },
                 actions = {
                     if (!isSearchFocused) {
+                        IconButton(onClick = onPlayQueue, enabled = savedPodcasts.isNotEmpty()) {
+                            Icon(Icons.Default.PlayArrow, contentDescription = "Play queue")
+                        }
                         TextButton(onClick = onOpenQueue, enabled = savedPodcasts.isNotEmpty()) {
                             Text("Queue")
                         }
@@ -106,7 +111,7 @@ fun PodcastListScreen(
                         if (!isSearchFocused) {
                             item {
                                 Text(
-                                    text = "Saved",
+                                    text = "Subscriptions",
                                     style = MaterialTheme.typography.titleMedium,
                                     modifier = Modifier.padding(vertical = 4.dp)
                                 )

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -24,6 +24,7 @@ import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.presentation.viewmodel.PlayerViewModel
 import com.podcastplayer.app.presentation.viewmodel.PodcastViewModel
 import com.podcastplayer.app.service.PlayerController
+import kotlinx.coroutines.launch
 
 private object Routes {
     const val Search = "search"
@@ -65,6 +66,7 @@ fun PodcastNavHost() {
         startDestination = Routes.Search
     ) {
         composable(Routes.Search) {
+            val scope = androidx.compose.runtime.rememberCoroutineScope()
             PodcastListScreen(
                 viewModel = podcastViewModel,
                 playerViewModel = playerViewModel,
@@ -73,7 +75,24 @@ fun PodcastNavHost() {
                     navController.navigate(Routes.episodes(podcast.id))
                 },
                 onOpenPlayer = { navController.navigate(Routes.Player) },
-                onOpenQueue = { navController.navigate(Routes.Queue) }
+                onOpenQueue = { navController.navigate(Routes.Queue) },
+                onPlayQueue = {
+                    // Build a flattened episode list from subscriptions in queue order and start playback.
+                    // If there are no episodes, do nothing.
+                    val podcasts = podcastViewModel.savedPodcasts.value
+                    if (podcasts.isNotEmpty()) {
+                        scope.launch {
+                            val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(podcasts)
+                            if (episodes.isNotEmpty()) {
+                                playerViewModel.playEpisodesQueue(
+                                    episodes = episodes,
+                                    defaultArtworkUrl = podcasts.firstOrNull()?.artworkUrl
+                                )
+                                navController.navigate(Routes.Player)
+                            }
+                        }
+                    }
+                }
             )
         }
 
@@ -110,6 +129,7 @@ fun PodcastNavHost() {
         }
 
         composable(Routes.Queue) {
+            val scope = androidx.compose.runtime.rememberCoroutineScope()
             val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
             val currentEpisode by playerViewModel.currentEpisode.collectAsState()
             val playerState by playerViewModel.playerState.collectAsState()
@@ -126,12 +146,16 @@ fun PodcastNavHost() {
                 onMove = { from, to -> podcastViewModel.moveSavedPodcast(from, to) },
                 onRemove = { podcastId -> podcastViewModel.removeSavedPodcast(podcastId) },
                 onPlayQueue = {
-                    savedPodcasts.firstOrNull()?.let { first ->
-                        podcastViewModel.selectPodcast(first)
-                        navController.navigate(Routes.episodes(first.id)) {
-                            // Match previous behavior: Queue -> Episodes should not return to Queue on back.
-                            popUpTo(Routes.Search) { inclusive = false }
-                            launchSingleTop = true
+                    if (savedPodcasts.isNotEmpty()) {
+                        scope.launch {
+                            val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(savedPodcasts)
+                            if (episodes.isNotEmpty()) {
+                                playerViewModel.playEpisodesQueue(
+                                    episodes = episodes,
+                                    defaultArtworkUrl = savedPodcasts.firstOrNull()?.artworkUrl
+                                )
+                                navController.navigate(Routes.Player)
+                            }
                         }
                     }
                 },

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
@@ -54,6 +54,28 @@ class PlayerViewModel(
         }
     }
 
+    fun playEpisodesQueue(episodes: List<Episode>, defaultArtworkUrl: String?) {
+        if (episodes.isEmpty()) return
+
+        viewModelScope.launch {
+            val first = episodes.first()
+            _currentEpisode.value = first
+            _currentArtworkUrl.value = first.imageUrl ?: defaultArtworkUrl
+            _playerState.value = _playerState.value.copy(
+                state = PlaybackState.LOADING,
+                currentEpisode = first
+            )
+
+            try {
+                playerController.playEpisodes(episodes, defaultArtworkUrl)
+                _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
+                startPositionUpdates()
+            } catch (e: Exception) {
+                _playerState.value = _playerState.value.copy(state = PlaybackState.ERROR)
+            }
+        }
+    }
+
     fun togglePlayPause() {
         viewModelScope.launch {
             val currentState = _playerState.value.state

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -13,7 +13,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class PodcastViewModel(
     private val repository: PodcastRepository,
@@ -173,6 +175,34 @@ class PodcastViewModel(
 
     fun moveSavedPodcast(fromIndex: Int, toIndex: Int) {
         viewModelScope.launch { savedPodcastsStorage.move(fromIndex, toIndex) }
+    }
+
+    /**
+     * Build a flattened list of unplayed episodes for the given podcasts, in the same podcast order.
+     * Within each podcast, episodes are ordered oldest -> newest (when pubDate is available).
+     */
+    suspend fun buildUnplayedEpisodesForPodcastQueue(podcasts: List<Podcast>): List<Episode> {
+        return withContext(Dispatchers.IO) {
+            val result = mutableListOf<Episode>()
+
+            for (podcast in podcasts) {
+                val feedUrl = podcast.feedUrl ?: continue
+
+                val episodes = repository.getEpisodes(feedUrl, podcast.id).getOrNull().orEmpty()
+                if (episodes.isEmpty()) continue
+
+                val progressByEpisodeId = playbackProgressDao.getByPodcastId(podcast.id)
+                    .associateBy { it.episodeId }
+
+                val unplayed = episodes
+                    .filter { ep -> progressByEpisodeId[ep.id]?.completed != true }
+                    .sortedWith(compareBy<Episode> { it.pubDate == null }.thenBy { it.pubDate })
+
+                result.addAll(unplayed)
+            }
+
+            result
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -22,7 +22,10 @@ class PlayerController private constructor(context: Context) {
 
     private val executor = Executors.newSingleThreadExecutor()
 
-    suspend fun playEpisode(episode: com.podcastplayer.app.domain.model.Episode, artworkUrl: String?) {
+    private fun episodeToMediaItem(
+        episode: com.podcastplayer.app.domain.model.Episode,
+        artworkUrl: String?
+    ): androidx.media3.common.MediaItem {
         val metadata = androidx.media3.common.MediaMetadata.Builder()
             .setTitle(episode.title)
             .setArtist(episode.podcastId)
@@ -30,16 +33,39 @@ class PlayerController private constructor(context: Context) {
             .setArtworkUri(artworkUrl?.let { android.net.Uri.parse(it) })
             .build()
 
-        val controller = controllerFuture.await()
         val mediaUri = episode.localPath?.takeIf { episode.isDownloaded }?.let {
             Uri.fromFile(File(it))
         } ?: Uri.parse(episode.audioUrl)
-        val mediaItem = androidx.media3.common.MediaItem.Builder()
+
+        return androidx.media3.common.MediaItem.Builder()
             .setMediaId(episode.id)
             .setUri(mediaUri)
             .setMediaMetadata(metadata)
             .build()
-        controller.setMediaItem(mediaItem)
+    }
+
+    suspend fun playEpisode(episode: com.podcastplayer.app.domain.model.Episode, artworkUrl: String?) {
+        val controller = controllerFuture.await()
+        controller.setMediaItem(episodeToMediaItem(episode, artworkUrl))
+        controller.prepare()
+        controller.play()
+    }
+
+    suspend fun playEpisodes(
+        episodes: List<com.podcastplayer.app.domain.model.Episode>,
+        defaultArtworkUrl: String?
+    ) {
+        if (episodes.isEmpty()) return
+
+        val controller = controllerFuture.await()
+        val items = episodes.map { episode ->
+            episodeToMediaItem(
+                episode = episode,
+                artworkUrl = episode.imageUrl ?: defaultArtworkUrl
+            )
+        }
+
+        controller.setMediaItems(items)
         controller.prepare()
         controller.play()
     }

--- a/docs/specs/004-podcast-queue-play.md
+++ b/docs/specs/004-podcast-queue-play.md
@@ -1,0 +1,52 @@
+# Spec 004: Podcast Queue Playback (Play Subscriptions)
+
+Last updated: 2026-01-31
+
+## 1) Problem
+- Users want a **quick Play button on Home** to start playing their queue.
+- Today, the app’s “Queue” is a **podcast list** (Saved podcasts), not an episode up-next list.
+- Today, “Play Queue” does **not** start playback; it just navigates to the Episodes screen for the first podcast.
+
+## 2) Decisions (based on user feedback)
+1. **Saved == Subscribed** (for now)
+   - We will treat the existing Saved podcasts list as the user’s subscriptions/library.
+2. **Queue remains podcast-level** (Option A)
+   - Queue is a manually ordered list of subscribed podcasts.
+3. **Play Queue behavior**
+   - “Play Queue” should play **all unplayed episodes** for each podcast **in the queue order**.
+   - Within a podcast, episodes are played in a consistent order (default: **oldest → newest** among unplayed episodes).
+
+## 3) UX changes
+### 3.1 Home (Search screen)
+- Add a **Play Queue** (play icon) action in the top app bar.
+- Enabled when the user has at least 1 saved/subscribed podcast.
+
+### 3.2 Queue screen
+- Keep the existing manual reorder/remove UX.
+- Update **Play Queue** to start playback rather than just navigating.
+
+## 4) Playback implementation
+- Build a flattened episode list:
+  1) Iterate podcasts in queue order
+  2) Fetch RSS episodes per podcast
+  3) Filter out completed episodes using `PlaybackProgressDao` (completed=true)
+  4) Append remaining episodes to a single list
+- Start playback using a Media3 playlist:
+  - `MediaController.setMediaItems(mediaItems)`
+  - `prepare()` then `play()`
+
+## 5) Data / filtering rules
+- “Unplayed” = no progress row, or `completed=false`.
+- Exclude episodes marked completed.
+- Partially played episodes are included.
+
+## 6) Non-goals (for this spec)
+- Episode-level Up Next queue UI.
+- Advanced smart-queue mixing across subscriptions.
+- Background refresh / WorkManager.
+
+## 7) Acceptance criteria
+- Home shows a Play Queue button when subscriptions exist.
+- Queue screen Play Queue starts audio playback.
+- Playback continues across multiple episodes (playlist) until exhausted.
+- Completed episodes are skipped.


### PR DESCRIPTION
Implements podcast-level Queue playback as requested.

- Home: adds a Play Queue action next to Queue
- Queue: Play Queue now starts playback
- Playback: builds a playlist of all *unplayed* episodes for each subscribed podcast in queue order (episodes ordered oldest→newest per podcast) and starts Media3 playlist playback
- Adds Spec 004 documenting behavior

Notes:
- Saved == Subscriptions for now (terminology updated in UI).
- Player UI still tracks the first episode as current; Media3 will advance through the playlist in the background.