### PR TITLE
Add queues and download management

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/local/DownloadedEpisodeDao.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DownloadedEpisodeDao.kt
@@ -9,6 +9,9 @@ interface DownloadedEpisodeDao {
     @Query("SELECT * FROM downloaded_episodes WHERE podcastId = :podcastId")
     fun getEpisodesByPodcast(podcastId: String): Flow<List<DownloadedEpisodeEntity>>
 
+    @Query("SELECT * FROM downloaded_episodes ORDER BY downloadDate DESC")
+    fun getAllEpisodes(): Flow<List<DownloadedEpisodeEntity>>
+
     @Query("SELECT * FROM downloaded_episodes WHERE id = :episodeId")
     suspend fun getEpisodeById(episodeId: String): DownloadedEpisodeEntity?
 
@@ -23,4 +26,7 @@ interface DownloadedEpisodeDao {
 
     @Query("SELECT EXISTS(SELECT 1 FROM downloaded_episodes WHERE id = :episodeId)")
     suspend fun isEpisodeDownloaded(episodeId: String): Boolean
+
+    @Query("DELETE FROM downloaded_episodes")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/podcastplayer/app/data/local/QueueStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/QueueStorage.kt
@@ -1,0 +1,146 @@
+package com.podcastplayer.app.data.local
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
+
+class QueueStorage(context: Context) {
+
+    data class QueuePayload(
+        val id: String,
+        val name: String,
+        val createdAt: Long,
+        val podcastIds: List<String>
+    )
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val gson = Gson()
+    private val mutex = Mutex()
+
+    private val _queues = MutableStateFlow(emptyList<QueuePayload>())
+    val queues: StateFlow<List<QueuePayload>> = _queues.asStateFlow()
+
+    init {
+        val loaded = load()
+        if (loaded.isEmpty()) {
+            val defaultQueue = QueuePayload(
+                id = UUID.randomUUID().toString(),
+                name = "Morning",
+                createdAt = System.currentTimeMillis(),
+                podcastIds = emptyList()
+            )
+            persist(listOf(defaultQueue))
+        } else {
+            _queues.value = loaded
+        }
+    }
+
+    suspend fun createQueue(name: String): String = mutex.withLock {
+        val id = UUID.randomUUID().toString()
+        val updated = _queues.value + QueuePayload(
+            id = id,
+            name = name.trim().ifBlank { "Queue" },
+            createdAt = System.currentTimeMillis(),
+            podcastIds = emptyList()
+        )
+        persist(updated)
+        id
+    }
+
+    suspend fun renameQueue(queueId: String, name: String) = mutex.withLock {
+        val updated = _queues.value.map { queue ->
+            if (queue.id == queueId) queue.copy(name = name.trim().ifBlank { queue.name }) else queue
+        }
+        persist(updated)
+    }
+
+    suspend fun deleteQueue(queueId: String) = mutex.withLock {
+        val updated = _queues.value.filterNot { it.id == queueId }
+        persist(updated)
+    }
+
+    suspend fun addPodcast(queueId: String, podcastId: String) = mutex.withLock {
+        val updated = _queues.value.map { queue ->
+            if (queue.id == queueId && !queue.podcastIds.contains(podcastId)) {
+                queue.copy(podcastIds = queue.podcastIds + podcastId)
+            } else {
+                queue
+            }
+        }
+        persist(updated)
+    }
+
+    suspend fun removePodcast(queueId: String, podcastId: String) = mutex.withLock {
+        val updated = _queues.value.map { queue ->
+            if (queue.id == queueId) {
+                queue.copy(podcastIds = queue.podcastIds.filterNot { it == podcastId })
+            } else {
+                queue
+            }
+        }
+        persist(updated)
+    }
+
+    suspend fun movePodcast(queueId: String, fromIndex: Int, toIndex: Int) = mutex.withLock {
+        val updated = _queues.value.map { queue ->
+            if (queue.id == queueId) {
+                val list = queue.podcastIds.toMutableList()
+                if (fromIndex in list.indices && toIndex in list.indices) {
+                    val item = list.removeAt(fromIndex)
+                    list.add(toIndex, item)
+                    queue.copy(podcastIds = list)
+                } else {
+                    queue
+                }
+            } else {
+                queue
+            }
+        }
+        persist(updated)
+    }
+
+    suspend fun setPodcastQueues(podcastId: String, queueIds: Set<String>) = mutex.withLock {
+        val updated = _queues.value.map { queue ->
+            val contains = queue.podcastIds.contains(podcastId)
+            val shouldContain = queueIds.contains(queue.id)
+            if (contains && !shouldContain) {
+                queue.copy(podcastIds = queue.podcastIds.filterNot { it == podcastId })
+            } else if (!contains && shouldContain) {
+                queue.copy(podcastIds = queue.podcastIds + podcastId)
+            } else {
+                queue
+            }
+        }
+        persist(updated)
+    }
+
+    fun getQueuesForPodcast(podcastId: String): Set<String> {
+        return _queues.value.filter { it.podcastIds.contains(podcastId) }.map { it.id }.toSet()
+    }
+
+    private fun persist(list: List<QueuePayload>) {
+        prefs.edit().putString(KEY_QUEUES, gson.toJson(list)).apply()
+        _queues.value = list
+    }
+
+    private fun load(): List<QueuePayload> {
+        val json = prefs.getString(KEY_QUEUES, null) ?: return emptyList()
+        return try {
+            val type = object : TypeToken<List<QueuePayload>>() {}.type
+            gson.fromJson(json, type) ?: emptyList()
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    companion object {
+        private const val PREFS_NAME = "podcast_queues"
+        private const val KEY_QUEUES = "queues"
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -85,6 +85,12 @@ class DownloadManager(private val context: Context) {
         }
     }
 
+    fun getAllDownloadedEpisodesFlow(): Flow<List<Episode>> {
+        return dao.getAllEpisodes().map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
     suspend fun deleteEpisode(episodeId: String): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val episode = dao.getEpisodeById(episodeId)
@@ -95,6 +101,22 @@ class DownloadManager(private val context: Context) {
                 }
                 dao.deleteEpisodeById(episodeId)
             }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun deleteAllDownloads(): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val episodes = dao.getAllEpisodes().first()
+            episodes.forEach { episode ->
+                val file = File(episode.localPath)
+                if (file.exists()) {
+                    file.delete()
+                }
+            }
+            dao.deleteAll()
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/podcastplayer/app/domain/model/PodcastQueue.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/PodcastQueue.kt
@@ -1,0 +1,7 @@
+package com.podcastplayer.app.domain.model
+
+data class PodcastQueue(
+    val id: String,
+    val name: String,
+    val createdAt: Long
+)

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -1,0 +1,158 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.podcastplayer.app.presentation.viewmodel.DownloadedEpisodeUi
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DownloadsScreen(
+    downloads: List<DownloadedEpisodeUi>,
+    onDeleteEpisode: (String) -> Unit,
+    onDeleteAll: () -> Unit,
+    onBack: () -> Unit
+) {
+    var showDeleteAllDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Downloads") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { showDeleteAllDialog = true },
+                        enabled = downloads.isNotEmpty()
+                    ) {
+                        Text("Remove all")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            if (downloads.isEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("No downloads")
+                    Text(
+                        text = "Download episodes to listen offline",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        top = 16.dp,
+                        end = 16.dp,
+                        bottom = 140.dp
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(downloads, key = { it.episode.id }) { item ->
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                        ) {
+                            Column(modifier = Modifier.padding(12.dp)) {
+                                Text(
+                                    text = item.episode.title,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                item.podcastTitle?.let {
+                                    Text(
+                                        text = it,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                                IconButton(
+                                    onClick = { onDeleteEpisode(item.episode.id) },
+                                    modifier = Modifier.align(Alignment.End)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = "Delete download",
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDeleteAllDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteAllDialog = false },
+            title = { Text("Remove all downloads") },
+            text = { Text("This will delete all downloaded audio files.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDeleteAll()
+                    showDeleteAllDialog = false
+                }) {
+                    Text("Remove all")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteAllDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -6,9 +6,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -24,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.presentation.viewmodel.PodcastUiState
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,6 +35,7 @@ fun PodcastListScreen(
     onPodcastSelected: (Podcast) -> Unit,
     onOpenPlayer: () -> Unit,
     onOpenQueue: () -> Unit,
+    onOpenDownloads: () -> Unit,
     onPlayQueue: () -> Unit,
 ) {
     var searchQuery by remember { mutableStateOf("") }
@@ -43,9 +46,17 @@ fun PodcastListScreen(
 
     val uiState by viewModel.uiState.collectAsState()
     val savedPodcasts by viewModel.savedPodcasts.collectAsState()
+    val queues by viewModel.queues.collectAsState()
+    val selectedQueueId by viewModel.selectedQueueId.collectAsState()
+    val selectedQueue = remember(queues, selectedQueueId) {
+        queues.firstOrNull { it.id == selectedQueueId }
+    }
+    val queuePodcasts by viewModel.selectedQueuePodcasts.collectAsState()
     val currentEpisode by playerViewModel.currentEpisode.collectAsState()
     val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
     val playerState by playerViewModel.playerState.collectAsState()
+    val scope = rememberCoroutineScope()
+    var queuePickerPodcast by remember { mutableStateOf<Podcast?>(null) }
 
     LaunchedEffect(searchQuery) {
         viewModel.searchPodcasts(searchQuery)
@@ -57,11 +68,11 @@ fun PodcastListScreen(
                 title = { Text("Podcast Player") },
                 actions = {
                     if (!isSearchFocused) {
-                        IconButton(onClick = onPlayQueue, enabled = savedPodcasts.isNotEmpty()) {
-                            Icon(Icons.Default.PlayArrow, contentDescription = "Play queue")
+                        IconButton(onClick = onOpenDownloads) {
+                            Icon(Icons.Default.Download, contentDescription = "Downloads")
                         }
-                        TextButton(onClick = onOpenQueue, enabled = savedPodcasts.isNotEmpty()) {
-                            Text("Queue")
+                        TextButton(onClick = onOpenQueue, enabled = queues.isNotEmpty()) {
+                            Text("Queues")
                         }
                     }
                 }
@@ -106,6 +117,16 @@ fun PodcastListScreen(
                     shape = RoundedCornerShape(24.dp)
                 )
 
+                if (showSaved) {
+                    QueuePlayRow(
+                        queues = queues,
+                        selectedQueue = selectedQueue,
+                        onSelectQueue = { viewModel.selectQueue(it) },
+                        onPlayQueue = onPlayQueue,
+                        enabled = queuePodcasts.isNotEmpty()
+                    )
+                }
+
                 Box(
                     modifier = Modifier
                         .weight(1f, fill = true)
@@ -137,6 +158,7 @@ fun PodcastListScreen(
                                             onPodcastSelected(podcast)
                                         },
                                         onSaveToggle = { viewModel.removeSavedPodcast(podcast.id) },
+                                        onAddToQueue = { queuePickerPodcast = podcast },
                                         isSaved = true
                                     )
                                 }
@@ -187,6 +209,7 @@ fun PodcastListScreen(
                                         onSaveToggle = {
                                             if (alreadySaved) viewModel.removeSavedPodcast(podcast.id) else viewModel.savePodcast(podcast)
                                         },
+                                        onAddToQueue = { queuePickerPodcast = podcast },
                                         isSaved = alreadySaved
                                     )
                                 }
@@ -220,6 +243,111 @@ fun PodcastListScreen(
             }
         }
     }
+
+    queuePickerPodcast?.let { podcast ->
+        QueuePickerDialog(
+            podcast = podcast,
+            queues = queues,
+            initialSelectedIds = viewModel.getQueueIdsForPodcast(podcast.id),
+            onConfirm = { selected ->
+                scope.launch { viewModel.setPodcastQueues(podcast, selected) }
+                queuePickerPodcast = null
+            },
+            onDismiss = { queuePickerPodcast = null }
+        )
+    }
+}
+
+@Composable
+private fun QueuePlayRow(
+    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
+    selectedQueue: com.podcastplayer.app.domain.model.PodcastQueue?,
+    onSelectQueue: (String) -> Unit,
+    onPlayQueue: () -> Unit,
+    enabled: Boolean
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Box {
+            TextButton(onClick = { expanded = true }, enabled = queues.isNotEmpty()) {
+                Text(selectedQueue?.name ?: "Select queue")
+                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                queues.forEach { queue ->
+                    DropdownMenuItem(
+                        text = { Text(queue.name) },
+                        onClick = {
+                            expanded = false
+                            onSelectQueue(queue.id)
+                        }
+                    )
+                }
+            }
+        }
+        Button(onClick = onPlayQueue, enabled = enabled) {
+            Text("Play")
+        }
+    }
+}
+
+@Composable
+private fun QueuePickerDialog(
+    podcast: Podcast,
+    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
+    initialSelectedIds: Set<String>,
+    onConfirm: (Set<String>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selectedIds by remember(podcast) { mutableStateOf(initialSelectedIds.toMutableSet()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add to queue") },
+        text = {
+            if (queues.isEmpty()) {
+                Text("Create a queue first")
+            } else {
+                Column {
+                    queues.forEach { queue ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Checkbox(
+                                checked = selectedIds.contains(queue.id),
+                                onCheckedChange = { checked ->
+                                    if (checked) {
+                                        selectedIds.add(queue.id)
+                                    } else {
+                                        selectedIds.remove(queue.id)
+                                    }
+                                }
+                            )
+                            Text(queue.name)
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selectedIds) }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable
@@ -265,6 +393,7 @@ fun PodcastItem(
     podcast: Podcast,
     onClick: () -> Unit,
     onSaveToggle: (() -> Unit)? = null,
+    onAddToQueue: (() -> Unit)? = null,
     isSaved: Boolean = false,
 ) {
     Card(
@@ -308,6 +437,12 @@ fun PodcastItem(
                 Spacer(modifier = Modifier.width(12.dp))
                 TextButton(onClick = it) {
                     Text(if (isSaved) "Saved" else "Subscribe")
+                }
+            }
+            onAddToQueue?.let {
+                Spacer(modifier = Modifier.width(4.dp))
+                TextButton(onClick = it) {
+                    Text("Queue")
                 }
             }
         }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
 import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
@@ -29,6 +30,7 @@ import kotlinx.coroutines.launch
 private object Routes {
     const val Search = "search"
     const val Queue = "queue"
+    const val Downloads = "downloads"
     const val Player = "player"
 
     const val EpisodesBase = "episodes"
@@ -50,6 +52,7 @@ fun PodcastNavHost() {
             PodcastRepository(iTunesApi.create(), RssParser()),
             DownloadManager(context),
             SavedPodcastsStorage(context),
+            QueueStorage(context),
             db.playbackProgressDao()
         )
     )
@@ -67,6 +70,8 @@ fun PodcastNavHost() {
     ) {
         composable(Routes.Search) {
             val scope = androidx.compose.runtime.rememberCoroutineScope()
+            val selectedQueuePodcasts by podcastViewModel.selectedQueuePodcasts.collectAsState()
+
             PodcastListScreen(
                 viewModel = podcastViewModel,
                 playerViewModel = playerViewModel,
@@ -76,10 +81,9 @@ fun PodcastNavHost() {
                 },
                 onOpenPlayer = { navController.navigate(Routes.Player) },
                 onOpenQueue = { navController.navigate(Routes.Queue) },
+                onOpenDownloads = { navController.navigate(Routes.Downloads) },
                 onPlayQueue = {
-                    // Build a flattened episode list from subscriptions in queue order and start playback.
-                    // If there are no episodes, do nothing.
-                    val podcasts = podcastViewModel.savedPodcasts.value
+                    val podcasts = selectedQueuePodcasts
                     if (podcasts.isNotEmpty()) {
                         scope.launch {
                             val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(podcasts)
@@ -130,29 +134,41 @@ fun PodcastNavHost() {
 
         composable(Routes.Queue) {
             val scope = androidx.compose.runtime.rememberCoroutineScope()
-            val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
+            val queues by podcastViewModel.queues.collectAsState()
+            val selectedQueueId by podcastViewModel.selectedQueueId.collectAsState()
+            val queuePodcasts by podcastViewModel.selectedQueuePodcasts.collectAsState()
             val currentEpisode by playerViewModel.currentEpisode.collectAsState()
             val playerState by playerViewModel.playerState.collectAsState()
             val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
 
             QueueScreen(
-                podcasts = savedPodcasts,
+                queues = queues,
+                selectedQueueId = selectedQueueId,
+                podcasts = queuePodcasts,
                 currentEpisode = currentEpisode,
                 currentArtworkUrl = currentArtworkUrl,
                 playerState = playerState,
+                onSelectQueue = { podcastViewModel.selectQueue(it) },
+                onCreateQueue = { podcastViewModel.createQueue(it) },
+                onRenameQueue = { id, name -> podcastViewModel.renameQueue(id, name) },
+                onDeleteQueue = { podcastViewModel.deleteQueue(it) },
                 onPlayPause = { playerViewModel.togglePlayPause() },
                 onOpenPlayer = { navController.navigate(Routes.Player) },
                 onSeek = { playerViewModel.seekTo(it) },
-                onMove = { from, to -> podcastViewModel.moveSavedPodcast(from, to) },
-                onRemove = { podcastId -> podcastViewModel.removeSavedPodcast(podcastId) },
+                onMove = { from, to ->
+                    selectedQueueId?.let { podcastViewModel.movePodcastInQueue(it, from, to) }
+                },
+                onRemove = { podcastId ->
+                    selectedQueueId?.let { podcastViewModel.removePodcastFromQueue(it, podcastId) }
+                },
                 onPlayQueue = {
-                    if (savedPodcasts.isNotEmpty()) {
+                    if (queuePodcasts.isNotEmpty()) {
                         scope.launch {
-                            val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(savedPodcasts)
+                            val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(queuePodcasts)
                             if (episodes.isNotEmpty()) {
                                 playerViewModel.playEpisodesQueue(
                                     episodes = episodes,
-                                    defaultArtworkUrl = savedPodcasts.firstOrNull()?.artworkUrl
+                                    defaultArtworkUrl = queuePodcasts.firstOrNull()?.artworkUrl
                                 )
                                 navController.navigate(Routes.Player)
                             }
@@ -163,6 +179,21 @@ fun PodcastNavHost() {
                     // Match previous behavior: Queue back always returns to Search.
                     navController.popBackStack(route = Routes.Search, inclusive = false)
                 }
+            )
+        }
+
+        composable(Routes.Downloads) {
+            val scope = androidx.compose.runtime.rememberCoroutineScope()
+            val downloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
+            DownloadsScreen(
+                downloads = downloads,
+                onDeleteEpisode = { episodeId ->
+                    scope.launch { podcastViewModel.deleteDownload(episodeId) }
+                },
+                onDeleteAll = {
+                    scope.launch { podcastViewModel.deleteAllDownloads() }
+                },
+                onBack = { navController.popBackStack(route = Routes.Search, inclusive = false) }
             )
         }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastViewModelFactory.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastViewModelFactory.kt
@@ -3,6 +3,7 @@ package com.podcastplayer.app.presentation.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.podcastplayer.app.data.local.PlaybackProgressDao
+import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
 import com.podcastplayer.app.data.repository.PodcastRepository
 
@@ -10,6 +11,7 @@ class PodcastViewModelFactory(
     private val repository: PodcastRepository,
     private val downloadManager: com.podcastplayer.app.data.repository.DownloadManager,
     private val savedPodcastsStorage: SavedPodcastsStorage,
+    private val queueStorage: QueueStorage,
     private val playbackProgressDao: PlaybackProgressDao
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
@@ -19,6 +21,7 @@ class PodcastViewModelFactory(
                 repository,
                 downloadManager,
                 savedPodcastsStorage,
+                queueStorage,
                 playbackProgressDao
             ) as T
         }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/QueueScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/QueueScreen.kt
@@ -14,20 +14,32 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -43,10 +55,16 @@ import org.burnoutcrew.reorderable.rememberReorderableLazyListState
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QueueScreen(
+    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
+    selectedQueueId: String?,
     podcasts: List<Podcast>,
     currentEpisode: Episode?,
     currentArtworkUrl: String?,
     playerState: PlayerState,
+    onSelectQueue: (String) -> Unit,
+    onCreateQueue: (String) -> Unit,
+    onRenameQueue: (String, String) -> Unit,
+    onDeleteQueue: (String) -> Unit,
     onPlayPause: () -> Unit,
     onOpenPlayer: () -> Unit,
     onSeek: (Long) -> Unit,
@@ -59,18 +77,42 @@ fun QueueScreen(
         onMove = { from, to -> onMove(from.index, to.index) }
     )
 
+    val selectedQueue = queues.firstOrNull { it.id == selectedQueueId }
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var showRenameDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var nameInput by remember { mutableStateOf("") }
+
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Queue") },
+                title = { Text("Queues") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
                 },
                 actions = {
-                    TextButton(onClick = onPlayQueue, enabled = podcasts.isNotEmpty()) {
-                        Text("Play Queue")
+                    IconButton(onClick = {
+                        nameInput = ""
+                        showCreateDialog = true
+                    }) {
+                        Icon(Icons.Default.Add, contentDescription = "Add queue")
+                    }
+                    IconButton(
+                        onClick = {
+                            nameInput = selectedQueue?.name.orEmpty()
+                            showRenameDialog = true
+                        },
+                        enabled = selectedQueue != null
+                    ) {
+                        Icon(Icons.Default.Edit, contentDescription = "Rename queue")
+                    }
+                    IconButton(
+                        onClick = { showDeleteDialog = true },
+                        enabled = selectedQueue != null
+                    ) {
+                        Icon(Icons.Default.Delete, contentDescription = "Delete queue")
                     }
                 }
             )
@@ -82,6 +124,14 @@ fun QueueScreen(
                 .padding(padding)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
+                QueueSelectorRow(
+                    queues = queues,
+                    selectedQueue = selectedQueue,
+                    onSelectQueue = onSelectQueue,
+                    onPlayQueue = onPlayQueue,
+                    enabled = podcasts.isNotEmpty()
+                )
+
                 if (podcasts.isEmpty()) {
                     Column(
                         modifier = Modifier
@@ -177,4 +227,121 @@ fun QueueScreen(
             }
         }
     }
+
+    if (showCreateDialog) {
+        QueueNameDialog(
+            title = "New queue",
+            initialName = nameInput,
+            onConfirm = {
+                onCreateQueue(it)
+                showCreateDialog = false
+            },
+            onDismiss = { showCreateDialog = false }
+        )
+    }
+
+    if (showRenameDialog && selectedQueue != null) {
+        QueueNameDialog(
+            title = "Rename queue",
+            initialName = nameInput.ifBlank { selectedQueue.name },
+            onConfirm = {
+                onRenameQueue(selectedQueue.id, it)
+                showRenameDialog = false
+            },
+            onDismiss = { showRenameDialog = false }
+        )
+    }
+
+    if (showDeleteDialog && selectedQueue != null) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete queue") },
+            text = { Text("Delete \"${selectedQueue.name}\"?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDeleteQueue(selectedQueue.id)
+                    showDeleteDialog = false
+                }) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun QueueSelectorRow(
+    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
+    selectedQueue: com.podcastplayer.app.domain.model.PodcastQueue?,
+    onSelectQueue: (String) -> Unit,
+    onPlayQueue: () -> Unit,
+    enabled: Boolean
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Box {
+            TextButton(onClick = { expanded = true }, enabled = queues.isNotEmpty()) {
+                Text(selectedQueue?.name ?: "Select queue")
+                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                queues.forEach { queue ->
+                    DropdownMenuItem(
+                        text = { Text(queue.name) },
+                        onClick = {
+                            expanded = false
+                            onSelectQueue(queue.id)
+                        }
+                    )
+                }
+            }
+        }
+        Button(onClick = onPlayQueue, enabled = enabled) {
+            Text("Play")
+        }
+    }
+}
+
+@Composable
+private fun QueueNameDialog(
+    title: String,
+    initialName: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var name by remember { mutableStateOf(initialName) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { value -> name = value },
+                placeholder = { Text("Queue name") }
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(name) }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -4,15 +4,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.podcastplayer.app.data.local.PlaybackProgressDao
 import com.podcastplayer.app.data.local.PlaybackProgressEntity
+import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
 import com.podcastplayer.app.data.repository.DownloadManager
 import com.podcastplayer.app.data.repository.PodcastRepository
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
+import com.podcastplayer.app.domain.model.PodcastQueue
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -21,6 +27,7 @@ class PodcastViewModel(
     private val repository: PodcastRepository,
     private val downloadManager: DownloadManager,
     private val savedPodcastsStorage: SavedPodcastsStorage,
+    private val queueStorage: QueueStorage,
     private val playbackProgressDao: PlaybackProgressDao
 ) : ViewModel() {
 
@@ -44,6 +51,40 @@ class PodcastViewModel(
 
     private val _savedPodcasts = MutableStateFlow<List<Podcast>>(emptyList())
     val savedPodcasts: StateFlow<List<Podcast>> = _savedPodcasts.asStateFlow()
+
+    private val _selectedQueueId = MutableStateFlow<String?>(null)
+    val selectedQueueId: StateFlow<String?> = _selectedQueueId.asStateFlow()
+
+    val queues: StateFlow<List<PodcastQueue>> = queueStorage.queues
+        .map { list -> list.map { PodcastQueue(it.id, it.name, it.createdAt) } }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    val selectedQueuePodcasts: StateFlow<List<Podcast>> = combine(
+        queueStorage.queues,
+        _selectedQueueId,
+        savedPodcasts
+    ) { queueList, selectedId, saved ->
+        val queue = queueList.firstOrNull { it.id == selectedId }
+        val savedMap = saved.associateBy { it.id }
+        queue?.podcastIds?.mapNotNull { savedMap[it] } ?: emptyList()
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    val downloadedEpisodesAll: StateFlow<List<Episode>> = downloadManager
+        .getAllDownloadedEpisodesFlow()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val downloadedEpisodesUi: StateFlow<List<DownloadedEpisodeUi>> = combine(
+        downloadedEpisodesAll,
+        savedPodcasts
+    ) { episodes, podcasts ->
+        val map = podcasts.associateBy { it.id }
+        episodes.map { episode ->
+            DownloadedEpisodeUi(
+                episode = episode,
+                podcastTitle = map[episode.podcastId]?.title
+            )
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _playbackProgress = MutableStateFlow<Map<String, PlaybackProgressEntity>>(emptyMap())
     val playbackProgress: StateFlow<Map<String, PlaybackProgressEntity>> = _playbackProgress.asStateFlow()
@@ -72,6 +113,7 @@ class PodcastViewModel(
 
     init {
         observeSaved()
+        observeQueues()
     }
 
     fun selectPodcast(podcast: Podcast) {
@@ -105,6 +147,17 @@ class PodcastViewModel(
         savedJob = viewModelScope.launch {
             savedPodcastsStorage.savedPodcasts.collect { list ->
                 _savedPodcasts.value = list
+            }
+        }
+    }
+
+    private fun observeQueues() {
+        viewModelScope.launch {
+            queueStorage.queues.collect { list ->
+                val selected = _selectedQueueId.value
+                if (list.isNotEmpty() && (selected == null || list.none { it.id == selected })) {
+                    _selectedQueueId.value = list.first().id
+                }
             }
         }
     }
@@ -177,6 +230,55 @@ class PodcastViewModel(
         viewModelScope.launch { savedPodcastsStorage.move(fromIndex, toIndex) }
     }
 
+    fun selectQueue(queueId: String) {
+        _selectedQueueId.value = queueId
+    }
+
+    fun createQueue(name: String) {
+        viewModelScope.launch {
+            val newId = queueStorage.createQueue(name)
+            _selectedQueueId.value = newId
+        }
+    }
+
+    fun renameQueue(queueId: String, name: String) {
+        viewModelScope.launch { queueStorage.renameQueue(queueId, name) }
+    }
+
+    fun deleteQueue(queueId: String) {
+        viewModelScope.launch { queueStorage.deleteQueue(queueId) }
+    }
+
+    fun addPodcastToQueue(queueId: String, podcast: Podcast) {
+        viewModelScope.launch {
+            savedPodcastsStorage.save(podcast)
+            queueStorage.addPodcast(queueId, podcast.id)
+        }
+    }
+
+    fun removePodcastFromQueue(queueId: String, podcastId: String) {
+        viewModelScope.launch { queueStorage.removePodcast(queueId, podcastId) }
+    }
+
+    fun movePodcastInQueue(queueId: String, fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch { queueStorage.movePodcast(queueId, fromIndex, toIndex) }
+    }
+
+    fun setPodcastQueues(podcast: Podcast, queueIds: Set<String>) {
+        viewModelScope.launch {
+            savedPodcastsStorage.save(podcast)
+            queueStorage.setPodcastQueues(podcast.id, queueIds)
+        }
+    }
+
+    fun getQueueIdsForPodcast(podcastId: String): Set<String> {
+        return queueStorage.getQueuesForPodcast(podcastId)
+    }
+
+    suspend fun deleteAllDownloads(): Result<Unit> {
+        return downloadManager.deleteAllDownloads()
+    }
+
     /**
      * Build a flattened list of unplayed episodes for the given podcasts, in the same podcast order.
      * Within each podcast, episodes are ordered oldest -> newest (when pubDate is available).
@@ -212,6 +314,11 @@ class PodcastViewModel(
         super.onCleared()
     }
 }
+
+data class DownloadedEpisodeUi(
+    val episode: Episode,
+    val podcastTitle: String?
+)
 
 sealed class PodcastUiState {
     data object Initial : PodcastUiState()

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -281,7 +281,7 @@ class PodcastViewModel(
 
     /**
      * Build a flattened list of unplayed episodes for the given podcasts, in the same podcast order.
-     * Within each podcast, episodes are ordered oldest -> newest (when pubDate is available).
+     * Within each podcast, episodes are ordered newest -> oldest (when pubDate is available).
      */
     suspend fun buildUnplayedEpisodesForPodcastQueue(podcasts: List<Podcast>): List<Episode> {
         return withContext(Dispatchers.IO) {
@@ -298,7 +298,7 @@ class PodcastViewModel(
 
                 val unplayed = episodes
                     .filter { ep -> progressByEpisodeId[ep.id]?.completed != true }
-                    .sortedWith(compareBy<Episode> { it.pubDate == null }.thenBy { it.pubDate })
+                    .sortedWith(compareByDescending<Episode> { it.pubDate?.time ?: Long.MIN_VALUE })
 
                 result.addAll(unplayed)
             }


### PR DESCRIPTION
## Summary
- Add multi-queue support (default "Morning" queue) with create/rename/delete + drag reorder
- Home screen queue selector + Play action tied to selected queue
- Podcast card queue picker for assigning to multiple queues
- Downloads management screen + bulk delete confirmation
- Download manager/DAO support for listing and deleting all downloads

## Testing
- ./gradlew :app:assembleDebug