### PR TITLE
fix: downloads playability + player session restore + queue prev/next

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -1,9 +1,11 @@
 package com.podcastplayer.app.presentation.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -33,12 +35,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.podcastplayer.app.R
 import com.podcastplayer.app.presentation.viewmodel.DownloadedEpisodeUi
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadsScreen(
     downloads: List<DownloadedEpisodeUi>,
+    onPlayEpisode: (DownloadedEpisodeUi) -> Unit,
     onDeleteEpisode: (String) -> Unit,
     onDeleteAll: () -> Unit,
     onBack: () -> Unit
@@ -98,29 +103,49 @@ fun DownloadsScreen(
                 ) {
                     items(downloads, key = { it.episode.id }) { item ->
                         Card(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onPlayEpisode(item) },
                             elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
                         ) {
-                            Column(modifier = Modifier.padding(12.dp)) {
-                                Text(
-                                    text = item.episode.title,
-                                    style = MaterialTheme.typography.titleMedium,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                AsyncImage(
+                                    model = item.episode.imageUrl ?: item.podcastArtworkUrl,
+                                    contentDescription = item.episode.title,
+                                    modifier = Modifier.size(56.dp),
+                                    placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                                    error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                                    fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder)
                                 )
-                                item.podcastTitle?.let {
+
+                                Column(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(start = 12.dp)
+                                ) {
                                     Text(
-                                        text = it,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        maxLines = 1,
+                                        text = item.episode.title,
+                                        style = MaterialTheme.typography.titleMedium,
+                                        maxLines = 2,
                                         overflow = TextOverflow.Ellipsis
                                     )
+                                    item.podcastTitle?.let {
+                                        Text(
+                                            text = it,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    }
                                 }
-                                IconButton(
-                                    onClick = { onDeleteEpisode(item.episode.id) },
-                                    modifier = Modifier.align(Alignment.End)
-                                ) {
+
+                                IconButton(onClick = { onDeleteEpisode(item.episode.id) }) {
                                     Icon(
                                         imageVector = Icons.Default.Delete,
                                         contentDescription = "Delete download",

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
@@ -1,16 +1,43 @@
 package com.podcastplayer.app.presentation.ui
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.NavigateBefore
+import androidx.compose.material.icons.filled.NavigateNext
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,7 +55,11 @@ fun PlayerScreen(
     playerState: PlayerState,
     artworkUrl: String?,
     sleepTimerRemaining: Long?,
+    hasPrevious: Boolean,
+    hasNext: Boolean,
     onPlayPause: () -> Unit,
+    onPlayPrevious: () -> Unit,
+    onPlayNext: () -> Unit,
     onSeek: (Long) -> Unit,
     onSpeedChange: (Float) -> Unit,
     onSetSleepTimer: (Long) -> Unit,
@@ -58,7 +89,7 @@ fun PlayerScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = Modifier.height(20.dp))
-            
+
             Box(
                 modifier = Modifier
                     .size(220.dp)
@@ -71,18 +102,18 @@ fun PlayerScreen(
                     modifier = Modifier.size(220.dp)
                 )
             }
-            
+
             Spacer(modifier = Modifier.height(24.dp))
-            
+
             Text(
                 text = episode.title,
                 style = MaterialTheme.typography.headlineSmall,
                 maxLines = 2,
                 textAlign = TextAlign.Center
             )
-            
+
             Spacer(modifier = Modifier.height(8.dp))
-            
+
             Text(
                 text = description,
                 style = MaterialTheme.typography.bodyMedium,
@@ -90,18 +121,18 @@ fun PlayerScreen(
                 maxLines = 4,
                 textAlign = TextAlign.Center
             )
-            
+
             Spacer(modifier = Modifier.height(24.dp))
-            
+
             Slider(
                 value = if (playerState.duration > 0) playerState.currentPosition.toFloat() else 0f,
                 valueRange = 0f..(if (playerState.duration > 0) playerState.duration.toFloat() else 1f),
                 onValueChange = { onSeek(it.toLong()) },
                 modifier = Modifier.fillMaxWidth()
             )
-            
+
             Spacer(modifier = Modifier.height(8.dp))
-            
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
@@ -201,21 +232,35 @@ fun PlayerScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(
+                    onClick = onPlayPrevious,
+                    enabled = hasPrevious,
+                    modifier = Modifier.size(64.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.NavigateBefore,
+                        contentDescription = "Previous episode",
+                        modifier = Modifier.size(36.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                IconButton(
                     onClick = { onSeek(playerState.currentPosition - 15000) },
-                    modifier = Modifier.size(96.dp)
+                    modifier = Modifier.size(76.dp)
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.FastRewind,
                         contentDescription = "Rewind 15s",
-                        modifier = Modifier.size(52.dp)
+                        modifier = Modifier.size(40.dp)
                     )
                 }
 
-                Spacer(modifier = Modifier.width(16.dp))
+                Spacer(modifier = Modifier.width(8.dp))
 
                 FloatingActionButton(
                     onClick = onPlayPause,
-                    modifier = Modifier.size(128.dp)
+                    modifier = Modifier.size(96.dp)
                 ) {
                     Icon(
                         imageVector = if (playerState.state == com.podcastplayer.app.domain.model.PlaybackState.PLAYING) {
@@ -228,20 +273,34 @@ fun PlayerScreen(
                         } else {
                             "Play"
                         },
-                        modifier = Modifier.size(76.dp)
+                        modifier = Modifier.size(56.dp)
                     )
                 }
 
-                Spacer(modifier = Modifier.width(16.dp))
+                Spacer(modifier = Modifier.width(8.dp))
 
                 IconButton(
                     onClick = { onSeek(playerState.currentPosition + 30000) },
-                    modifier = Modifier.size(96.dp)
+                    modifier = Modifier.size(76.dp)
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.FastForward,
                         contentDescription = "Forward 30s",
-                        modifier = Modifier.size(52.dp)
+                        modifier = Modifier.size(40.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                IconButton(
+                    onClick = onPlayNext,
+                    enabled = hasNext,
+                    modifier = Modifier.size(64.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.NavigateNext,
+                        contentDescription = "Next episode",
+                        modifier = Modifier.size(36.dp)
                     )
                 }
             }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -187,6 +187,10 @@ fun PodcastNavHost() {
             val downloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
             DownloadsScreen(
                 downloads = downloads,
+                onPlayEpisode = { item ->
+                    playerViewModel.playEpisode(item.episode, item.podcastArtworkUrl)
+                    navController.navigate(Routes.Player)
+                },
                 onDeleteEpisode = { episodeId ->
                     scope.launch { podcastViewModel.deleteDownload(episodeId) }
                 },
@@ -202,6 +206,8 @@ fun PodcastNavHost() {
             val playerState by playerViewModel.playerState.collectAsState()
             val sleepTimerRemaining by playerViewModel.sleepTimerRemaining.collectAsState()
             val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
+            val hasPrevious by playerViewModel.hasPrevious.collectAsState()
+            val hasNext by playerViewModel.hasNext.collectAsState()
             val selectedPodcast by podcastViewModel.selectedPodcast.collectAsState()
 
             fun goToEpisodesOrSearch() {
@@ -221,18 +227,30 @@ fun PodcastNavHost() {
                 goToEpisodesOrSearch()
             }
 
-            PlayerScreen(
-                episode = currentEpisode ?: Episode("", "", "", null, null, "", null, null),
-                playerState = playerState,
-                artworkUrl = currentArtworkUrl ?: selectedPodcast?.artworkUrl,
-                sleepTimerRemaining = sleepTimerRemaining,
-                onPlayPause = { playerViewModel.togglePlayPause() },
-                onSeek = { playerViewModel.seekTo(it) },
-                onSpeedChange = { playerViewModel.setPlaybackSpeed(it) },
-                onSetSleepTimer = { playerViewModel.setSleepTimer(it) },
-                onCancelSleepTimer = { playerViewModel.cancelSleepTimer() },
-                onDismiss = { goToEpisodesOrSearch() }
-            )
+            currentEpisode?.let { episode ->
+                PlayerScreen(
+                    episode = episode,
+                    playerState = playerState,
+                    artworkUrl = currentArtworkUrl ?: selectedPodcast?.artworkUrl,
+                    sleepTimerRemaining = sleepTimerRemaining,
+                    hasPrevious = hasPrevious,
+                    hasNext = hasNext,
+                    onPlayPause = { playerViewModel.togglePlayPause() },
+                    onPlayPrevious = { playerViewModel.playPrevious() },
+                    onPlayNext = { playerViewModel.playNext() },
+                    onSeek = { playerViewModel.seekTo(it) },
+                    onSpeedChange = { playerViewModel.setPlaybackSpeed(it) },
+                    onSetSleepTimer = { playerViewModel.setSleepTimer(it) },
+                    onCancelSleepTimer = { playerViewModel.cancelSleepTimer() },
+                    onDismiss = { goToEpisodesOrSearch() }
+                )
+            }
+
+            if (currentEpisode == null) {
+                androidx.compose.runtime.LaunchedEffect(Unit) {
+                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
@@ -31,6 +31,12 @@ class PlayerViewModel(
     private val _sleepTimerRemaining = MutableStateFlow<Long?>(null)
     val sleepTimerRemaining: StateFlow<Long?> = _sleepTimerRemaining.asStateFlow()
 
+    private val _hasPrevious = MutableStateFlow(false)
+    val hasPrevious: StateFlow<Boolean> = _hasPrevious.asStateFlow()
+
+    private val _hasNext = MutableStateFlow(false)
+    val hasNext: StateFlow<Boolean> = _hasNext.asStateFlow()
+
     private var sleepTimerJob: Job? = null
 
     private var queueEpisodes: Map<String, Episode> = emptyMap()
@@ -44,6 +50,12 @@ class PlayerViewModel(
                 updateCurrentEpisode(episode, queueDefaultArtworkUrl)
             }
         })
+
+        viewModelScope.launch {
+            playerController.restoreLastSessionIfNeeded()
+            refreshFromController()
+            startPositionUpdates()
+        }
     }
 
     fun playEpisode(episode: Episode, artworkUrl: String?) {
@@ -60,7 +72,7 @@ class PlayerViewModel(
                 _playerState.value = _playerState.value.copy(
                     state = PlaybackState.PLAYING
                 )
-                startPositionUpdates()
+                refreshFromController()
             } catch (e: Exception) {
                 _playerState.value = _playerState.value.copy(
                     state = PlaybackState.ERROR
@@ -86,7 +98,7 @@ class PlayerViewModel(
             try {
                 playerController.playEpisodes(episodes, defaultArtworkUrl)
                 _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
-                startPositionUpdates()
+                refreshFromController()
             } catch (e: Exception) {
                 _playerState.value = _playerState.value.copy(state = PlaybackState.ERROR)
             }
@@ -95,26 +107,38 @@ class PlayerViewModel(
 
     fun togglePlayPause() {
         viewModelScope.launch {
-            val currentState = _playerState.value.state
-            val episode = _currentEpisode.value
-            val playbackUrl = episode?.localPath?.takeIf { episode.isDownloaded } ?: episode?.audioUrl.orEmpty()
-            when (currentState) {
+            when (_playerState.value.state) {
                 PlaybackState.PLAYING -> {
                     playerController.pause()
-                    _playerState.value = _playerState.value.copy(
-                        state = PlaybackState.PAUSED
-                    )
+                    _playerState.value = _playerState.value.copy(state = PlaybackState.PAUSED)
                 }
-                PlaybackState.PAUSED -> {
-                    if (playbackUrl.isNotBlank() && episode != null) {
-                        playerController.playEpisode(episode, null)
-                        _playerState.value = _playerState.value.copy(
-                            state = PlaybackState.PLAYING
-                        )
-                    }
+                PlaybackState.PAUSED, PlaybackState.IDLE -> {
+                    playerController.play()
+                    _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
                 }
-                else -> {}
+                else -> Unit
             }
+            refreshFromController()
+        }
+    }
+
+    fun playNext() {
+        viewModelScope.launch {
+            if (!_hasNext.value) return@launch
+            playerController.skipToNext()
+            playerController.play()
+            _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
+            refreshFromController()
+        }
+    }
+
+    fun playPrevious() {
+        viewModelScope.launch {
+            if (!_hasPrevious.value) return@launch
+            playerController.skipToPrevious()
+            playerController.play()
+            _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
+            refreshFromController()
         }
     }
 
@@ -122,7 +146,7 @@ class PlayerViewModel(
         viewModelScope.launch {
             playerController.seekTo(position)
             _playerState.value = _playerState.value.copy(
-                currentPosition = position
+                currentPosition = position.coerceAtLeast(0)
             )
         }
     }
@@ -158,19 +182,35 @@ class PlayerViewModel(
         _sleepTimerRemaining.value = null
     }
 
+    private suspend fun refreshFromController() {
+        val episode = playerController.getCurrentEpisode()
+        _currentEpisode.value = episode
+        _currentArtworkUrl.value = playerController.getCurrentArtworkUrl() ?: episode?.imageUrl
+        _hasPrevious.value = playerController.hasPrevious()
+        _hasNext.value = playerController.hasNext()
+
+        val playbackState = when {
+            playerController.isPlaying() -> PlaybackState.PLAYING
+            episode != null -> PlaybackState.PAUSED
+            else -> PlaybackState.IDLE
+        }
+
+        _playerState.value = _playerState.value.copy(
+            state = playbackState,
+            currentEpisode = episode,
+            currentPosition = playerController.getCurrentPosition().coerceAtLeast(0L),
+            duration = playerController.getDuration().coerceAtLeast(0L)
+        )
+    }
+
     private fun startPositionUpdates() {
         viewModelScope.launch {
-            while (_playerState.value.state == PlaybackState.PLAYING) {
+            while (true) {
                 try {
-                    val position = playerController.getCurrentPosition()
-                    val duration = playerController.getDuration()
-                    _playerState.value = _playerState.value.copy(
-                        currentPosition = position,
-                        duration = duration
-                    )
+                    refreshFromController()
                     kotlinx.coroutines.delay(1000)
                 } catch (e: Exception) {
-                    break
+                    kotlinx.coroutines.delay(2000)
                 }
             }
         }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -81,7 +81,8 @@ class PodcastViewModel(
         episodes.map { episode ->
             DownloadedEpisodeUi(
                 episode = episode,
-                podcastTitle = map[episode.podcastId]?.title
+                podcastTitle = map[episode.podcastId]?.title,
+                podcastArtworkUrl = map[episode.podcastId]?.artworkUrl
             )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
@@ -323,7 +324,8 @@ class PodcastViewModel(
 
 data class DownloadedEpisodeUi(
     val episode: Episode,
-    val podcastTitle: String?
+    val podcastTitle: String?,
+    val podcastArtworkUrl: String?
 )
 
 sealed class PodcastUiState {

--- a/app/src/main/java/com/podcastplayer/app/service/PlaybackSessionStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlaybackSessionStorage.kt
@@ -1,0 +1,100 @@
+package com.podcastplayer.app.service
+
+import android.content.Context
+import androidx.core.content.edit
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal data class StoredPlaybackSession(
+    val items: List<MediaItem>,
+    val currentIndex: Int,
+    val currentPositionMs: Long,
+    val wasPlaying: Boolean,
+    val playbackSpeed: Float,
+    val isCompleted: Boolean
+)
+
+internal class PlaybackSessionStorage(context: Context) {
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun save(
+        items: List<MediaItem>,
+        currentIndex: Int,
+        currentPositionMs: Long,
+        wasPlaying: Boolean,
+        playbackSpeed: Float,
+        isCompleted: Boolean
+    ) {
+        if (items.isEmpty() || currentIndex !in items.indices) return
+
+        val payload = JSONObject().apply {
+            put("currentIndex", currentIndex)
+            put("currentPositionMs", currentPositionMs.coerceAtLeast(0L))
+            put("wasPlaying", wasPlaying)
+            put("playbackSpeed", playbackSpeed)
+            put("isCompleted", isCompleted)
+            put("items", JSONArray().apply {
+                items.forEach { item ->
+                    put(JSONObject().apply {
+                        put("mediaId", item.mediaId)
+                        put("uri", item.localConfiguration?.uri?.toString().orEmpty())
+                        put("title", item.mediaMetadata.title?.toString())
+                        put("artist", item.mediaMetadata.artist?.toString())
+                        put("description", item.mediaMetadata.description?.toString())
+                        put("artworkUri", item.mediaMetadata.artworkUri?.toString())
+                    })
+                }
+            })
+        }
+
+        prefs.edit { putString(KEY_SESSION, payload.toString()) }
+    }
+
+    fun load(): StoredPlaybackSession? {
+        val raw = prefs.getString(KEY_SESSION, null) ?: return null
+        return runCatching {
+            val json = JSONObject(raw)
+            val itemsArray = json.optJSONArray("items") ?: return null
+            val items = mutableListOf<MediaItem>()
+            for (i in 0 until itemsArray.length()) {
+                val itemJson = itemsArray.optJSONObject(i) ?: continue
+                val uri = itemJson.optString("uri")
+                val mediaId = itemJson.optString("mediaId")
+                if (uri.isBlank() || mediaId.isBlank()) continue
+
+                val metadata = MediaMetadata.Builder()
+                    .setTitle(itemJson.optString("title").ifBlank { null })
+                    .setArtist(itemJson.optString("artist").ifBlank { null })
+                    .setDescription(itemJson.optString("description").ifBlank { null })
+                    .setArtworkUri(itemJson.optString("artworkUri").ifBlank { null }?.let(android.net.Uri::parse))
+                    .build()
+
+                items += MediaItem.Builder()
+                    .setMediaId(mediaId)
+                    .setUri(uri)
+                    .setMediaMetadata(metadata)
+                    .build()
+            }
+
+            if (items.isEmpty()) return null
+
+            val index = json.optInt("currentIndex", 0).coerceIn(0, items.lastIndex)
+            StoredPlaybackSession(
+                items = items,
+                currentIndex = index,
+                currentPositionMs = json.optLong("currentPositionMs", 0L).coerceAtLeast(0L),
+                wasPlaying = json.optBoolean("wasPlaying", false),
+                playbackSpeed = json.optDouble("playbackSpeed", 1.0).toFloat().coerceAtLeast(0.5f),
+                isCompleted = json.optBoolean("isCompleted", false)
+            )
+        }.getOrNull()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "player_session"
+        private const val KEY_SESSION = "last_session"
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -161,7 +161,7 @@ class PlayerController private constructor(private val context: Context) {
 
     suspend fun restoreLastSessionIfNeeded(): com.podcastplayer.app.domain.model.Episode? {
         val controller = controllerFuture.await()
-        if (controller.currentMediaItems.isNotEmpty()) {
+        if (controller.mediaItemCount > 0) {
             return getCurrentEpisode()
         }
 

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.util.concurrent.Executors
 import kotlinx.coroutines.guava.await
 
-class PlayerController private constructor(context: Context) {
+class PlayerController private constructor(private val context: Context) {
 
     private val sessionToken = SessionToken(
         context,
@@ -21,6 +21,7 @@ class PlayerController private constructor(context: Context) {
         .buildAsync()
 
     private val executor = Executors.newSingleThreadExecutor()
+    private val playbackSessionStorage = PlaybackSessionStorage(context)
 
     private fun episodeToMediaItem(
         episode: com.podcastplayer.app.domain.model.Episode,
@@ -70,6 +71,10 @@ class PlayerController private constructor(context: Context) {
         controller.play()
     }
 
+    suspend fun play() {
+        controllerFuture.await().play()
+    }
+
     suspend fun pause() {
         val controller = controllerFuture.await()
         controller.pause()
@@ -78,6 +83,26 @@ class PlayerController private constructor(context: Context) {
     suspend fun seekTo(position: Long) {
         val controller = controllerFuture.await()
         controller.seekTo(position)
+    }
+
+    suspend fun skipToPrevious() {
+        val controller = controllerFuture.await()
+        controller.seekToPreviousMediaItem()
+    }
+
+    suspend fun skipToNext() {
+        val controller = controllerFuture.await()
+        controller.seekToNextMediaItem()
+    }
+
+    suspend fun hasPrevious(): Boolean {
+        val controller = controllerFuture.await()
+        return controller.hasPreviousMediaItem()
+    }
+
+    suspend fun hasNext(): Boolean {
+        val controller = controllerFuture.await()
+        return controller.hasNextMediaItem()
     }
 
     suspend fun setPlaybackSpeed(speed: Float) {
@@ -110,6 +135,54 @@ class PlayerController private constructor(context: Context) {
             },
             executor
         )
+    }
+
+    suspend fun isPlaying(): Boolean {
+        return controllerFuture.await().isPlaying
+    }
+
+    suspend fun getCurrentEpisode(): com.podcastplayer.app.domain.model.Episode? {
+        val item = controllerFuture.await().currentMediaItem ?: return null
+        val uri = item.localConfiguration?.uri?.toString().orEmpty()
+        val isLocal = uri.startsWith("file://")
+        return com.podcastplayer.app.domain.model.Episode(
+            id = item.mediaId,
+            podcastId = item.mediaMetadata.artist?.toString().orEmpty(),
+            title = item.mediaMetadata.title?.toString().orEmpty(),
+            description = item.mediaMetadata.description?.toString(),
+            pubDate = null,
+            audioUrl = uri,
+            duration = null,
+            imageUrl = item.mediaMetadata.artworkUri?.toString(),
+            isDownloaded = isLocal,
+            localPath = if (isLocal) item.localConfiguration?.uri?.path else null
+        )
+    }
+
+    suspend fun restoreLastSessionIfNeeded(): com.podcastplayer.app.domain.model.Episode? {
+        val controller = controllerFuture.await()
+        if (controller.currentMediaItems.isNotEmpty()) {
+            return getCurrentEpisode()
+        }
+
+        val session = playbackSessionStorage.load() ?: return null
+        if (session.items.isEmpty()) return null
+
+        controller.setMediaItems(session.items, session.currentIndex, session.currentPositionMs)
+        controller.prepare()
+        controller.playbackParameters = controller.playbackParameters.withSpeed(session.playbackSpeed)
+
+        if (session.wasPlaying && !session.isCompleted) {
+            controller.play()
+        } else {
+            controller.pause()
+        }
+
+        return getCurrentEpisode()
+    }
+
+    suspend fun getCurrentArtworkUrl(): String? {
+        return controllerFuture.await().currentMediaItem?.mediaMetadata?.artworkUri?.toString()
     }
 
     fun release() {

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
@@ -39,6 +39,7 @@ class PlayerService : MediaSessionService() {
     private var pendingSeekToMs: Long? = null
 
     private val playbackProgressDao by lazy { DatabaseProvider.getDatabase(this).playbackProgressDao() }
+    private val playbackSessionStorage by lazy { PlaybackSessionStorage(this) }
 
     private val CHANNEL_ID = "podcast_player_channel"
     private val NOTIFICATION_ID = 1
@@ -64,6 +65,7 @@ class PlayerService : MediaSessionService() {
                         val saved = playbackProgressDao.getByEpisodeId(episodeId)
                         pendingSeekToMs = saved?.takeIf { !it.completed }?.positionMs
                     }
+                    persistPlaybackSession(isCompleted = false)
                 }
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
@@ -76,6 +78,7 @@ class PlayerService : MediaSessionService() {
                     }
                     if (playbackState == Player.STATE_ENDED) {
                         persistProgress(markCompleted = true)
+                        persistPlaybackSession(isCompleted = true)
                     }
                 }
 
@@ -86,6 +89,7 @@ class PlayerService : MediaSessionService() {
                         stopPersistLoop()
                         persistProgress(markCompleted = false)
                     }
+                    persistPlaybackSession(isCompleted = false)
                 }
 
                 override fun onPositionDiscontinuity(
@@ -95,6 +99,7 @@ class PlayerService : MediaSessionService() {
                 ) {
                     // e.g. user scrubs; record sooner.
                     persistProgress(markCompleted = false)
+                    persistPlaybackSession(isCompleted = false)
                 }
             }
         )
@@ -107,6 +112,7 @@ class PlayerService : MediaSessionService() {
         persistJob = serviceScope.launch {
             while (true) {
                 persistProgress(markCompleted = false)
+                persistPlaybackSession(isCompleted = false)
                 delay(5_000)
             }
         }
@@ -115,6 +121,22 @@ class PlayerService : MediaSessionService() {
     private fun stopPersistLoop() {
         persistJob?.cancel()
         persistJob = null
+    }
+
+    private fun persistPlaybackSession(isCompleted: Boolean) {
+        val p = player ?: return
+        val currentIndex = p.currentMediaItemIndex
+        val items = p.currentMediaItems
+        if (items.isEmpty() || currentIndex !in items.indices) return
+
+        playbackSessionStorage.save(
+            items = items,
+            currentIndex = currentIndex,
+            currentPositionMs = p.currentPosition,
+            wasPlaying = p.playWhenReady && p.playbackState != Player.STATE_ENDED,
+            playbackSpeed = p.playbackParameters.speed,
+            isCompleted = isCompleted
+        )
     }
 
     private fun persistProgress(markCompleted: Boolean) {
@@ -262,6 +284,7 @@ class PlayerService : MediaSessionService() {
     override fun onDestroy() {
         stopPersistLoop()
         persistProgress(markCompleted = false)
+        persistPlaybackSession(isCompleted = false)
         serviceJob.cancel()
         notificationManager?.setPlayer(null)
         notificationManager = null

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
@@ -126,8 +126,9 @@ class PlayerService : MediaSessionService() {
     private fun persistPlaybackSession(isCompleted: Boolean) {
         val p = player ?: return
         val currentIndex = p.currentMediaItemIndex
-        val items = p.currentMediaItems
-        if (items.isEmpty() || currentIndex !in items.indices) return
+        val mediaItemCount = p.mediaItemCount
+        if (mediaItemCount <= 0 || currentIndex !in 0 until mediaItemCount) return
+        val items = (0 until mediaItemCount).map { index -> p.getMediaItemAt(index) }
 
         playbackSessionStorage.save(
             items = items,


### PR DESCRIPTION
## Summary\n- make downloaded episodes tappable to play immediately\n- add thumbnail artwork to downloads list rows\n- persist/restore playback session so player can resume after app relaunch\n- add previous/next episode controls in player for queue navigation\n- fix Media3 API compatibility for queue item access in CI\n\n## Verification\n- GitHub Action build-debug APK succeeded\n- manually tested APK (reported working well)