### PR TITLE
feat: OPML export/import for podcast subscriptions

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -2,6 +2,8 @@ name: Build debug APK
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ feature/opml-export-import ]
   pull_request:
     branches: [ main ]
 

--- a/app/src/main/java/com/podcastplayer/app/data/local/OpmlManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/OpmlManager.kt
@@ -1,0 +1,99 @@
+package com.podcastplayer.app.data.local
+
+import android.util.Xml
+import com.podcastplayer.app.domain.model.Podcast
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.InputStream
+import java.io.OutputStream
+
+object OpmlManager {
+
+    private const val NS_PODCASTPLAYER = "https://podcastplayer.com/opml"
+
+    fun writeOpml(podcasts: List<Podcast>, outputStream: OutputStream): Result<Int> {
+        return try {
+            val exportable = podcasts.filter { it.feedUrl != null }
+            val serializer = Xml.newSerializer()
+            serializer.setOutput(outputStream, "UTF-8")
+            serializer.startDocument("UTF-8", true)
+
+            serializer.startTag(null, "opml")
+            serializer.attribute(null, "version", "2.0")
+            serializer.attribute("xmlns", "podcastplayer", NS_PODCASTPLAYER)
+
+            serializer.startTag(null, "head")
+            serializer.startTag(null, "title")
+            serializer.text("Vibe Podcast Subscriptions")
+            serializer.endTag(null, "title")
+            serializer.endTag(null, "head")
+
+            serializer.startTag(null, "body")
+            for (podcast in exportable) {
+                serializer.startTag(null, "outline")
+                serializer.attribute(null, "type", "rss")
+                serializer.attribute(null, "text", podcast.title)
+                serializer.attribute(null, "xmlUrl", podcast.feedUrl!!)
+                serializer.attribute(NS_PODCASTPLAYER, "id", podcast.id)
+                serializer.attribute(NS_PODCASTPLAYER, "artist", podcast.artist)
+                podcast.artworkUrl?.let {
+                    serializer.attribute(NS_PODCASTPLAYER, "artworkUrl", it)
+                }
+                serializer.endTag(null, "outline")
+            }
+            serializer.endTag(null, "body")
+
+            serializer.endTag(null, "opml")
+            serializer.endDocument()
+            serializer.flush()
+
+            Result.success(exportable.size)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    fun readOpml(inputStream: InputStream): Result<List<Podcast>> {
+        return try {
+            val factory = XmlPullParserFactory.newInstance()
+            factory.isNamespaceAware = true
+            val parser = factory.newPullParser()
+            parser.setInput(inputStream, null)
+
+            val podcasts = mutableListOf<Podcast>()
+            var eventType = parser.eventType
+
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                if (eventType == XmlPullParser.START_TAG && parser.name == "outline") {
+                    val type = parser.getAttributeValue(null, "type")
+                    val xmlUrl = parser.getAttributeValue(null, "xmlUrl")
+
+                    if (type?.equals("rss", ignoreCase = true) == true && !xmlUrl.isNullOrBlank()) {
+                        val customId = parser.getAttributeValue(NS_PODCASTPLAYER, "id")
+                        val customArtist = parser.getAttributeValue(NS_PODCASTPLAYER, "artist")
+                        val customArtwork = parser.getAttributeValue(NS_PODCASTPLAYER, "artworkUrl")
+
+                        val text = parser.getAttributeValue(null, "text")
+                            ?: parser.getAttributeValue(null, "title")
+                            ?: ""
+
+                        podcasts.add(
+                            Podcast(
+                                id = customId ?: xmlUrl,
+                                title = text,
+                                artist = customArtist ?: "",
+                                artworkUrl = customArtwork,
+                                feedUrl = xmlUrl,
+                            )
+                        )
+                    }
+                }
+                eventType = parser.next()
+            }
+
+            Result.success(podcasts)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
@@ -33,6 +33,13 @@ class SavedPodcastsStorage(context: Context) {
         }
     }
 
+    suspend fun saveAll(podcasts: List<Podcast>) {
+        mutex.withLock {
+            val updated = (_savedPodcasts.value + podcasts).distinctBy { it.id }
+            persist(updated)
+        }
+    }
+
     suspend fun move(fromIndex: Int, toIndex: Int) {
         mutex.withLock {
             val list = _savedPodcasts.value.toMutableList()

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -24,6 +25,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.domain.model.Podcast
+import com.podcastplayer.app.presentation.viewmodel.OpmlResult
 import com.podcastplayer.app.presentation.viewmodel.PodcastUiState
 import kotlinx.coroutines.launch
 
@@ -37,6 +39,8 @@ fun PodcastListScreen(
     onOpenQueue: () -> Unit,
     onOpenDownloads: () -> Unit,
     onPlayQueue: () -> Unit,
+    onExportOpml: () -> Unit = {},
+    onImportOpml: () -> Unit = {},
 ) {
     var searchQuery by remember { mutableStateOf("") }
     var isSearchFocused by remember { mutableStateOf(false) }
@@ -57,12 +61,26 @@ fun PodcastListScreen(
     val playerState by playerViewModel.playerState.collectAsState()
     val scope = rememberCoroutineScope()
     var queuePickerPodcast by remember { mutableStateOf<Podcast?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val opmlResult by viewModel.opmlResult.collectAsState()
+
+    LaunchedEffect(opmlResult) {
+        val result = opmlResult ?: return@LaunchedEffect
+        val message = when (result) {
+            is OpmlResult.ExportSuccess -> "Exported ${result.count} subscriptions"
+            is OpmlResult.ImportSuccess -> "Imported ${result.count} subscriptions"
+            is OpmlResult.Error -> "Error: ${result.message}"
+        }
+        snackbarHostState.showSnackbar(message)
+        viewModel.clearOpmlResult()
+    }
 
     LaunchedEffect(searchQuery) {
         viewModel.searchPodcasts(searchQuery)
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text("Podcast Player") },
@@ -73,6 +91,25 @@ fun PodcastListScreen(
                         }
                         TextButton(onClick = onOpenQueue, enabled = queues.isNotEmpty()) {
                             Text("Queues")
+                        }
+                        Box {
+                            var showOverflow by remember { mutableStateOf(false) }
+                            IconButton(onClick = { showOverflow = true }) {
+                                Icon(Icons.Default.MoreVert, contentDescription = "More options")
+                            }
+                            DropdownMenu(
+                                expanded = showOverflow,
+                                onDismissRequest = { showOverflow = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Export subscriptions") },
+                                    onClick = { showOverflow = false; onExportOpml() }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Import subscriptions") },
+                                    onClick = { showOverflow = false; onImportOpml() }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -2,10 +2,13 @@ package com.podcastplayer.app.presentation.ui
 
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
@@ -63,6 +66,32 @@ fun PodcastNavHost() {
     )
 
     val navController = rememberNavController()
+    val contentResolver = context.contentResolver
+    val opmlScope = rememberCoroutineScope()
+
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("text/x-opml")
+    ) { uri ->
+        uri?.let {
+            opmlScope.launch {
+                contentResolver.openOutputStream(it)?.use { os ->
+                    podcastViewModel.exportOpml(os)
+                }
+            }
+        }
+    }
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let {
+            opmlScope.launch {
+                contentResolver.openInputStream(it)?.use { inputStream ->
+                    podcastViewModel.importOpml(inputStream)
+                }
+            }
+        }
+    }
 
     NavHost(
         navController = navController,
@@ -96,6 +125,10 @@ fun PodcastNavHost() {
                             }
                         }
                     }
+                },
+                onExportOpml = { exportLauncher.launch("vibe-podcasts.opml") },
+                onImportOpml = {
+                    importLauncher.launch(arrayOf("text/x-opml", "text/xml", "application/xml", "*/*"))
                 }
             )
         }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -2,6 +2,7 @@ package com.podcastplayer.app.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.podcastplayer.app.data.local.OpmlManager
 import com.podcastplayer.app.data.local.PlaybackProgressDao
 import com.podcastplayer.app.data.local.PlaybackProgressEntity
 import com.podcastplayer.app.data.local.QueueStorage
@@ -11,6 +12,8 @@ import com.podcastplayer.app.data.repository.PodcastRepository
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.domain.model.PodcastQueue
+import java.io.InputStream
+import java.io.OutputStream
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -89,6 +92,9 @@ class PodcastViewModel(
 
     private val _playbackProgress = MutableStateFlow<Map<String, PlaybackProgressEntity>>(emptyMap())
     val playbackProgress: StateFlow<Map<String, PlaybackProgressEntity>> = _playbackProgress.asStateFlow()
+
+    private val _opmlResult = MutableStateFlow<OpmlResult?>(null)
+    val opmlResult: StateFlow<OpmlResult?> = _opmlResult.asStateFlow()
 
     private var downloadsJob: Job? = null
     private var savedJob: Job? = null
@@ -280,6 +286,31 @@ class PodcastViewModel(
         return downloadManager.deleteAllDownloads()
     }
 
+    suspend fun exportOpml(outputStream: OutputStream) {
+        withContext(Dispatchers.IO) {
+            OpmlManager.writeOpml(_savedPodcasts.value, outputStream)
+        }.fold(
+            onSuccess = { count -> _opmlResult.value = OpmlResult.ExportSuccess(count) },
+            onFailure = { e -> _opmlResult.value = OpmlResult.Error(e.message ?: "Export failed") }
+        )
+    }
+
+    suspend fun importOpml(inputStream: InputStream) {
+        withContext(Dispatchers.IO) {
+            OpmlManager.readOpml(inputStream)
+        }.fold(
+            onSuccess = { podcasts ->
+                savedPodcastsStorage.saveAll(podcasts)
+                _opmlResult.value = OpmlResult.ImportSuccess(podcasts.size)
+            },
+            onFailure = { e -> _opmlResult.value = OpmlResult.Error(e.message ?: "Import failed") }
+        )
+    }
+
+    fun clearOpmlResult() {
+        _opmlResult.value = null
+    }
+
     /**
      * Build a list containing the latest unplayed episode from each podcast (queue order preserved).
      */
@@ -340,4 +371,10 @@ sealed class EpisodesUiState {
     data object Loading : EpisodesUiState()
     data class Success(val episodes: List<Episode>) : EpisodesUiState()
     data class Error(val message: String) : EpisodesUiState()
+}
+
+sealed class OpmlResult {
+    data class ExportSuccess(val count: Int) : OpmlResult()
+    data class ImportSuccess(val count: Int) : OpmlResult()
+    data class Error(val message: String) : OpmlResult()
 }


### PR DESCRIPTION
## Summary
- Add OPML 2.0 export/import so subscriptions survive app reinstalls and can be transferred between podcast apps
- Uses Android Storage Access Framework (SAF) — no new permissions required
- Includes custom XML namespace attributes for lossless round-trip (ID, artist, artwork), with graceful fallback for OPML files from other apps

## Changes
| File | Description |
|---|---|
| `data/local/OpmlManager.kt` | **New** — OPML write (`XmlSerializer`) and read (`XmlPullParser`) |
| `data/local/SavedPodcastsStorage.kt` | Add `saveAll()` for bulk import with dedup |
| `presentation/viewmodel/PodcastViewModel.kt` | Add `exportOpml()`, `importOpml()`, `OpmlResult` sealed class |
| `presentation/ui/PodcastListScreen.kt` | Overflow menu (Export/Import) + Snackbar feedback |
| `presentation/ui/PodcastNavHost.kt` | SAF `CreateDocument`/`OpenDocument` launchers |
| `.github/workflows/android-debug-apk.yml` | Add push trigger for feature branch |

## Test plan
- [ ] Subscribe to several podcasts → Export → verify `.opml` file is valid XML with correct `<outline>` entries
- [ ] Import the exported file → verify no duplicates created
- [ ] Import an OPML file from another podcast app (e.g., Podcast Addict) → verify feeds appear with feedUrl as ID
- [ ] Export with zero subscriptions → verify valid empty OPML, snackbar shows "Exported 0 subscriptions"
- [ ] Cancel the file picker during export/import → no crash, no error snackbar
- [ ] Import a malformed/non-OPML file → error snackbar shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)