### PR TITLE
chore: add issue templates (bug, feature)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Something is broken in BunPod
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in as much as you can — the more detail, the faster it gets fixed.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps that reliably trigger the bug.
+      placeholder: |
+        1. Open the app
+        2. Tap ...
+        3. ...
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device (make/model)
+      placeholder: e.g. Pixel 7
+    validations:
+      required: true
+
+  - type: input
+    id: android_version
+    attributes:
+      label: Android version / API level
+      placeholder: e.g. Android 14 (API 34)
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version or commit SHA
+      placeholder: e.g. 1.0.0 or ffd5e60
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logcat / stack trace
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or screen recording
+      description: Drag and drop images or video here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a feature or enhancement for BunPod
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What pain is this solving? Who is it for?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? UX, behavior, edge cases.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What does "done" look like?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and rejected.


### PR DESCRIPTION
> [!NOTE]
> 🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

Adds GitHub Issue Forms for bug reports and feature requests, and disables blank issues so every new report is actionable.

## Changes

- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug form, auto-labels `bug`.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured feature form, auto-labels `enhancement`.

No workflows or secrets added. The issue-to-implementation loop stays manual: maintainer picks an issue and drives Claude Code locally (e.g. "work on issue 12"), so no Claude subscription OAuth token is exposed to a public repo.

## Test plan

- [ ] On GitHub, click **New issue** — confirm only Bug / Feature appear, no "Open a blank issue" link.
- [ ] Start a Bug report — required fields (summary, steps, expected, actual, device, Android version) block submission until filled.
- [ ] File a dummy bug — confirm `bug` label is auto-applied.
- [ ] File a dummy feature — confirm `enhancement` label is auto-applied.
- [ ] End-to-end: tell Claude locally "work on issue #N"; verify the PR body references `Closes #N` and merging closes the issue.