### PR TITLE
Fix episode download filename handling

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -1,6 +1,7 @@
 package com.podcastplayer.app.data.repository
 
 import android.content.Context
+import android.net.Uri
 import android.os.Environment
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.DownloadedEpisodeDao
@@ -14,7 +15,9 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URL
+import java.security.MessageDigest
 import java.util.Date
+import java.util.Locale
 
 class DownloadManager(private val context: Context) {
 
@@ -31,7 +34,7 @@ class DownloadManager(private val context: Context) {
         onProgress: (Float) -> Unit = {}
     ): Result<String> = withContext(Dispatchers.IO) {
         try {
-            val fileName = "${episode.id}.mp3"
+            val fileName = buildSafeFileName(episode)
             val localFile = File(downloadDir, fileName)
 
             if (localFile.exists()) {
@@ -100,6 +103,25 @@ class DownloadManager(private val context: Context) {
 
     suspend fun getDownloadedEpisode(episodeId: String): DownloadedEpisodeEntity? {
         return dao.getEpisodeById(episodeId)
+    }
+
+    private fun buildSafeFileName(episode: Episode): String {
+        val source = episode.id.takeIf { it.isNotBlank() } ?: episode.audioUrl
+        val extension = guessExtension(episode.audioUrl) ?: "mp3"
+        val hash = MessageDigest.getInstance("MD5")
+            .digest(source.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+        return "$hash.$extension"
+    }
+
+    private fun guessExtension(url: String): String? {
+        return try {
+            val lastSegment = Uri.parse(url).lastPathSegment ?: return null
+            val ext = lastSegment.substringAfterLast('.', "").lowercase(Locale.US)
+            if (ext.isBlank()) null else ext.takeIf { it.length in 1..5 }
+        } catch (e: Exception) {
+            null
+        }
     }
 
     private fun Episode.toEntity(localPath: String): DownloadedEpisodeEntity {


### PR DESCRIPTION
Fixes episode download failures caused by using raw episode IDs/URLs as filenames. Generates a safe hashed filename and preserves file extension when possible.