### PR TITLE
feat: redesign PlayerScreen with Vibe aesthetic

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
@@ -1,5 +1,8 @@
 package com.podcastplayer.app.presentation.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,31 +11,27 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.NavigateBefore
-import androidx.compose.material.icons.filled.NavigateNext
-import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.outlined.KeyboardArrowDown
+import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
+import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,14 +40,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.text.HtmlCompat
 import coil.compose.AsyncImage
+import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.domain.model.PlayerState
+import com.podcastplayer.app.ui.theme.JetBrainsMono
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlayerScreen(
     episode: Episode,
@@ -64,261 +69,384 @@ fun PlayerScreen(
     onSpeedChange: (Float) -> Unit,
     onSetSleepTimer: (Long) -> Unit,
     onCancelSleepTimer: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
+    val colors = MaterialTheme.colorScheme
     val description = remember(episode.description) { episode.description.stripHtml() }
-    var sleepMinutes by remember { mutableStateOf(15) }
+    val isPlaying = playerState.state == PlaybackState.PLAYING
+    val duration = playerState.duration.coerceAtLeast(1L)
+    val position = playerState.currentPosition.coerceIn(0L, duration)
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Now Playing") },
-                navigationIcon = {
-                    IconButton(onClick = onDismiss) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { padding ->
-        Column(
+    var sleepSheetOpen by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background)
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Top bar — minimal, just a chevron-down dismiss
+        Row(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .fillMaxWidth()
+                .padding(top = 12.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Spacer(modifier = Modifier.height(20.dp))
-
             Box(
                 modifier = Modifier
-                    .size(220.dp)
-                    .clip(MaterialTheme.shapes.large),
-                contentAlignment = Alignment.Center
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(colors.surfaceVariant)
+                    .clickable(onClick = onDismiss),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.KeyboardArrowDown,
+                    contentDescription = "Close player",
+                    tint = colors.onSurface,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = "NOW PLAYING",
+                fontSize = 10.sp,
+                fontFamily = JetBrainsMono,
+                fontWeight = FontWeight.Medium,
+                color = colors.onSurfaceVariant,
+                letterSpacing = 1.8.sp,
+            )
+            Spacer(Modifier.weight(1f))
+            Box(Modifier.size(40.dp))
+        }
+
+        Spacer(Modifier.height(28.dp))
+
+        // Hero artwork with subtle accent border
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(300.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .border(1.dp, colors.outline, RoundedCornerShape(20.dp)),
             ) {
                 AsyncImage(
                     model = episode.imageUrl ?: artworkUrl,
                     contentDescription = episode.title,
-                    modifier = Modifier.size(220.dp)
+                    placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                    error = painterResource(R.drawable.ic_artwork_placeholder),
+                    fallback = painterResource(R.drawable.ic_artwork_placeholder),
+                    modifier = Modifier.fillMaxSize(),
                 )
             }
+        }
 
-            Spacer(modifier = Modifier.height(24.dp))
+        Spacer(Modifier.height(28.dp))
 
+        // Title + description
+        Text(
+            text = episode.title,
+            style = MaterialTheme.typography.headlineSmall,
+            color = colors.onBackground,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = colors.onSurfaceVariant,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        // Scrubber
+        Slider(
+            value = position.toFloat(),
+            valueRange = 0f..duration.toFloat(),
+            onValueChange = { onSeek(it.toLong()) },
+            colors = SliderDefaults.colors(
+                thumbColor = colors.primary,
+                activeTrackColor = colors.primary,
+                inactiveTrackColor = colors.outlineVariant,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
             Text(
-                text = episode.title,
-                style = MaterialTheme.typography.headlineSmall,
-                maxLines = 2,
-                textAlign = TextAlign.Center
+                text = formatPlayerTime(position),
+                fontSize = 11.sp,
+                fontFamily = JetBrainsMono,
+                color = colors.primary,
             )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
             Text(
-                text = description,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 4,
-                textAlign = TextAlign.Center
+                text = "-${formatPlayerTime(duration - position)}",
+                fontSize = 11.sp,
+                fontFamily = JetBrainsMono,
+                color = colors.onSurfaceVariant,
             )
+        }
 
-            Spacer(modifier = Modifier.height(24.dp))
+        Spacer(Modifier.height(20.dp))
 
-            Slider(
-                value = if (playerState.duration > 0) playerState.currentPosition.toFloat() else 0f,
-                valueRange = 0f..(if (playerState.duration > 0) playerState.duration.toFloat() else 1f),
-                onValueChange = { onSeek(it.toLong()) },
-                modifier = Modifier.fillMaxWidth()
+        // Speed + Sleep pills
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            VibePill(
+                icon = { Icon(Icons.Rounded.Speed, null, Modifier.size(14.dp), tint = colors.onSurface) },
+                label = "${formatSpeed(playerState.playbackSpeed)}x",
+                onClick = { onSpeedChange(cycleSpeed(playerState.playbackSpeed)) },
             )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = formatTime(playerState.currentPosition),
-                    style = MaterialTheme.typography.bodySmall
-                )
-                Text(
-                    text = formatTime(playerState.duration),
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = "Sleep timer",
-                    style = MaterialTheme.typography.titleSmall
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                if (sleepTimerRemaining != null) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Ends in ${formatTime(sleepTimerRemaining)}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        OutlinedButton(onClick = onCancelSleepTimer) {
-                            Text("Cancel")
-                        }
-                    }
-                } else {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            IconButton(onClick = { sleepMinutes = (sleepMinutes - 5).coerceAtLeast(5) }) {
-                                Icon(Icons.Default.Remove, contentDescription = "Decrease timer")
-                            }
-                            Text(
-                                text = "${sleepMinutes} min",
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            IconButton(onClick = { sleepMinutes = (sleepMinutes + 5).coerceAtMost(120) }) {
-                                Icon(Icons.Default.Add, contentDescription = "Increase timer")
-                            }
-                        }
-                        Button(onClick = { onSetSleepTimer(sleepMinutes * 60 * 1000L) }) {
-                            Text("Start")
-                        }
-                    }
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                TextButton(
-                    onClick = {
-                        val newSpeed = when (playerState.playbackSpeed) {
-                            0.5f -> 0.75f
-                            0.75f -> 1.0f
-                            1.0f -> 1.25f
-                            1.25f -> 1.5f
-                            1.5f -> 2.0f
-                            else -> 0.5f
-                        }
-                        onSpeedChange(newSpeed)
-                    }
-                ) {
-                    Text(
-                        text = "Speed ${playerState.playbackSpeed}x",
-                        style = MaterialTheme.typography.labelMedium
+            Spacer(Modifier.width(10.dp))
+            val sleepLabel = sleepTimerRemaining
+                ?.let { "${(it / 60000L).coerceAtLeast(1)}m" }
+                ?: "Sleep"
+            VibePill(
+                icon = {
+                    Icon(
+                        Icons.Outlined.Timer,
+                        null,
+                        Modifier.size(14.dp),
+                        tint = if (sleepTimerRemaining != null) colors.primary else colors.onSurface,
                     )
-                }
-            }
+                },
+                label = sleepLabel,
+                active = sleepTimerRemaining != null,
+                onClick = {
+                    if (sleepTimerRemaining != null) onCancelSleepTimer() else sleepSheetOpen = true
+                },
+            )
+        }
 
-            Spacer(modifier = Modifier.weight(1f))
+        Spacer(Modifier.weight(1f))
 
-            Row(
+        // Transport row
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TransportButton(
+                icon = Icons.Rounded.SkipPrevious,
+                description = "Previous episode",
+                enabled = hasPrevious,
+                size = 44.dp,
+                iconSize = 26.dp,
+                onClick = onPlayPrevious,
+            )
+            TransportButton(
+                icon = Icons.Rounded.FastRewind,
+                description = "Rewind 15s",
+                size = 52.dp,
+                iconSize = 28.dp,
+                onClick = { onSeek((position - 15_000L).coerceAtLeast(0L)) },
+            )
+            // Primary play/pause — circular accent
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 16.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(colors.primary)
+                    .clickable(onClick = onPlayPause),
+                contentAlignment = Alignment.Center,
             ) {
-                IconButton(
-                    onClick = onPlayPrevious,
-                    enabled = hasPrevious,
-                    modifier = Modifier.size(64.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.NavigateBefore,
-                        contentDescription = "Previous episode",
-                        modifier = Modifier.size(36.dp)
-                    )
+                Icon(
+                    imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                    contentDescription = if (isPlaying) "Pause" else "Play",
+                    tint = colors.onPrimary,
+                    modifier = Modifier.size(40.dp),
+                )
+            }
+            TransportButton(
+                icon = Icons.Rounded.FastForward,
+                description = "Forward 30s",
+                size = 52.dp,
+                iconSize = 28.dp,
+                onClick = { onSeek((position + 30_000L).coerceAtMost(duration)) },
+            )
+            TransportButton(
+                icon = Icons.Rounded.SkipNext,
+                description = "Next episode",
+                enabled = hasNext,
+                size = 44.dp,
+                iconSize = 26.dp,
+                onClick = onPlayNext,
+            )
+        }
+    }
+
+    if (sleepSheetOpen) {
+        SleepTimerPicker(
+            onDismiss = { sleepSheetOpen = false },
+            onPick = { minutes ->
+                sleepSheetOpen = false
+                onSetSleepTimer(minutes * 60_000L)
+            },
+        )
+    }
+}
+
+@Composable
+private fun VibePill(
+    icon: @Composable () -> Unit,
+    label: String,
+    onClick: () -> Unit,
+    active: Boolean = false,
+) {
+    val colors = MaterialTheme.colorScheme
+    val bg = if (active) colors.primaryContainer else colors.surfaceVariant
+    val fg = if (active) colors.primary else colors.onSurface
+    Row(
+        modifier = Modifier
+            .heightIn(min = 34.dp)
+            .clip(RoundedCornerShape(999.dp))
+            .background(bg)
+            .border(1.dp, colors.outline, RoundedCornerShape(999.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon()
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            fontFamily = JetBrainsMono,
+            fontWeight = FontWeight.Medium,
+            color = fg,
+        )
+    }
+}
+
+@Composable
+private fun TransportButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    description: String,
+    onClick: () -> Unit,
+    size: androidx.compose.ui.unit.Dp,
+    iconSize: androidx.compose.ui.unit.Dp,
+    enabled: Boolean = true,
+) {
+    val colors = MaterialTheme.colorScheme
+    val tint = if (enabled) colors.onSurface else colors.onSurfaceVariant.copy(alpha = 0.4f)
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = description,
+            tint = tint,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}
+
+@Composable
+private fun SleepTimerPicker(
+    onDismiss: () -> Unit,
+    onPick: (Long) -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val options = listOf(5L, 10L, 15L, 30L, 45L, 60L)
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background.copy(alpha = 0.85f))
+            .clickable(onClick = onDismiss),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(colors.surface)
+                .border(1.dp, colors.outline, RoundedCornerShape(20.dp))
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Sleep timer",
+                style = MaterialTheme.typography.titleMedium,
+                color = colors.onSurface,
+            )
+            Spacer(Modifier.height(14.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                options.take(3).forEach { m ->
+                    SleepOption(minutes = m, onClick = { onPick(m) })
                 }
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                IconButton(
-                    onClick = { onSeek(playerState.currentPosition - 15000) },
-                    modifier = Modifier.size(76.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.FastRewind,
-                        contentDescription = "Rewind 15s",
-                        modifier = Modifier.size(40.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                FloatingActionButton(
-                    onClick = onPlayPause,
-                    modifier = Modifier.size(96.dp)
-                ) {
-                    Icon(
-                        imageVector = if (playerState.state == com.podcastplayer.app.domain.model.PlaybackState.PLAYING) {
-                            Icons.Rounded.Pause
-                        } else {
-                            Icons.Rounded.PlayArrow
-                        },
-                        contentDescription = if (playerState.state == com.podcastplayer.app.domain.model.PlaybackState.PLAYING) {
-                            "Pause"
-                        } else {
-                            "Play"
-                        },
-                        modifier = Modifier.size(56.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                IconButton(
-                    onClick = { onSeek(playerState.currentPosition + 30000) },
-                    modifier = Modifier.size(76.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.FastForward,
-                        contentDescription = "Forward 30s",
-                        modifier = Modifier.size(40.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                IconButton(
-                    onClick = onPlayNext,
-                    enabled = hasNext,
-                    modifier = Modifier.size(64.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.NavigateNext,
-                        contentDescription = "Next episode",
-                        modifier = Modifier.size(36.dp)
-                    )
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                options.drop(3).forEach { m ->
+                    SleepOption(minutes = m, onClick = { onPick(m) })
                 }
             }
         }
     }
 }
 
-private fun formatTime(ms: Long): String {
-    val totalSeconds = ms / 1000
-    val hours = totalSeconds / 3600
-    val minutes = (totalSeconds % 3600) / 60
-    val seconds = totalSeconds % 60
-
-    return if (hours > 0) {
-        String.format("%d:%02d:%02d", hours, minutes, seconds)
-    } else {
-        String.format("%d:%02d", minutes, seconds)
+@Composable
+private fun SleepOption(minutes: Long, onClick: () -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    Box(
+        modifier = Modifier
+            .size(width = 64.dp, height = 44.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(colors.surfaceVariant)
+            .border(1.dp, colors.outline, RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "${minutes}m",
+            fontSize = 13.sp,
+            fontFamily = JetBrainsMono,
+            fontWeight = FontWeight.Medium,
+            color = colors.onSurface,
+        )
     }
+}
+
+private fun cycleSpeed(current: Float): Float = when (current) {
+    0.75f -> 1.0f
+    1.0f -> 1.25f
+    1.25f -> 1.5f
+    1.5f -> 1.75f
+    1.75f -> 2.0f
+    2.0f -> 0.75f
+    else -> 1.0f
+}
+
+private fun formatSpeed(speed: Float): String =
+    if (speed % 1f == 0f) "%.1f".format(speed) else "%.2f".format(speed).trimEnd('0')
+
+private fun formatPlayerTime(ms: Long): String {
+    val s = (ms / 1000).coerceAtLeast(0)
+    val h = s / 3600
+    val m = (s % 3600) / 60
+    val sec = s % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
 }
 
 private fun String?.stripHtml(): String {


### PR DESCRIPTION
## Summary

Follow-up to [#18](https://github.com/thomasz-nyt/vibe-podcast-android/pull/18): adopt the Vibe aesthetic on the full-screen player.

- Chevron-down dismiss + centered "NOW PLAYING" eyebrow (JetBrains Mono, uppercase, tracked)
- 300dp hero artwork with outlined frame, 20dp radius
- Vibe-tinted scrubber with accent thumb/active track
- JetBrains Mono elapsed (accent) / remaining (muted) timestamps
- Pill chips for speed (cycles 0.75→2.0) and sleep timer
- 5-button transport row anchored by an 80dp circular accent play/pause button
- Modal sleep timer picker (5 / 10 / 15 / 30 / 45 / 60 min presets)

## Test plan

- [ ] APK built by GitHub Actions installs and launches
- [ ] PlayerScreen renders on dark + light themes
- [ ] Scrubber seeks correctly; timestamps update
- [ ] Speed pill cycles through 0.75, 1.0, 1.25, 1.5, 1.75, 2.0
- [ ] Sleep timer picker opens, selecting a preset starts the timer
- [ ] While timer is active, pill turns accent and tapping cancels
- [ ] Skip next/prev disable correctly when at queue bounds
- [ ] Rewind 15s / Forward 30s clamp to [0, duration]

🤖 Generated with [Claude Code](https://claude.com/claude-code)