### PR TITLE
feat: Vibe redesign — remaining screens

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -1,31 +1,32 @@
 package com.podcastplayer.app.presentation.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,127 +34,94 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.presentation.viewmodel.DownloadedEpisodeUi
+import com.podcastplayer.app.ui.theme.JetBrainsMono
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadsScreen(
     downloads: List<DownloadedEpisodeUi>,
     onPlayEpisode: (DownloadedEpisodeUi) -> Unit,
     onDeleteEpisode: (String) -> Unit,
     onDeleteAll: () -> Unit,
-    onBack: () -> Unit
+    @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
     var showDeleteAllDialog by remember { mutableStateOf(false) }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Downloads") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            VibeTopBar(
+                title = "Downloads",
+                eyebrow = "Offline",
+                actions = {
+                    if (downloads.isNotEmpty()) {
+                        VibeChip(
+                            label = "Remove all",
+                            onClick = { showDeleteAllDialog = true },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Delete,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            },
+                        )
                     }
                 },
-                actions = {
-                    TextButton(
-                        onClick = { showDeleteAllDialog = true },
-                        enabled = downloads.isNotEmpty()
-                    ) {
-                        Text("Remove all")
-                    }
-                }
             )
-        }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
+
             if (downloads.isEmpty()) {
-                Column(
+                Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
+                        .padding(horizontal = 16.dp, vertical = 24.dp),
+                    contentAlignment = Alignment.Center,
                 ) {
-                    Text("No downloads")
-                    Text(
-                        text = "Download episodes to listen offline",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    VibeEmptyState(
+                        icon = Icons.Outlined.CloudDownload,
+                        title = "No downloads",
+                        subtitle = "Download episodes to listen offline",
                     )
                 }
             } else {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    VibeSectionEyebrow(text = "Saved episodes", modifier = Modifier.weight(1f))
+                    Text(
+                        text = "${downloads.size}",
+                        fontFamily = JetBrainsMono,
+                        fontSize = 11.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(
                         start = 16.dp,
-                        top = 16.dp,
+                        top = 8.dp,
                         end = 16.dp,
-                        bottom = 140.dp
+                        bottom = 140.dp,
                     ),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     items(downloads, key = { it.episode.id }) { item ->
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onPlayEpisode(item) },
-                            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                AsyncImage(
-                                    model = item.episode.imageUrl ?: item.podcastArtworkUrl,
-                                    contentDescription = item.episode.title,
-                                    modifier = Modifier.size(56.dp),
-                                    placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
-                                    error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
-                                    fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder)
-                                )
-
-                                Column(
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(start = 12.dp)
-                                ) {
-                                    Text(
-                                        text = item.episode.title,
-                                        style = MaterialTheme.typography.titleMedium,
-                                        maxLines = 2,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                    item.podcastTitle?.let {
-                                        Text(
-                                            text = it,
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
-                                    }
-                                }
-
-                                IconButton(onClick = { onDeleteEpisode(item.episode.id) }) {
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = "Delete download",
-                                        modifier = Modifier.size(20.dp)
-                                    )
-                                }
-                            }
-                        }
+                        DownloadRow(
+                            item = item,
+                            onPlay = { onPlayEpisode(item) },
+                            onDelete = { onDeleteEpisode(item.episode.id) },
+                        )
                     }
                 }
             }
@@ -170,14 +138,86 @@ fun DownloadsScreen(
                     onDeleteAll()
                     showDeleteAllDialog = false
                 }) {
-                    Text("Remove all")
+                    Text("Remove all", fontWeight = FontWeight.SemiBold)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteAllDialog = false }) {
                     Text("Cancel")
                 }
+            },
+            containerColor = MaterialTheme.colorScheme.surface,
+        )
+    }
+}
+
+@Composable
+private fun DownloadRow(
+    item: DownloadedEpisodeUi,
+    onPlay: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(14.dp)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(colors.surface)
+            .border(1.dp, colors.outline, shape)
+            .clickable(onClick = onPlay)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = item.episode.imageUrl ?: item.podcastArtworkUrl,
+            contentDescription = item.episode.title,
+            modifier = Modifier
+                .size(60.dp)
+                .clip(RoundedCornerShape(10.dp)),
+            placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+            error = painterResource(R.drawable.ic_artwork_placeholder),
+            fallback = painterResource(R.drawable.ic_artwork_placeholder),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            item.podcastTitle?.let {
+                Text(
+                    text = it.uppercase(),
+                    fontFamily = JetBrainsMono,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 1.4.sp,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(2.dp))
             }
+            Text(
+                text = item.episode.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = colors.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        VibeCircleIconButton(
+            icon = Icons.Outlined.Delete,
+            description = "Delete download",
+            onClick = onDelete,
+            size = 36.dp,
+            iconSize = 18.dp,
+        )
+        Spacer(Modifier.width(6.dp))
+        VibeCircleIconButton(
+            icon = Icons.Default.PlayArrow,
+            description = "Play",
+            onClick = onPlay,
+            size = 40.dp,
+            iconSize = 22.dp,
+            tinted = true,
         )
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
@@ -1,30 +1,61 @@
 package com.podcastplayer.app.presentation.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.DownloadDone
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.text.HtmlCompat
 import coil.compose.AsyncImage
+import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.presentation.viewmodel.EpisodesUiState
 import com.podcastplayer.app.presentation.viewmodel.PlayerViewModel
 import com.podcastplayer.app.presentation.viewmodel.PodcastViewModel
+import com.podcastplayer.app.ui.theme.JetBrainsMono
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EpisodeListScreen(
     podcast: Podcast?,
@@ -32,8 +63,9 @@ fun EpisodeListScreen(
     playerViewModel: PlayerViewModel,
     onBack: () -> Unit,
     onPlayEpisode: () -> Unit = {},
-    onOpenPlayer: () -> Unit
+    onOpenPlayer: () -> Unit,
 ) {
+    val colors = MaterialTheme.colorScheme
     val episodesState by podcastViewModel.episodesUiState.collectAsState()
     val downloadedEpisodes by podcastViewModel.downloadedEpisodes.collectAsState()
     val downloadProgress by podcastViewModel.downloadProgress.collectAsState()
@@ -44,113 +76,140 @@ fun EpisodeListScreen(
     val playerState by playerViewModel.playerState.collectAsState()
     val scope = rememberCoroutineScope()
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(podcast?.title ?: "Episodes") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { padding ->
+    Scaffold(containerColor = colors.background) { padding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(padding)
+                .padding(padding),
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                Box(modifier = Modifier.weight(1f, fill = true)) {
-                when (val state = episodesState) {
-                    is EpisodesUiState.Initial -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = androidx.compose.ui.Alignment.Center
-                        ) {
-                            Text("Loading episodes...")
-                        }
-                    }
-                    is EpisodesUiState.Loading -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = androidx.compose.ui.Alignment.Center
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    }
-                    is EpisodesUiState.Success -> {
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 140.dp),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            items(state.episodes, key = { it.id }) { episode ->
-                                val isDownloaded = downloadedIds.contains(episode.id) || episode.isDownloaded
-                                val progress = downloadProgress[episode.id]
+                VibeTopBar(
+                    title = podcast?.title ?: "Episodes",
+                    eyebrow = podcast?.artist,
+                    onBack = onBack,
+                )
 
-                                val playback = playbackProgressMap[episode.id]
-                                val isCompleted = playback?.completed == true
-                                val playbackProgress = playback?.let {
-                                    val duration = it.durationMs
-                                    if (duration <= 0L) null else (it.positionMs.toFloat() / duration.toFloat())
-                                }
-
-                                EpisodeItem(
-                                    episode = episode,
-                                    artworkUrl = podcast?.artworkUrl,
-                                    isDownloaded = isDownloaded,
-                                    downloadProgress = progress,
-                                    isCompleted = isCompleted,
-                                    playbackProgress = playbackProgress,
-                                    onClick = {
-                                        playerViewModel.playEpisode(episode, podcast?.artworkUrl)
-                                        onPlayEpisode()
-                                    },
-                                    onDownload = {
-                                        podcastViewModel.startDownload(episode)
-                                    },
-                                    onDelete = {
-                                        scope.launch { podcastViewModel.deleteDownload(episode.id) }
-                                    }
+                Box(modifier = Modifier.weight(1f)) {
+                    when (val state = episodesState) {
+                        is EpisodesUiState.Initial,
+                        is EpisodesUiState.Loading -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(
+                                    color = colors.primary,
+                                    strokeWidth = 2.dp,
+                                    modifier = Modifier.size(28.dp),
                                 )
                             }
                         }
-                    }
-                    is EpisodesUiState.Error -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = androidx.compose.ui.Alignment.Center
-                        ) {
-                            Text("Error: ${state.message}")
+
+                        is EpisodesUiState.Success -> {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = PaddingValues(
+                                    start = 16.dp,
+                                    top = 4.dp,
+                                    end = 16.dp,
+                                    bottom = 140.dp,
+                                ),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                item {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(bottom = 4.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        VibeSectionEyebrow("Episodes")
+                                        Spacer(Modifier.weight(1f))
+                                        Text(
+                                            text = state.episodes.size.toString(),
+                                            fontSize = 11.sp,
+                                            fontWeight = FontWeight.Medium,
+                                            color = colors.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                                items(state.episodes, key = { it.id }) { episode ->
+                                    val isDownloaded = downloadedIds.contains(episode.id) || episode.isDownloaded
+                                    val progress = downloadProgress[episode.id]
+                                    val playback = playbackProgressMap[episode.id]
+                                    val isCompleted = playback?.completed == true
+                                    val playbackProgress = playback?.let {
+                                        val duration = it.durationMs
+                                        if (duration <= 0L) null
+                                        else (it.positionMs.toFloat() / duration.toFloat())
+                                    }
+
+                                    EpisodeRow(
+                                        episode = episode,
+                                        artworkUrl = podcast?.artworkUrl,
+                                        isDownloaded = isDownloaded,
+                                        downloadProgress = progress,
+                                        isCompleted = isCompleted,
+                                        playbackProgress = playbackProgress,
+                                        onClick = {
+                                            playerViewModel.playEpisode(episode, podcast?.artworkUrl)
+                                            onPlayEpisode()
+                                        },
+                                        onDownload = { podcastViewModel.startDownload(episode) },
+                                        onDelete = {
+                                            scope.launch { podcastViewModel.deleteDownload(episode.id) }
+                                        },
+                                    )
+                                }
+                            }
+                        }
+
+                        is EpisodesUiState.Error -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize().padding(24.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                VibeSurface {
+                                    Column(modifier = Modifier.padding(16.dp)) {
+                                        Text(
+                                            text = "Could not load episodes",
+                                            style = MaterialTheme.typography.titleSmall,
+                                            color = colors.onSurface,
+                                        )
+                                        Spacer(Modifier.height(4.dp))
+                                        Text(
+                                            text = state.message,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = colors.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
-        }
 
-        currentEpisode?.let {
-            MiniPlayerBar(
-                episode = it,
-                artworkUrl = currentArtworkUrl ?: podcast?.artworkUrl,
-                playerState = playerState,
-                onPlayPause = { playerViewModel.togglePlayPause() },
-                onOpenPlayer = onOpenPlayer,
-                onSeek = { playerViewModel.seekTo(it) },
-                onDismiss = { playerViewModel.clearPlayer() },
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(horizontal = 8.dp, vertical = 6.dp)
-            )
+            currentEpisode?.let {
+                MiniPlayerBar(
+                    episode = it,
+                    artworkUrl = currentArtworkUrl ?: podcast?.artworkUrl,
+                    playerState = playerState,
+                    onPlayPause = { playerViewModel.togglePlayPause() },
+                    onOpenPlayer = onOpenPlayer,
+                    onSeek = { ms -> playerViewModel.seekTo(ms) },
+                    onDismiss = { playerViewModel.clearPlayer() },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 8.dp, vertical = 6.dp),
+                )
+            }
         }
     }
 }
 
-}
-
 @Composable
-fun EpisodeItem(
+private fun EpisodeRow(
     episode: Episode,
     artworkUrl: String?,
     isDownloaded: Boolean,
@@ -159,105 +218,160 @@ fun EpisodeItem(
     playbackProgress: Float?,
     onClick: () -> Unit,
     onDownload: () -> Unit,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
 ) {
+    val colors = MaterialTheme.colorScheme
     val description = remember(episode.description) { episode.description.stripHtml() }
     var expanded by remember { mutableStateOf(false) }
 
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
-        shape = MaterialTheme.shapes.medium
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp)
-        ) {
-            Row(
-                verticalAlignment = Alignment.Top
-            ) {
-                AsyncImage(
-                    model = episode.imageUrl ?: artworkUrl,
-                    contentDescription = episode.title,
-                    modifier = Modifier.size(72.dp)
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column(
-                    modifier = Modifier.weight(1f)
-                ) {
+    VibeSurface(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.Top) {
+                Box {
+                    AsyncImage(
+                        model = episode.imageUrl ?: artworkUrl,
+                        contentDescription = episode.title,
+                        placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                        error = painterResource(R.drawable.ic_artwork_placeholder),
+                        fallback = painterResource(R.drawable.ic_artwork_placeholder),
+                        modifier = Modifier
+                            .size(68.dp)
+                            .clip(RoundedCornerShape(10.dp)),
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = episode.title,
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = colors.onSurface,
                         maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
                     )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Text(
-                        text = buildMetadataLabel(episode),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    if (isCompleted) {
-                        Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(Modifier.height(6.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "Played",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
+                            text = buildMetadataLabel(episode),
+                            fontFamily = JetBrainsMono,
+                            fontSize = 10.sp,
+                            color = colors.onSurfaceVariant,
                         )
+                        if (isCompleted) {
+                            Spacer(Modifier.width(8.dp))
+                            Icon(
+                                Icons.Outlined.CheckCircle,
+                                contentDescription = "Played",
+                                tint = colors.primary,
+                                modifier = Modifier.size(13.dp),
+                            )
+                            Spacer(Modifier.width(3.dp))
+                            Text(
+                                text = "Played",
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = colors.primary,
+                            )
+                        }
                     }
+                }
+                Spacer(Modifier.width(8.dp))
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(999.dp))
+                        .background(colors.primary)
+                        .clickable(onClick = onClick),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.PlayArrow,
+                        contentDescription = "Play",
+                        tint = colors.onPrimary,
+                        modifier = Modifier.size(20.dp),
+                    )
                 }
             }
 
             if (!isCompleted && playbackProgress != null && playbackProgress > 0.01f) {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(Modifier.height(10.dp))
                 LinearProgressIndicator(
                     progress = playbackProgress.coerceIn(0f, 1f),
-                    modifier = Modifier.fillMaxWidth()
+                    color = colors.primary,
+                    trackColor = colors.outlineVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .clip(RoundedCornerShape(999.dp)),
                 )
             }
 
             if (description.isNotBlank()) {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(Modifier.height(10.dp))
                 Text(
                     text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = if (expanded) Int.MAX_VALUE else 4,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.onSurfaceVariant,
+                    maxLines = if (expanded) Int.MAX_VALUE else 3,
                     overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    modifier = Modifier.clickable { expanded = !expanded },
                 )
-                TextButton(onClick = { expanded = !expanded }) {
-                    Text(if (expanded) "Less" else "More")
-                }
             }
-            Spacer(modifier = Modifier.height(12.dp))
+
             if (downloadProgress != null && !isDownloaded) {
+                Spacer(Modifier.height(10.dp))
                 LinearProgressIndicator(
                     progress = downloadProgress.coerceIn(0f, 1f),
-                    modifier = Modifier.fillMaxWidth()
+                    color = colors.primary,
+                    trackColor = colors.outlineVariant,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .clip(RoundedCornerShape(999.dp)),
                 )
-                Spacer(modifier = Modifier.height(8.dp))
             }
+
+            Spacer(Modifier.height(12.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (isDownloaded) {
-                    Text(
-                        text = "Downloaded",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    TextButton(onClick = onDelete) {
-                        Text("Delete")
+                when {
+                    isDownloaded -> {
+                        VibeChip(
+                            label = "Downloaded",
+                            onClick = onDelete,
+                            active = true,
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Outlined.DownloadDone,
+                                    null,
+                                    modifier = Modifier.size(14.dp),
+                                    tint = colors.primary,
+                                )
+                            },
+                        )
                     }
-                } else {
-                    Spacer(modifier = Modifier.width(1.dp))
-                    Button(
-                        onClick = onDownload,
-                        enabled = downloadProgress == null
-                    ) {
-                        Text(if (downloadProgress != null) "Downloading..." else "Download")
+                    downloadProgress != null -> {
+                        VibeChip(
+                            label = "Downloading…",
+                            onClick = {},
+                            enabled = false,
+                        )
+                    }
+                    else -> {
+                        VibeChip(
+                            label = "Download",
+                            onClick = onDownload,
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Outlined.Download,
+                                    null,
+                                    modifier = Modifier.size(14.dp),
+                                    tint = colors.onSurface,
+                                )
+                            },
+                        )
                     }
                 }
             }
@@ -276,9 +390,7 @@ private fun buildMetadataLabel(episode: Episode): String {
         val formatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
         parts.add(formatter.format(it))
     }
-    episode.duration?.let {
-        parts.add(formatDuration(it))
-    }
+    episode.duration?.let { parts.add(formatDuration(it)) }
     return parts.joinToString(" • ")
 }
 
@@ -287,10 +399,6 @@ private fun formatDuration(ms: Long): String {
     val hours = totalSeconds / 3600
     val minutes = (totalSeconds % 3600) / 60
     val seconds = totalSeconds % 60
-
-    return if (hours > 0) {
-        String.format("%d:%02d:%02d", hours, minutes, seconds)
-    } else {
-        String.format("%d:%02d", minutes, seconds)
-    }
+    return if (hours > 0) "%d:%02d:%02d".format(hours, minutes, seconds)
+    else "%d:%02d".format(minutes, seconds)
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -1,30 +1,76 @@
 package com.podcastplayer.app.presentation.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.BookmarkAdd
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.outlined.BookmarkAdd
+import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.MoreHoriz
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.PlaylistAdd
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.rounded.Bookmark
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Podcast
+import com.podcastplayer.app.domain.model.PodcastQueue
 import com.podcastplayer.app.presentation.viewmodel.OpmlResult
 import com.podcastplayer.app.presentation.viewmodel.PodcastUiState
 import kotlinx.coroutines.launch
@@ -37,11 +83,12 @@ fun PodcastListScreen(
     onPodcastSelected: (Podcast) -> Unit,
     onOpenPlayer: () -> Unit,
     onOpenQueue: () -> Unit,
-    onOpenDownloads: () -> Unit,
+    @Suppress("UNUSED_PARAMETER") onOpenDownloads: () -> Unit,
     onPlayQueue: () -> Unit,
     onExportOpml: () -> Unit = {},
     onImportOpml: () -> Unit = {},
 ) {
+    val colors = MaterialTheme.colorScheme
     var searchQuery by remember { mutableStateOf("") }
     var isSearchFocused by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
@@ -63,6 +110,7 @@ fun PodcastListScreen(
     var queuePickerPodcast by remember { mutableStateOf<Podcast?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     val opmlResult by viewModel.opmlResult.collectAsState()
+    var overflowOpen by remember { mutableStateOf(false) }
 
     LaunchedEffect(opmlResult) {
         val result = opmlResult ?: return@LaunchedEffect
@@ -80,41 +128,8 @@ fun PodcastListScreen(
     }
 
     Scaffold(
+        containerColor = colors.background,
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        topBar = {
-            TopAppBar(
-                title = { Text("Podcast Player") },
-                actions = {
-                    if (!isSearchFocused) {
-                        IconButton(onClick = onOpenDownloads) {
-                            Icon(Icons.Default.Download, contentDescription = "Downloads")
-                        }
-                        TextButton(onClick = onOpenQueue, enabled = queues.isNotEmpty()) {
-                            Text("Queues")
-                        }
-                        Box {
-                            var showOverflow by remember { mutableStateOf(false) }
-                            IconButton(onClick = { showOverflow = true }) {
-                                Icon(Icons.Default.MoreVert, contentDescription = "More options")
-                            }
-                            DropdownMenu(
-                                expanded = showOverflow,
-                                onDismissRequest = { showOverflow = false }
-                            ) {
-                                DropdownMenuItem(
-                                    text = { Text("Export subscriptions") },
-                                    onClick = { showOverflow = false; onExportOpml() }
-                                )
-                                DropdownMenuItem(
-                                    text = { Text("Import subscriptions") },
-                                    onClick = { showOverflow = false; onImportOpml() }
-                                )
-                            }
-                        }
-                    }
-                }
-            )
-        }
     ) { padding ->
         Box(
             modifier = Modifier
@@ -122,142 +137,198 @@ fun PodcastListScreen(
                 .padding(padding)
                 .pointerInput(Unit) {
                     detectTapGestures(onTap = { focusManager.clearFocus() })
-                }
+                },
         ) {
-            Column(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                        .focusRequester(focusRequester)
-                        .onFocusChanged { isSearchFocused = it.isFocused },
-                    placeholder = { Text("Search podcasts...") },
-                    leadingIcon = {
-                        Icon(Icons.Default.Search, contentDescription = null)
-                    },
-                    trailingIcon = {
-                        if (searchQuery.isNotBlank()) {
-                            IconButton(
-                                onClick = {
-                                    searchQuery = ""
-                                    focusManager.clearFocus()
-                                }
+            Column(modifier = Modifier.fillMaxSize()) {
+                VibeTopBar(
+                    title = "Vibe",
+                    eyebrow = "Podcasts",
+                    actions = {
+                        Box {
+                            VibeCircleIconButton(
+                                icon = Icons.Outlined.MoreHoriz,
+                                description = "More options",
+                                onClick = { overflowOpen = true },
+                            )
+                            DropdownMenu(
+                                expanded = overflowOpen,
+                                onDismissRequest = { overflowOpen = false },
                             ) {
-                                Icon(Icons.Default.Close, contentDescription = "Clear search")
+                                DropdownMenuItem(
+                                    text = { Text("Export subscriptions") },
+                                    onClick = { overflowOpen = false; onExportOpml() },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Import subscriptions") },
+                                    onClick = { overflowOpen = false; onImportOpml() },
+                                )
                             }
                         }
                     },
-                    shape = RoundedCornerShape(24.dp)
                 )
 
-                if (showSaved) {
+                SearchField(
+                    value = searchQuery,
+                    onChange = { searchQuery = it },
+                    focusRequester = focusRequester,
+                    onFocusChange = { isSearchFocused = it },
+                    onClear = {
+                        searchQuery = ""
+                        focusManager.clearFocus()
+                    },
+                )
+
+                if (showSaved && queues.isNotEmpty()) {
+                    Spacer(Modifier.height(8.dp))
                     QueuePlayRow(
                         queues = queues,
                         selectedQueue = selectedQueue,
                         onSelectQueue = { viewModel.selectQueue(it) },
                         onPlayQueue = onPlayQueue,
-                        enabled = queuePodcasts.isNotEmpty()
+                        onOpenQueues = onOpenQueue,
+                        enabled = queuePodcasts.isNotEmpty(),
                     )
                 }
 
-                Box(
-                    modifier = Modifier
-                        .weight(1f, fill = true)
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        top = 12.dp,
+                        end = 16.dp,
+                        bottom = 140.dp,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(
-                            start = 16.dp,
-                            top = 8.dp,
-                            end = 16.dp,
-                            bottom = 140.dp
-                        ),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        if (showSaved) {
-                            item {
+                    if (showSaved) {
+                        item {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                VibeSectionEyebrow("Subscriptions")
+                                Spacer(Modifier.weight(1f))
                                 Text(
-                                    text = "Subscriptions",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    modifier = Modifier.padding(vertical = 4.dp)
+                                    text = savedPodcasts.size.toString(),
+                                    fontSize = 11.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    color = colors.onSurfaceVariant,
                                 )
                             }
-                            if (savedPodcasts.isNotEmpty()) {
-                                items(savedPodcasts) { podcast ->
-                                    PodcastItem(
-                                        podcast = podcast,
-                                        onClick = {
-                                            focusManager.clearFocus()
-                                            onPodcastSelected(podcast)
-                                        },
-                                        onSaveToggle = { viewModel.removeSavedPodcast(podcast.id) },
-                                        onAddToQueue = { queuePickerPodcast = podcast },
-                                        isSaved = true
-                                    )
-                                }
-                            } else {
+                        }
+                        if (savedPodcasts.isNotEmpty()) {
+                            items(savedPodcasts, key = { it.id }) { podcast ->
+                                PodcastRow(
+                                    podcast = podcast,
+                                    onClick = {
+                                        focusManager.clearFocus()
+                                        onPodcastSelected(podcast)
+                                    },
+                                    onSaveToggle = { viewModel.removeSavedPodcast(podcast.id) },
+                                    onAddToQueue = { queuePickerPodcast = podcast },
+                                    isSaved = true,
+                                )
+                            }
+                        } else {
+                            item {
+                                VibeEmptyState(
+                                    icon = Icons.Outlined.BookmarkAdd,
+                                    title = "No subscriptions yet",
+                                    subtitle = "Search above and tap Subscribe to start your library.",
+                                    action = {
+                                        VibePrimaryPill(
+                                            label = "Browse podcasts",
+                                            onClick = { focusRequester.requestFocus() },
+                                        )
+                                    },
+                                )
+                            }
+                        }
+                        item { Spacer(Modifier.height(12.dp)) }
+                    }
+
+                    when (val state = uiState) {
+                        is PodcastUiState.Initial -> {
+                            if (!showSaved) {
                                 item {
-                                    SavedEmptyStateCard(onBrowse = { focusRequester.requestFocus() })
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 32.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        Text(
+                                            text = "Search for podcasts above",
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = colors.onSurfaceVariant,
+                                        )
+                                    }
                                 }
                             }
-                            item { Divider() }
                         }
 
-                        when (val state = uiState) {
-                            is PodcastUiState.Initial -> {
-                                item {
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(vertical = 24.dp),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        Text("Search for podcasts above")
-                                    }
+                        is PodcastUiState.Loading -> {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 32.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator(
+                                        color = colors.primary,
+                                        strokeWidth = 2.dp,
+                                        modifier = Modifier.size(28.dp),
+                                    )
                                 }
                             }
+                        }
 
-                            is PodcastUiState.Loading -> {
+                        is PodcastUiState.Success -> {
+                            if (state.podcasts.isNotEmpty()) {
                                 item {
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(vertical = 24.dp),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        CircularProgressIndicator()
-                                    }
+                                    VibeSectionEyebrow(
+                                        "Results",
+                                        modifier = Modifier.padding(bottom = 4.dp),
+                                    )
                                 }
-                            }
-
-                            is PodcastUiState.Success -> {
-                                items(state.podcasts) { podcast ->
+                                items(state.podcasts, key = { it.id }) { podcast ->
                                     val alreadySaved = savedPodcasts.any { it.id == podcast.id }
-                                    PodcastItem(
+                                    PodcastRow(
                                         podcast = podcast,
                                         onClick = {
                                             focusManager.clearFocus()
                                             onPodcastSelected(podcast)
                                         },
                                         onSaveToggle = {
-                                            if (alreadySaved) viewModel.removeSavedPodcast(podcast.id) else viewModel.savePodcast(podcast)
+                                            if (alreadySaved) viewModel.removeSavedPodcast(podcast.id)
+                                            else viewModel.savePodcast(podcast)
                                         },
                                         onAddToQueue = { queuePickerPodcast = podcast },
-                                        isSaved = alreadySaved
+                                        isSaved = alreadySaved,
                                     )
                                 }
                             }
+                        }
 
-                            is PodcastUiState.Error -> {
-                                item {
-                                    Text(
-                                        text = "Error: ${state.message}",
-                                        color = MaterialTheme.colorScheme.error
-                                    )
+                        is PodcastUiState.Error -> {
+                            item {
+                                VibeSurface {
+                                    Column(modifier = Modifier.padding(16.dp)) {
+                                        Text(
+                                            text = "Error",
+                                            style = MaterialTheme.typography.titleSmall,
+                                            color = colors.error,
+                                        )
+                                        Spacer(Modifier.height(4.dp))
+                                        Text(
+                                            text = state.message,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = colors.onSurfaceVariant,
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -276,7 +347,7 @@ fun PodcastListScreen(
                     onDismiss = { playerViewModel.clearPlayer() },
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
-                        .padding(horizontal = 8.dp, vertical = 6.dp)
+                        .padding(horizontal = 8.dp, vertical = 6.dp),
                 )
             }
         }
@@ -291,19 +362,83 @@ fun PodcastListScreen(
                 scope.launch { viewModel.setPodcastQueues(podcast, selected) }
                 queuePickerPodcast = null
             },
-            onDismiss = { queuePickerPodcast = null }
+            onDismiss = { queuePickerPodcast = null },
         )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchField(
+    value: String,
+    onChange: (String) -> Unit,
+    focusRequester: FocusRequester,
+    onFocusChange: (Boolean) -> Unit,
+    onClear: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    OutlinedTextField(
+        value = value,
+        onValueChange = onChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .focusRequester(focusRequester)
+            .onFocusChanged { onFocusChange(it.isFocused) },
+        placeholder = {
+            Text(
+                text = "Search podcasts",
+                color = colors.onSurfaceVariant,
+                fontSize = 14.sp,
+            )
+        },
+        leadingIcon = {
+            Icon(
+                Icons.Outlined.Search,
+                contentDescription = null,
+                tint = colors.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+        },
+        trailingIcon = if (value.isNotBlank()) {
+            {
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(CircleShape)
+                        .clickable(onClick = onClear),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Outlined.Close,
+                        contentDescription = "Clear search",
+                        tint = colors.onSurfaceVariant,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+        } else null,
+        singleLine = true,
+        shape = RoundedCornerShape(999.dp),
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = colors.primary,
+            unfocusedBorderColor = colors.outline,
+            containerColor = colors.surface,
+            cursorColor = colors.primary,
+        ),
+    )
+}
+
 @Composable
 private fun QueuePlayRow(
-    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
-    selectedQueue: com.podcastplayer.app.domain.model.PodcastQueue?,
+    queues: List<PodcastQueue>,
+    selectedQueue: PodcastQueue?,
     onSelectQueue: (String) -> Unit,
     onPlayQueue: () -> Unit,
-    enabled: Boolean
+    onOpenQueues: () -> Unit,
+    enabled: Boolean,
 ) {
+    val colors = MaterialTheme.colorScheme
     var expanded by remember { mutableStateOf(false) }
 
     Row(
@@ -311,27 +446,116 @@ private fun QueuePlayRow(
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Box {
-            TextButton(onClick = { expanded = true }, enabled = queues.isNotEmpty()) {
-                Text(selectedQueue?.name ?: "Select queue")
-                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
-            }
-            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        Box(modifier = Modifier.weight(1f)) {
+            VibeChip(
+                label = selectedQueue?.name ?: "Select queue",
+                onClick = { expanded = true },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+            ) {
                 queues.forEach { queue ->
                     DropdownMenuItem(
                         text = { Text(queue.name) },
                         onClick = {
                             expanded = false
                             onSelectQueue(queue.id)
-                        }
+                        },
                     )
                 }
+                DropdownMenuItem(
+                    text = { Text("Manage queues", color = colors.primary) },
+                    onClick = {
+                        expanded = false
+                        onOpenQueues()
+                    },
+                )
             }
         }
-        Button(onClick = onPlayQueue, enabled = enabled) {
-            Text("Play")
+        VibePrimaryPill(
+            label = "Play queue",
+            onClick = onPlayQueue,
+            enabled = enabled,
+            leadingIcon = {
+                Icon(
+                    Icons.Outlined.PlayArrow,
+                    null,
+                    modifier = Modifier.size(14.dp),
+                    tint = if (enabled) colors.onPrimary else colors.onSurfaceVariant,
+                )
+            },
+        )
+    }
+}
+
+@Composable
+private fun PodcastRow(
+    podcast: Podcast,
+    onClick: () -> Unit,
+    onSaveToggle: (() -> Unit)?,
+    onAddToQueue: (() -> Unit)?,
+    isSaved: Boolean,
+) {
+    val colors = MaterialTheme.colorScheme
+    VibeSurface(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                model = podcast.artworkUrl,
+                contentDescription = podcast.title,
+                placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                error = painterResource(R.drawable.ic_artwork_placeholder),
+                fallback = painterResource(R.drawable.ic_artwork_placeholder),
+                modifier = Modifier
+                    .size(60.dp)
+                    .clip(RoundedCornerShape(10.dp)),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = podcast.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = colors.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = podcast.artist,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            if (onSaveToggle != null) {
+                val icon = if (isSaved) Icons.Rounded.Bookmark else Icons.Outlined.BookmarkBorder
+                VibeCircleIconButton(
+                    icon = icon,
+                    description = if (isSaved) "Unsubscribe" else "Subscribe",
+                    onClick = onSaveToggle,
+                    size = 36.dp,
+                    iconSize = 18.dp,
+                    tinted = isSaved,
+                )
+            }
+            if (onAddToQueue != null) {
+                Spacer(Modifier.width(6.dp))
+                VibeCircleIconButton(
+                    icon = Icons.Outlined.PlaylistAdd,
+                    description = "Add to queue",
+                    onClick = onAddToQueue,
+                    size = 36.dp,
+                    iconSize = 18.dp,
+                )
+            }
         }
     }
 }
@@ -339,15 +563,16 @@ private fun QueuePlayRow(
 @Composable
 private fun QueuePickerDialog(
     podcast: Podcast,
-    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
+    queues: List<PodcastQueue>,
     initialSelectedIds: Set<String>,
     onConfirm: (Set<String>) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     var selectedIds by remember(podcast) { mutableStateOf(initialSelectedIds.toMutableSet()) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surface,
         title = { Text("Add to queue") },
         text = {
             if (queues.isEmpty()) {
@@ -357,17 +582,14 @@ private fun QueuePickerDialog(
                     queues.forEach { queue ->
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth()
+                            modifier = Modifier.fillMaxWidth(),
                         ) {
                             Checkbox(
                                 checked = selectedIds.contains(queue.id),
                                 onCheckedChange = { checked ->
-                                    if (checked) {
-                                        selectedIds.add(queue.id)
-                                    } else {
-                                        selectedIds.remove(queue.id)
-                                    }
-                                }
+                                    if (checked) selectedIds.add(queue.id)
+                                    else selectedIds.remove(queue.id)
+                                },
                             )
                             Text(queue.name)
                         }
@@ -376,113 +598,10 @@ private fun QueuePickerDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(selectedIds) }) {
-                Text("Save")
-            }
+            TextButton(onClick = { onConfirm(selectedIds) }) { Text("Save") }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        }
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
     )
-}
-
-@Composable
-fun SavedEmptyStateCard(
-    onBrowse: () -> Unit
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Icons.Default.BookmarkAdd,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "No saved podcasts yet",
-                style = MaterialTheme.typography.titleSmall
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = "Tap Subscribe on search results to add favorites",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(onClick = onBrowse) {
-                Text("Browse podcasts")
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun PodcastItem(
-    podcast: Podcast,
-    onClick: () -> Unit,
-    onSaveToggle: (() -> Unit)? = null,
-    onAddToQueue: (() -> Unit)? = null,
-    isSaved: Boolean = false,
-) {
-    Card(
-        onClick = onClick,
-        modifier = Modifier
-            .fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp)
-    ) {
-        Row(
-            modifier = Modifier
-                .padding(12.dp)
-                .height(IntrinsicSize.Min),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            AsyncImage(
-                model = podcast.artworkUrl,
-                contentDescription = podcast.title,
-                modifier = Modifier
-                    .size(60.dp)
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                Text(
-                    text = podcast.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = podcast.artist,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            onSaveToggle?.let {
-                Spacer(modifier = Modifier.width(12.dp))
-                TextButton(onClick = it) {
-                    Text(if (isSaved) "Saved" else "Subscribe")
-                }
-            }
-            onAddToQueue?.let {
-                Spacer(modifier = Modifier.width(4.dp))
-                TextButton(onClick = it) {
-                    Text("Queue")
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/QueueScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/QueueScreen.kt
@@ -1,6 +1,9 @@
 package com.podcastplayer.app.presentation.ui
 
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,32 +12,29 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.QueueMusic
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,20 +42,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.PlayerState
 import com.podcastplayer.app.domain.model.Podcast
+import com.podcastplayer.app.domain.model.PodcastQueue
+import com.podcastplayer.app.ui.theme.JetBrainsMono
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
 import org.burnoutcrew.reorderable.reorderable
 import org.burnoutcrew.reorderable.rememberReorderableLazyListState
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QueueScreen(
-    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
+    queues: List<PodcastQueue>,
     selectedQueueId: String?,
     podcasts: List<Podcast>,
     currentEpisode: Episode?,
@@ -72,10 +77,12 @@ fun QueueScreen(
     onRemove: (String) -> Unit,
     onPlayQueue: () -> Unit,
     onDismissPlayer: () -> Unit,
-    onBack: () -> Unit
+    @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
+    val listState = rememberLazyListState()
     val reorderState = rememberReorderableLazyListState(
-        onMove = { from, to -> onMove(from.index, to.index) }
+        listState = listState,
+        onMove = { from, to -> onMove(from.index, to.index) },
     )
 
     val selectedQueue = queues.firstOrNull { it.id == selectedQueueId }
@@ -84,149 +91,117 @@ fun QueueScreen(
     var showDeleteDialog by remember { mutableStateOf(false) }
     var nameInput by remember { mutableStateOf("") }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Queues") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            VibeTopBar(
+                title = selectedQueue?.name ?: "Queues",
+                eyebrow = "Queue",
+                actions = {
+                    VibeCircleIconButton(
+                        icon = Icons.Default.Add,
+                        description = "Add queue",
+                        onClick = {
+                            nameInput = ""
+                            showCreateDialog = true
+                        },
+                    )
+                    if (selectedQueue != null) {
+                        Spacer(Modifier.width(8.dp))
+                        VibeCircleIconButton(
+                            icon = Icons.Outlined.Edit,
+                            description = "Rename queue",
+                            onClick = {
+                                nameInput = selectedQueue.name
+                                showRenameDialog = true
+                            },
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        VibeCircleIconButton(
+                            icon = Icons.Outlined.Delete,
+                            description = "Delete queue",
+                            onClick = { showDeleteDialog = true },
+                        )
                     }
                 },
-                actions = {
-                    IconButton(onClick = {
-                        nameInput = ""
-                        showCreateDialog = true
-                    }) {
-                        Icon(Icons.Default.Add, contentDescription = "Add queue")
-                    }
-                    IconButton(
-                        onClick = {
-                            nameInput = selectedQueue?.name.orEmpty()
-                            showRenameDialog = true
-                        },
-                        enabled = selectedQueue != null
-                    ) {
-                        Icon(Icons.Default.Edit, contentDescription = "Rename queue")
-                    }
-                    IconButton(
-                        onClick = { showDeleteDialog = true },
-                        enabled = selectedQueue != null
-                    ) {
-                        Icon(Icons.Default.Delete, contentDescription = "Delete queue")
-                    }
-                }
             )
-        }
-    ) { padding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
-            Column(modifier = Modifier.fillMaxSize()) {
-                QueueSelectorRow(
-                    queues = queues,
-                    selectedQueue = selectedQueue,
-                    onSelectQueue = onSelectQueue,
-                    onPlayQueue = onPlayQueue,
-                    enabled = podcasts.isNotEmpty()
-                )
 
-                if (podcasts.isEmpty()) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(16.dp),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text("No podcasts in queue")
-                        Text(
-                            text = "Add from Saved to get started",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                } else {
-                    LazyColumn(
-                        state = reorderState.listState,
-                        modifier = Modifier
-                            .weight(1f)
-                            .reorderable(reorderState),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = PaddingValues(
-                            start = 16.dp,
-                            top = 16.dp,
-                            end = 16.dp,
-                            bottom = 140.dp
-                        )
-                    ) {
-                        items(podcasts, key = { it.id }) { podcast ->
-                            ReorderableItem(reorderState, key = podcast.id) { isDragging ->
-                                val elevation = animateDpAsState(
-                                    targetValue = if (isDragging) 6.dp else 0.dp,
-                                    label = "elevation"
-                                )
-                                Card(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 2.dp)
-                                        .detectReorderAfterLongPress(reorderState),
-                                    elevation = CardDefaults.cardElevation(
-                                        defaultElevation = elevation.value
-                                    )
-                                ) {
-                                    Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(12.dp),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        AsyncImage(
-                                            model = podcast.artworkUrl,
-                                            contentDescription = podcast.title,
-                                            modifier = Modifier.size(56.dp)
-                                        )
-                                        Spacer(modifier = Modifier.size(12.dp))
-                                        Column(modifier = Modifier.weight(1f)) {
-                                            Text(podcast.title, style = MaterialTheme.typography.titleMedium)
-                                            Text(
-                                                podcast.artist,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        }
-                                        IconButton(onClick = { onRemove(podcast.id) }) {
-                                            Icon(Icons.Default.Delete, contentDescription = "Remove")
-                                        }
-                                        Icon(
-                                            imageVector = Icons.Default.DragHandle,
-                                            contentDescription = "Reorder",
-                                            modifier = Modifier.size(32.dp)
-                                        )
-                                    }
-                                }
-                            }
+            QueueSelectorRow(
+                queues = queues,
+                selectedQueue = selectedQueue,
+                onSelectQueue = onSelectQueue,
+                onPlayQueue = onPlayQueue,
+                enabled = podcasts.isNotEmpty(),
+            )
+
+            if (podcasts.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp, vertical = 24.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    VibeEmptyState(
+                        icon = Icons.Outlined.QueueMusic,
+                        title = "No podcasts in queue",
+                        subtitle = "Add from Saved to get started",
+                    )
+                }
+            } else {
+                Spacer(Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    VibeSectionEyebrow(text = "Podcasts", modifier = Modifier.weight(1f))
+                    Text(
+                        text = "${podcasts.size}",
+                        fontFamily = JetBrainsMono,
+                        fontSize = 11.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .weight(1f)
+                        .reorderable(reorderState),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(
+                        start = 16.dp,
+                        top = 8.dp,
+                        end = 16.dp,
+                        bottom = 140.dp,
+                    ),
+                ) {
+                    items(podcasts, key = { it.id }) { podcast ->
+                        ReorderableItem(reorderState, key = podcast.id) { isDragging ->
+                            QueueRow(
+                                podcast = podcast,
+                                isDragging = isDragging,
+                                onRemove = { onRemove(podcast.id) },
+                                reorderModifier = Modifier.detectReorderAfterLongPress(reorderState),
+                            )
                         }
                     }
                 }
             }
+        }
 
-            currentEpisode?.let { episode ->
-                MiniPlayerBar(
-                    episode = episode,
-                    artworkUrl = currentArtworkUrl,
-                    playerState = playerState,
-                    onPlayPause = onPlayPause,
-                    onOpenPlayer = onOpenPlayer,
-                    onSeek = onSeek,
-                    onDismiss = onDismissPlayer,
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(horizontal = 8.dp, vertical = 6.dp)
-                )
-            }
+        currentEpisode?.let { episode ->
+            MiniPlayerBar(
+                episode = episode,
+                artworkUrl = currentArtworkUrl,
+                playerState = playerState,
+                onPlayPause = onPlayPause,
+                onOpenPlayer = onOpenPlayer,
+                onSeek = onSeek,
+                onDismiss = onDismissPlayer,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+            )
         }
     }
 
@@ -238,7 +213,7 @@ fun QueueScreen(
                 onCreateQueue(it)
                 showCreateDialog = false
             },
-            onDismiss = { showCreateDialog = false }
+            onDismiss = { showCreateDialog = false },
         )
     }
 
@@ -250,7 +225,7 @@ fun QueueScreen(
                 onRenameQueue(selectedQueue.id, it)
                 showRenameDialog = false
             },
-            onDismiss = { showRenameDialog = false }
+            onDismiss = { showRenameDialog = false },
         )
     }
 
@@ -271,47 +246,135 @@ fun QueueScreen(
                 TextButton(onClick = { showDeleteDialog = false }) {
                     Text("Cancel")
                 }
-            }
+            },
+            containerColor = MaterialTheme.colorScheme.surface,
         )
     }
 }
 
 @Composable
-private fun QueueSelectorRow(
-    queues: List<com.podcastplayer.app.domain.model.PodcastQueue>,
-    selectedQueue: com.podcastplayer.app.domain.model.PodcastQueue?,
-    onSelectQueue: (String) -> Unit,
-    onPlayQueue: () -> Unit,
-    enabled: Boolean
+private fun QueueRow(
+    podcast: Podcast,
+    isDragging: Boolean,
+    onRemove: () -> Unit,
+    reorderModifier: Modifier,
 ) {
-    var expanded by remember { mutableStateOf(false) }
-
-    Row(
+    val colors = MaterialTheme.colorScheme
+    val borderColor = if (isDragging) colors.primary else colors.outline
+    val elevation = animateDpAsState(
+        targetValue = if (isDragging) 1.dp else 0.dp,
+        label = "drag-border",
+    )
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.surface)
+            .border(
+                width = 1.dp + elevation.value,
+                color = borderColor,
+                shape = RoundedCornerShape(14.dp),
+            ),
     ) {
-        Box {
-            TextButton(onClick = { expanded = true }, enabled = queues.isNotEmpty()) {
-                Text(selectedQueue?.name ?: "Select queue")
-                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                model = podcast.artworkUrl,
+                contentDescription = podcast.title,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(10.dp)),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = podcast.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = colors.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = podcast.artist,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
-            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                queues.forEach { queue ->
-                    DropdownMenuItem(
-                        text = { Text(queue.name) },
-                        onClick = {
-                            expanded = false
-                            onSelectQueue(queue.id)
-                        }
+            Spacer(Modifier.width(8.dp))
+            VibeCircleIconButton(
+                icon = Icons.Outlined.Delete,
+                description = "Remove",
+                onClick = onRemove,
+                size = 36.dp,
+                iconSize = 18.dp,
+            )
+            Spacer(Modifier.width(4.dp))
+            Box(
+                modifier = reorderModifier
+                    .size(36.dp)
+                    .clip(CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.DragHandle,
+                    contentDescription = "Reorder",
+                    tint = colors.onSurfaceVariant,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun QueueSelectorRow(
+    queues: List<PodcastQueue>,
+    selectedQueue: PodcastQueue?,
+    onSelectQueue: (String) -> Unit,
+    onPlayQueue: () -> Unit,
+    enabled: Boolean,
+) {
+    if (queues.isEmpty()) return
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+        VibeSectionEyebrow(text = "Select queue")
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            androidx.compose.foundation.lazy.LazyRow(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(queues, key = { it.id }) { queue ->
+                    VibeChip(
+                        label = queue.name,
+                        onClick = { onSelectQueue(queue.id) },
+                        active = queue.id == selectedQueue?.id,
                     )
                 }
             }
-        }
-        Button(onClick = onPlayQueue, enabled = enabled) {
-            Text("Play")
+            Spacer(Modifier.width(8.dp))
+            VibePrimaryPill(
+                label = "Play",
+                onClick = onPlayQueue,
+                enabled = enabled,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+            )
         }
     }
 }
@@ -321,7 +384,7 @@ private fun QueueNameDialog(
     title: String,
     initialName: String,
     onConfirm: (String) -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
 ) {
     var name by remember { mutableStateOf(initialName) }
 
@@ -332,18 +395,21 @@ private fun QueueNameDialog(
             OutlinedTextField(
                 value = name,
                 onValueChange = { value -> name = value },
-                placeholder = { Text("Queue name") }
+                placeholder = { Text("Queue name") },
+                shape = RoundedCornerShape(12.dp),
             )
         },
         confirmButton = {
             TextButton(onClick = { onConfirm(name) }) {
-                Text("Save")
+                Text("Save", fontWeight = FontWeight.SemiBold)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text("Cancel")
             }
-        }
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
     )
 }
+

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/VibeComponents.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/VibeComponents.kt
@@ -1,0 +1,276 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.podcastplayer.app.ui.theme.JetBrainsMono
+
+/**
+ * Vibe-styled top bar. Use on sub-screens (Episodes, Queue, Downloads) and root screens.
+ * Keeps a consistent header layout: optional back button, optional eyebrow, title, and actions.
+ */
+@Composable
+fun VibeTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    eyebrow: String? = null,
+    onBack: (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (onBack != null) {
+            VibeCircleIconButton(
+                icon = Icons.Outlined.ArrowBack,
+                description = "Back",
+                onClick = onBack,
+            )
+            Spacer(Modifier.width(12.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            if (eyebrow != null) {
+                Text(
+                    text = eyebrow.uppercase(),
+                    fontFamily = JetBrainsMono,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 1.6.sp,
+                    color = colors.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(2.dp))
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                color = colors.onBackground,
+            )
+        }
+        Row(verticalAlignment = Alignment.CenterVertically, content = actions)
+    }
+}
+
+/** Small circular icon button used in top bars and inline actions. */
+@Composable
+fun VibeCircleIconButton(
+    icon: ImageVector,
+    description: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp,
+    iconSize: Dp = 20.dp,
+    tinted: Boolean = false,
+) {
+    val colors = MaterialTheme.colorScheme
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(if (tinted) colors.primaryContainer else colors.surfaceVariant)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = description,
+            tint = if (tinted) colors.primary else colors.onSurface,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}
+
+/** Rounded pill chip with optional leading icon. */
+@Composable
+fun VibeChip(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    active: Boolean = false,
+    enabled: Boolean = true,
+    leadingIcon: (@Composable () -> Unit)? = null,
+) {
+    val colors = MaterialTheme.colorScheme
+    val bg = when {
+        !enabled -> colors.surfaceVariant
+        active -> colors.primaryContainer
+        else -> colors.surfaceVariant
+    }
+    val fg = when {
+        !enabled -> colors.onSurfaceVariant.copy(alpha = 0.5f)
+        active -> colors.primary
+        else -> colors.onSurface
+    }
+    Row(
+        modifier = modifier
+            .heightIn(min = 34.dp)
+            .clip(RoundedCornerShape(999.dp))
+            .background(bg)
+            .border(1.dp, colors.outline, RoundedCornerShape(999.dp))
+            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingIcon != null) {
+            leadingIcon()
+            Spacer(Modifier.width(6.dp))
+        }
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            color = fg,
+        )
+    }
+}
+
+/** Solid accent pill action. Use for primary CTAs (Play, Save, etc). */
+@Composable
+fun VibePrimaryPill(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    leadingIcon: (@Composable () -> Unit)? = null,
+) {
+    val colors = MaterialTheme.colorScheme
+    val bg = if (enabled) colors.primary else colors.surfaceVariant
+    val fg = if (enabled) colors.onPrimary else colors.onSurfaceVariant.copy(alpha = 0.5f)
+    Row(
+        modifier = modifier
+            .heightIn(min = 36.dp)
+            .clip(RoundedCornerShape(999.dp))
+            .background(bg)
+            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 16.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (leadingIcon != null) {
+            leadingIcon()
+            Spacer(Modifier.width(6.dp))
+        }
+        Text(
+            text = label,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = fg,
+        )
+    }
+}
+
+/** Outlined card surface. The default for Vibe list rows and containers. */
+@Composable
+fun VibeSurface(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    shape: RoundedCornerShape = RoundedCornerShape(14.dp),
+    content: @Composable () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(colors.surface)
+            .border(1.dp, colors.outline, shape)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+    ) { content() }
+}
+
+/** Empty state card used on Saved/Queue/Downloads. */
+@Composable
+fun VibeEmptyState(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    action: (@Composable () -> Unit)? = null,
+) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(colors.surface)
+            .border(1.dp, colors.outline, RoundedCornerShape(16.dp))
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .background(colors.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = colors.primary,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = colors.onSurface,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = colors.onSurfaceVariant,
+        )
+        if (action != null) {
+            Spacer(Modifier.height(14.dp))
+            action()
+        }
+    }
+}
+
+/** Eyebrow label used to section content (e.g. "SUBSCRIPTIONS", "LATEST"). */
+@Composable
+fun VibeSectionEyebrow(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text.uppercase(),
+        fontFamily = JetBrainsMono,
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Medium,
+        letterSpacing = 1.6.sp,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+


### PR DESCRIPTION
## Summary

Third and final phase of the Vibe "Deep Night" redesign. Applies the visual language from [#18](https://github.com/thomasz-nyt/vibe-podcast-android/pull/18) (foundation + bottom nav) and [#19](https://github.com/thomasz-nyt/vibe-podcast-android/pull/19) (PlayerScreen) to the remaining four screens.

## Changes

- **New shared primitives** in `VibeComponents.kt`: `VibeTopBar`, `VibeCircleIconButton`, `VibeChip`, `VibePrimaryPill`, `VibeSurface`, `VibeEmptyState`, `VibeSectionEyebrow`
- **PodcastListScreen** — pill search field, "Vibe / Podcasts" eyebrow top bar, outlined row cards, queue chip selector with accent play pill
- **EpisodeListScreen** — Vibe top bar with artist eyebrow + back, JetBrains Mono metadata, slim 2dp progress bars, chip-based download states, circular accent play button per row
- **QueueScreen** — queue-name top bar with add/rename/delete circle buttons, chip-based queue switcher, reorderable rows with accent border on drag (replacing elevation)
- **DownloadsScreen** — "Offline" top bar with remove-all chip, outlined row cards with JetBrains Mono podcast eyebrow, tinted circular play button

## Test plan

- [x] `./gradlew assembleDebug` builds clean
- [ ] Manual QA: navigate through all 4 screens, verify drag-reorder still works in QueueScreen, verify empty states render, verify queue selection + play
- [ ] Manual QA: dark + light themes on a physical device

🤖 Generated with [Claude Code](https://claude.ai/code)