### PR TITLE
feat: Vibe Home screen

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/local/PlaybackProgressDao.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/PlaybackProgressDao.kt
@@ -21,6 +21,9 @@ interface PlaybackProgressDao {
     @Query("SELECT * FROM playback_progress WHERE podcastId = :podcastId")
     suspend fun getByPodcastId(podcastId: String): List<PlaybackProgressEntity>
 
+    @Query("SELECT * FROM playback_progress WHERE completed = 0 AND positionMs > 0 ORDER BY lastPlayedAtMs DESC")
+    fun observeInProgress(): Flow<List<PlaybackProgressEntity>>
+
     @Query("DELETE FROM playback_progress WHERE episodeId = :episodeId")
     suspend fun deleteByEpisodeId(episodeId: String)
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/HomeScreen.kt
@@ -1,0 +1,366 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.podcastplayer.app.R
+import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.PlayerState
+import com.podcastplayer.app.domain.model.Podcast
+import com.podcastplayer.app.presentation.viewmodel.ContinueListeningUi
+import com.podcastplayer.app.ui.theme.JetBrainsMono
+import java.time.LocalDateTime
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Composable
+fun HomeScreen(
+    subscriptions: List<Podcast>,
+    continueListening: List<ContinueListeningUi>,
+    currentEpisode: Episode?,
+    currentArtworkUrl: String?,
+    playerState: PlayerState,
+    onOpenPodcast: (Podcast) -> Unit,
+    onOpenSearch: () -> Unit,
+    onPlayEpisode: (Episode, String?) -> Unit,
+    onPlayPause: () -> Unit,
+    onOpenPlayer: () -> Unit,
+    onSeek: (Long) -> Unit,
+    onDismissPlayer: () -> Unit,
+) {
+    val now = remember { LocalDateTime.now() }
+    val scrollState = rememberScrollState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState),
+        ) {
+            HomeHeader(now = now)
+
+            if (continueListening.isNotEmpty()) {
+                SectionHeader(label = "Continue listening")
+                ContinueListeningRow(
+                    items = continueListening,
+                    onPlay = { item ->
+                        onPlayEpisode(item.episode, item.podcastArtworkUrl)
+                    },
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
+            if (subscriptions.isEmpty()) {
+                VibeEmptyState(
+                    icon = Icons.Outlined.Search,
+                    title = "No subscriptions yet",
+                    subtitle = "Search for podcasts to start building your library",
+                    action = {
+                        VibePrimaryPill(label = "Browse podcasts", onClick = onOpenSearch)
+                    },
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                )
+            } else {
+                SectionHeader(
+                    label = "Your subscriptions",
+                    count = subscriptions.size,
+                )
+                SubscriptionsGrid(
+                    podcasts = subscriptions,
+                    onOpenPodcast = onOpenPodcast,
+                )
+            }
+
+            Spacer(Modifier.height(160.dp))
+        }
+
+        currentEpisode?.let { episode ->
+            MiniPlayerBar(
+                episode = episode,
+                artworkUrl = currentArtworkUrl,
+                playerState = playerState,
+                onPlayPause = onPlayPause,
+                onOpenPlayer = onOpenPlayer,
+                onSeek = onSeek,
+                onDismiss = onDismissPlayer,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun HomeHeader(now: LocalDateTime) {
+    val colors = MaterialTheme.colorScheme
+    val statusPad = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 20.dp, top = statusPad + 14.dp, bottom = 6.dp),
+    ) {
+        Text(
+            text = formatDateEyebrow(now),
+            fontFamily = JetBrainsMono,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 1.8.sp,
+            color = colors.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = greeting(now.hour),
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = colors.onBackground,
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(label: String, count: Int? = null) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 20.dp, top = 18.dp, bottom = 10.dp),
+        verticalAlignment = Alignment.Bottom,
+    ) {
+        Text(
+            text = label,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Bold,
+            color = colors.onBackground,
+            modifier = Modifier.weight(1f),
+        )
+        if (count != null) {
+            Text(
+                text = count.toString().padStart(2, '0'),
+                fontFamily = JetBrainsMono,
+                fontSize = 11.sp,
+                color = colors.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContinueListeningRow(
+    items: List<ContinueListeningUi>,
+    onPlay: (ContinueListeningUi) -> Unit,
+) {
+    val scroll = rememberScrollState()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scroll)
+            .padding(horizontal = 20.dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items.forEach { item ->
+            ContinueListeningCard(item = item, onClick = { onPlay(item) })
+        }
+    }
+}
+
+@Composable
+private fun ContinueListeningCard(item: ContinueListeningUi, onClick: () -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .width(248.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.surface)
+            .border(1.dp, colors.outline, RoundedCornerShape(14.dp))
+            .clickable(onClick = onClick)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = item.episode.imageUrl ?: item.podcastArtworkUrl,
+            contentDescription = item.episode.title,
+            modifier = Modifier
+                .size(70.dp)
+                .clip(RoundedCornerShape(8.dp)),
+            placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            item.podcastTitle?.let {
+                Text(
+                    text = it.uppercase(),
+                    fontFamily = JetBrainsMono,
+                    fontSize = 9.5.sp,
+                    letterSpacing = 1.4.sp,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = item.episode.title,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                lineHeight = 17.sp,
+            )
+            Spacer(Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = item.progressFraction,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(2.dp)),
+                color = colors.primary,
+                trackColor = colors.outline,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "${formatRemaining(item.remainingMs)} left",
+                fontFamily = JetBrainsMono,
+                fontSize = 10.sp,
+                color = colors.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionsGrid(
+    podcasts: List<Podcast>,
+    onOpenPodcast: (Podcast) -> Unit,
+) {
+    val rows = podcasts.chunked(3)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        rows.forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                row.forEach { podcast ->
+                    SubscriptionTile(
+                        podcast = podcast,
+                        onClick = { onOpenPodcast(podcast) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                // Pad last row so tiles keep width
+                repeat(3 - row.size) { Spacer(Modifier.weight(1f)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionTile(
+    podcast: Podcast,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = modifier.clickable(onClick = onClick),
+    ) {
+        AsyncImage(
+            model = podcast.artworkUrl,
+            contentDescription = podcast.title,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(10.dp))
+                .background(colors.surfaceVariant),
+            placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = podcast.title,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = colors.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = podcast.artist.uppercase(),
+            fontFamily = JetBrainsMono,
+            fontSize = 9.5.sp,
+            letterSpacing = 0.8.sp,
+            color = colors.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────
+
+private fun greeting(hour: Int): String = when {
+    hour < 12 -> "Good morning."
+    hour < 18 -> "Good afternoon."
+    else -> "Good evening."
+}
+
+private fun formatDateEyebrow(now: LocalDateTime): String {
+    val dow = now.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.ENGLISH).uppercase()
+    val mon = now.month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH).uppercase()
+    val day = now.dayOfMonth.toString().padStart(2, '0')
+    val hh = now.hour.toString().padStart(2, '0')
+    val mm = now.minute.toString().padStart(2, '0')
+    return "$dow · $mon $day · $hh:$mm"
+}
+
+private fun formatRemaining(ms: Long): String {
+    val totalSec = ms / 1000
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    return if (h > 0) "${h}h ${m}m" else "${m}m"
+}

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 private object Routes {
+    const val Home = "home"
     const val Search = "search"
     const val Queue = "queue"
     const val Downloads = "downloads"
@@ -168,8 +169,8 @@ fun PodcastNavHost() {
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
-    val bottomNavRoutes = setOf(Routes.Search, Routes.Queue, Routes.Downloads)
-    val bottomNavTabs = listOf(VibeTab.Search, VibeTab.Queue, VibeTab.Downloads)
+    val bottomNavRoutes = setOf(Routes.Home, Routes.Search, Routes.Queue, Routes.Downloads)
+    val bottomNavTabs = listOf(VibeTab.Home, VibeTab.Search, VibeTab.Queue, VibeTab.Downloads)
 
     Scaffold(
         bottomBar = {
@@ -178,7 +179,7 @@ fun PodcastNavHost() {
                     active = currentRoute ?: "",
                     onNavigate = { tab ->
                         navController.navigate(tab.id) {
-                            popUpTo(Routes.Search) { inclusive = false }
+                            popUpTo(Routes.Home) { inclusive = false }
                             launchSingleTop = true
                         }
                     },
@@ -189,9 +190,38 @@ fun PodcastNavHost() {
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = Routes.Search,
+            startDestination = Routes.Home,
             modifier = Modifier.padding(innerPadding)
         ) {
+            composable(Routes.Home) {
+                val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
+                val continueListening by podcastViewModel.continueListening.collectAsState()
+                val currentEpisode by playerViewModel.currentEpisode.collectAsState()
+                val playerState by playerViewModel.playerState.collectAsState()
+                val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
+
+                HomeScreen(
+                    subscriptions = savedPodcasts,
+                    continueListening = continueListening,
+                    currentEpisode = currentEpisode,
+                    currentArtworkUrl = currentArtworkUrl,
+                    playerState = playerState,
+                    onOpenPodcast = { podcast ->
+                        podcastViewModel.selectPodcast(podcast)
+                        navController.navigate(Routes.episodes(podcast.id))
+                    },
+                    onOpenSearch = { navController.navigate(Routes.Search) },
+                    onPlayEpisode = { episode, artwork ->
+                        playerViewModel.playEpisode(episode, artwork)
+                        navController.navigate(Routes.Player)
+                    },
+                    onPlayPause = { playerViewModel.togglePlayPause() },
+                    onOpenPlayer = { navController.navigate(Routes.Player) },
+                    onSeek = { playerViewModel.seekTo(it) },
+                    onDismissPlayer = { playerViewModel.clearPlayer() },
+                )
+            }
+
             composable(Routes.Search) {
             val scope = androidx.compose.runtime.rememberCoroutineScope()
             val selectedQueuePodcasts by podcastViewModel.selectedQueuePodcasts.collectAsState()
@@ -253,7 +283,7 @@ fun PodcastNavHost() {
                 playerViewModel = playerViewModel,
                 onBack = {
                     // Match previous behavior: Episodes back always returns to Search.
-                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                    navController.popBackStack(route = Routes.Home, inclusive = false)
                 },
                 onPlayEpisode = { navController.navigate(Routes.Player) },
                 onOpenPlayer = { navController.navigate(Routes.Player) }
@@ -306,7 +336,7 @@ fun PodcastNavHost() {
                 onDismissPlayer = { playerViewModel.clearPlayer() },
                 onBack = {
                     // Match previous behavior: Queue back always returns to Search.
-                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                    navController.popBackStack(route = Routes.Home, inclusive = false)
                 }
             )
         }
@@ -326,7 +356,7 @@ fun PodcastNavHost() {
                 onDeleteAll = {
                     scope.launch { podcastViewModel.deleteAllDownloads() }
                 },
-                onBack = { navController.popBackStack(route = Routes.Search, inclusive = false) }
+                onBack = { navController.popBackStack(route = Routes.Home, inclusive = false) }
             )
         }
 
@@ -342,11 +372,11 @@ fun PodcastNavHost() {
             fun goToEpisodesOrSearch() {
                 val podcastId = selectedPodcast?.id
                 if (podcastId == null) {
-                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                    navController.popBackStack(route = Routes.Home, inclusive = false)
                 } else {
                     navController.navigate(Routes.episodes(podcastId)) {
-                        // Match previous behavior: Player back always returns to Episodes (and then to Search).
-                        popUpTo(Routes.Search) { inclusive = false }
+                        // Match previous behavior: Player back always returns to Episodes (and then to Home).
+                        popUpTo(Routes.Home) { inclusive = false }
                         launchSingleTop = true
                     }
                 }
@@ -377,7 +407,7 @@ fun PodcastNavHost() {
 
             if (currentEpisode == null) {
                 androidx.compose.runtime.LaunchedEffect(Unit) {
-                    navController.popBackStack(route = Routes.Search, inclusive = false)
+                    navController.popBackStack(route = Routes.Home, inclusive = false)
                 }
             }
         }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -90,6 +90,31 @@ class PodcastViewModel(
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /**
+     * In-progress episodes for the Home "Continue listening" shelf. We only have episode
+     * metadata for downloaded episodes (RSS feeds aren't persisted), so this is the
+     * intersection of downloads and in-progress progress entries, most-recent first.
+     */
+    val continueListening: StateFlow<List<ContinueListeningUi>> = combine(
+        downloadedEpisodesUi,
+        playbackProgressDao.observeInProgress()
+    ) { downloads, progress ->
+        val downloadsById = downloads.associateBy { it.episode.id }
+        progress.mapNotNull { entry ->
+            val ui = downloadsById[entry.episodeId] ?: return@mapNotNull null
+            val fraction = if (entry.durationMs > 0L) {
+                (entry.positionMs.toFloat() / entry.durationMs.toFloat()).coerceIn(0f, 1f)
+            } else 0f
+            ContinueListeningUi(
+                episode = ui.episode,
+                podcastTitle = ui.podcastTitle,
+                podcastArtworkUrl = ui.podcastArtworkUrl,
+                progressFraction = fraction,
+                remainingMs = (entry.durationMs - entry.positionMs).coerceAtLeast(0L)
+            )
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     private val _playbackProgress = MutableStateFlow<Map<String, PlaybackProgressEntity>>(emptyMap())
     val playbackProgress: StateFlow<Map<String, PlaybackProgressEntity>> = _playbackProgress.asStateFlow()
 
@@ -357,6 +382,14 @@ data class DownloadedEpisodeUi(
     val episode: Episode,
     val podcastTitle: String?,
     val podcastArtworkUrl: String?
+)
+
+data class ContinueListeningUi(
+    val episode: Episode,
+    val podcastTitle: String?,
+    val podcastArtworkUrl: String?,
+    val progressFraction: Float,
+    val remainingMs: Long,
 )
 
 sealed class PodcastUiState {


### PR DESCRIPTION
> [!NOTE]
> 🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

Implements the Home screen from the Vibe Podcast design prototype and wires it as the new start destination.

## Changes

- New `HomeScreen` composable: date eyebrow, time-of-day greeting, Continue Listening horizontal shelf, 3-column subscriptions grid, mini player overlay, empty-state CTA.
- New `PlaybackProgressDao.observeInProgress()` query for in-progress episodes across all podcasts.
- New `PodcastViewModel.continueListening` StateFlow joining in-progress progress rows with downloaded-episode metadata.
- Added `Home` to `Routes` and `VibeTab`; Home is now the `NavHost` start destination and `popBackStack` targets (previously `Search`) now pop to `Home`.

## Test plan

- [x] Open app — Home is shown first with greeting matching current time.
- [ ] If downloaded + partially played episodes exist, they appear in Continue Listening with progress bar and "X left".
- [ ] Tapping a Continue Listening card plays the episode and opens the player.
- [ ] Subscriptions grid renders 3-column; tap opens Episodes.
- [ ] With no subscriptions, empty state shows with "Browse podcasts" → Search.
- [ ] Bottom nav shows Home/Search/Queue/Downloads; tab switching keeps back behavior consistent.