### PR TITLE
fix(image): migrate cached 100x100 iTunes artwork URLs to 600x600

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
@@ -3,6 +3,7 @@ package com.podcastplayer.app.data.local
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.podcastplayer.app.data.remote.upgradeITunesArtwork
 import com.podcastplayer.app.domain.model.Podcast
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -51,18 +52,24 @@ class SavedPodcastsStorage(context: Context) {
     }
 
     private fun persist(list: List<Podcast>) {
-        prefs.edit().putString(KEY_PODCASTS, gson.toJson(list)).apply()
-        _savedPodcasts.value = list
+        val migrated = list.map { it.copy(artworkUrl = upgradeITunesArtwork(it.artworkUrl)) }
+        prefs.edit().putString(KEY_PODCASTS, gson.toJson(migrated)).apply()
+        _savedPodcasts.value = migrated
     }
 
     private fun load(): List<Podcast> {
         val json = prefs.getString(KEY_PODCASTS, null) ?: return emptyList()
-        return try {
+        val parsed = try {
             val type = object : TypeToken<List<Podcast>>() {}.type
-            gson.fromJson(json, type) ?: emptyList()
+            gson.fromJson<List<Podcast>>(json, type) ?: emptyList()
         } catch (_: Exception) {
-            emptyList()
+            return emptyList()
         }
+        val migrated = parsed.map { it.copy(artworkUrl = upgradeITunesArtwork(it.artworkUrl)) }
+        if (migrated != parsed) {
+            prefs.edit().putString(KEY_PODCASTS, gson.toJson(migrated)).apply()
+        }
+        return migrated
     }
 
     companion object {

--- a/app/src/main/java/com/podcastplayer/app/data/remote/ArtworkUrl.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/remote/ArtworkUrl.kt
@@ -1,0 +1,4 @@
+package com.podcastplayer.app.data.remote
+
+internal fun upgradeITunesArtwork(url: String?): String? =
+    url?.replace("/100x100bb.", "/600x600bb.")

--- a/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
@@ -2,6 +2,7 @@ package com.podcastplayer.app.data.repository
 
 import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
+import com.podcastplayer.app.data.remote.upgradeITunesArtwork
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.domain.model.PodcastDto
@@ -46,7 +47,7 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
             id = collectionId.toString(),
             title = collectionName,
             artist = artistName,
-            artworkUrl = artworkUrl600 ?: artworkUrl100,
+            artworkUrl = upgradeITunesArtwork(artworkUrl600 ?: artworkUrl100),
             feedUrl = feedUrl
         )
     }

--- a/app/src/main/java/com/podcastplayer/app/service/PlaybackSessionStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlaybackSessionStorage.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.core.content.edit
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import com.podcastplayer.app.data.remote.upgradeITunesArtwork
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -69,7 +70,10 @@ class PlaybackSessionStorage(context: Context) {
                     .setTitle(itemJson.optString("title").ifBlank { null })
                     .setArtist(itemJson.optString("artist").ifBlank { null })
                     .setDescription(itemJson.optString("description").ifBlank { null })
-                    .setArtworkUri(itemJson.optString("artworkUri").ifBlank { null }?.let(android.net.Uri::parse))
+                    .setArtworkUri(
+                        upgradeITunesArtwork(itemJson.optString("artworkUri").ifBlank { null })
+                            ?.let(android.net.Uri::parse)
+                    )
                     .build()
 
                 items += MediaItem.Builder()


### PR DESCRIPTION
PR #34 only updated the iTunes API → domain mapping, so it has no effect for users who subscribed before that fix landed. Their `artworkUrl` is still cached as `…/100x100bb.jpg` in SharedPreferences and renders blurry on the 300dp PlayerScreen hero, the 180dp EpisodeListScreen header, and the HomeScreen tiles.

Add a small `upgradeITunesArtwork()` utility that rewrites the deterministic iTunes resolution suffix and apply it at every cache boundary so existing data heals on first launch:

- SavedPodcastsStorage.load(): migrate parsed URLs and rewrite the prefs JSON if anything changed; persist() upgrades on every write so OPML re-imports cannot reintroduce 100x100 URLs.
- PlaybackSessionStorage.load(): upgrade the stored MediaMetadata.artworkUri so the resumed session shows sharp artwork in the MiniPlayer / PlayerScreen from the first frame.
- PodcastRepository.toDomain(): defensive upgrade so future iTunes responses without artworkUrl600 are not stuck at 100px.

https://claude.ai/code/session_0149rD4fNhR8Dx87y2Jk4CWP