### PR TITLE
Use higher resolution artwork URL for podcast thumbnails

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
@@ -46,7 +46,7 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
             id = collectionId.toString(),
             title = collectionName,
             artist = artistName,
-            artworkUrl = artworkUrl100,
+            artworkUrl = artworkUrl600 ?: artworkUrl100,
             feedUrl = feedUrl
         )
     }

--- a/app/src/main/java/com/podcastplayer/app/domain/model/PodcastSearchResponse.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/PodcastSearchResponse.kt
@@ -9,6 +9,7 @@ data class PodcastDto(
     val collectionId: Long,
     val collectionName: String,
     val artistName: String,
+    val artworkUrl600: String?,
     val artworkUrl100: String?,
     val feedUrl: String?
 )


### PR DESCRIPTION
## Summary
Updated the podcast repository to use higher resolution artwork images (600x600) from the iTunes API when available, falling back to the lower resolution (100x100) if the higher resolution is not provided.

## Key Changes
- Added `artworkUrl600` field to `PodcastDto` to capture the higher resolution artwork URL from the iTunes API response
- Modified `PodcastRepository.mapToPodcast()` to prioritize `artworkUrl600` over `artworkUrl100` with a fallback mechanism using the Elvis operator (`?:`)

## Implementation Details
The change improves the visual quality of podcast thumbnails by leveraging the higher resolution artwork available from iTunes API. The fallback to `artworkUrl100` ensures backward compatibility and graceful degradation if the 600x600 URL is not available in the API response.

https://claude.ai/code/session_0149rD4fNhR8Dx87y2Jk4CWP