### PR TITLE
fix: Add-to-queue checkbox toggle (#24)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Something is broken in BunPod
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in as much as you can — the more detail, the faster it gets fixed.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps that reliably trigger the bug.
+      placeholder: |
+        1. Open the app
+        2. Tap ...
+        3. ...
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device (make/model)
+      placeholder: e.g. Pixel 7
+    validations:
+      required: true
+
+  - type: input
+    id: android_version
+    attributes:
+      label: Android version / API level
+      placeholder: e.g. Android 14 (API 34)
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version or commit SHA
+      placeholder: e.g. 1.0.0 or ffd5e60
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logcat / stack trace
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or screen recording
+      description: Drag and drop images or video here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a feature or enhancement for BunPod
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What pain is this solving? Who is it for?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? UX, behavior, edge cases.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What does "done" look like?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and rejected.

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -568,7 +568,7 @@ private fun QueuePickerDialog(
     onConfirm: (Set<String>) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var selectedIds by remember(podcast) { mutableStateOf(initialSelectedIds.toMutableSet()) }
+    var selectedIds by remember(podcast) { mutableStateOf(initialSelectedIds) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -580,15 +580,21 @@ private fun QueuePickerDialog(
             } else {
                 Column {
                     queues.forEach { queue ->
+                        val checked = queue.id in selectedIds
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    selectedIds = if (checked) selectedIds - queue.id
+                                    else selectedIds + queue.id
+                                },
                         ) {
                             Checkbox(
-                                checked = selectedIds.contains(queue.id),
-                                onCheckedChange = { checked ->
-                                    if (checked) selectedIds.add(queue.id)
-                                    else selectedIds.remove(queue.id)
+                                checked = checked,
+                                onCheckedChange = { isChecked ->
+                                    selectedIds = if (isChecked) selectedIds + queue.id
+                                    else selectedIds - queue.id
                                 },
                             )
                             Text(queue.name)


### PR DESCRIPTION
> [!NOTE]
> 🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #24

## Summary

The Add-to-queue dialog checkbox didn't visibly toggle when tapped, even though membership was saved correctly on Save.

Root cause: `QueuePickerDialog` held a `MutableSet<String>` inside `mutableStateOf`. `onCheckedChange` called `.add`/`.remove` which mutated the same set instance — the `State`'s value reference never changed, so Compose's snapshot system didn't detect a change and the checkbox never recomposed.

## Changes

- `PodcastListScreen.kt`: change state from `MutableSet` → immutable `Set<String>`, reassigned via `+` / `-` so snapshot observation fires.
- Make the entire row clickable (not just the checkbox) for easier tapping.

## Test plan

- [ ] Open the app → Search → open a podcast → tap "Add to queue".
- [ ] Tap a queue's checkbox → checkbox visibly toggles checked/unchecked.
- [ ] Tap anywhere on the row (outside the checkbox) → also toggles.
- [ ] Save → membership matches what was shown.
- [ ] Reopen the dialog → state reflects the saved membership.