### PR TITLE
feat: add YouTube/X URL downloads with offline playback (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,11 +109,13 @@ Both ViewModels are scoped at the `PodcastNavHost` top level so state survives n
 
 Routes:
 ```
+"home"                   → HomeScreen
 "search"                 → PodcastListScreen
 "episodes/{podcastId}"   → EpisodeListScreen
 "queue"                  → QueueScreen
 "downloads"              → DownloadsScreen
 "player"                 → PlayerScreen
+"add-url?url={url}"      → AddFromUrlScreen   (issue #33)
 ```
 
 All "back" presses pop to `"search"` (inclusive = false) rather than following the system back stack.
@@ -153,9 +155,46 @@ Exposed `StateFlow` values:
 
 **`data/local/QueueStorage.kt`** — SharedPreferences `podcast_queues` pref. Manages named queues of podcast IDs. Creates a default `"Morning"` queue on first run.
 
-**`data/local/PodcastDatabase.kt`** — Room database (v2). Tables:
-- `downloaded_episodes` — downloaded episode metadata
+**`data/local/PodcastDatabase.kt`** — Room database (v3). Tables:
+- `downloaded_episodes` — RSS-podcast download metadata
 - `playback_progress` — per-episode listen position and completion status
+- `url_downloads` — URL-downloaded media (issue #33), separate from RSS downloads
+
+### Add-from-URL feature (issue #33)
+**`PodcastApplication.kt`** — Application class that initializes `YoutubeDL` + `FFmpeg`
+on a background coroutine and attempts a yt-dlp binary refresh. `youtubeDlReady`
+is the gate the repository checks before invoking yt-dlp.
+
+**`data/repository/UrlDownloadRepository.kt`** — Owns metadata extraction
+(`yt-dlp --dump-json`), the `url_downloads` Room rows, and the on-disk download
+dir (`filesDir/url_downloads/`). Builds `YoutubeDLRequest` for audio (MP3 via
+ffmpeg) vs video (mp4 merge). Maps completed entities to `Episode` for the
+existing player pipeline.
+
+**`data/repository/UrlSource.kt`** — `UrlSource` enum (YouTube / X / Other) with
+host-based `classify(url)`, `UrlDownloadStatus` enum, and `UrlValidator` (regex
+URL extraction, canonicalization with tracking-param stripping, stable IDs).
+
+**`service/UrlDownloadService.kt`** — Foreground service (type: `dataSync`) that
+drains the URL download queue serially. Concurrency capped at 1; cancel via
+`destroyProcessById`.
+
+**`presentation/viewmodel/UrlDownloadViewModel.kt`** — `AndroidViewModel` exposing
+`previewState`, `selectedMediaType`, `completedDownloads`, `inFlightDownloads`.
+`confirmCurrentDownload()` enqueues + kicks the service.
+
+**`presentation/ui/AddFromUrlScreen.kt`** — Single converged entry point: paste,
+share intent, and dedicated button all land here. Shows metadata preview +
+audio/video toggle + confirm.
+
+**`presentation/ui/VideoSurface.kt`** — Composable wrapper around Media3
+`PlayerView`, bound to the same `MediaController` that drives audio playback.
+Used inside `PlayerScreen` when `episode.mediaType == MediaType.VIDEO`.
+
+Manifest hooks:
+- `MainActivity` is `singleTask` and registers `ACTION_SEND` text/plain so
+  share-to-app works from YouTube/X/etc.
+- `UrlDownloadService` is declared with `foregroundServiceType="dataSync"`.
 
 ### Service Layer
 **`service/PlayerService.kt`** — `MediaSessionService` wrapping ExoPlayer. Handles:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ A simple podcast player app built with Kotlin and Jetpack Compose.
 - **Offline Playback**: Download episodes for offline listening
 - **Background Play**: Foreground service with media session for background playback
 - **Player Controls**: Play/pause, seek, playback speed control
+- **Add from URL**: Paste / share / type a YouTube or X (Twitter) URL and save the
+  audio (MP3) or video (MP4) for fully offline playback. Powered by yt-dlp via
+  [`youtubedl-android`](https://github.com/yausername/youtubedl-android).
 
 ## Architecture
 
@@ -99,6 +102,35 @@ This project expects **JDK 17**. If your system `java` is newer and Gradle fails
 
 - `PlayerService.kt`: Media session service for background playback
 - `PlayerController.kt`: Interface to control the player service
+- `UrlDownloadService.kt`: Foreground service that drives yt-dlp downloads for
+  the "Add from URL" feature, surfacing progress in the notification shade
+
+### Add-from-URL feature (issue #33)
+
+The "Add from URL" flow lets the user feed an external video/audio link from
+YouTube or X into the same offline-first playback pipeline as podcast episodes.
+
+Three converged entry points all open the same screen:
+
+1. **Share intent** — share-to-app from YouTube / X (or any app that emits a
+   text/plain URL).
+2. **Paste in search** — pasting a recognized link into the Search screen
+   surfaces a "Save offline" affordance above the results.
+3. **Dedicated button** — "Add from URL" chip on the Home screen.
+
+Pipeline:
+
+- `UrlDownloadRepository` extracts metadata via `yt-dlp --dump-json`.
+- The user picks audio (MP3, extracted via ffmpeg) or video (MP4, h264+aac merged).
+- A row is inserted into Room (`url_downloads` table) and `UrlDownloadService`
+  drains the queue serially, posting progress updates back through the repo.
+- Completed items appear in a "Saved from URL" section on the home screen and
+  play through the existing Media3 player. Video items render via a `PlayerView`
+  surface in the player screen; audio items reuse the artwork view.
+
+> ⚠️ **Personal/internal use.** YouTube and X Terms of Service generally prohibit
+> unauthorized downloading. Distribution through the Play Store is **not**
+> recommended for builds with this feature enabled.
 
 ## API Endpoints
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,20 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // youtubedl-android requires native libs that are extracted at runtime.
+        ndk {
+            // Match the ABIs published by youtubedl-android.
+            abiFilters += setOf("arm64-v8a", "armeabi-v7a", "x86", "x86_64")
+        }
+    }
+
+    // youtubedl-android's bundled Python runtime & yt-dlp script need to be
+    // extracted from the APK on first launch — they are not loaded as JNI libs.
+    packaging {
+        jniLibs {
+            useLegacyPackaging = true
+        }
     }
 
     buildTypes {
@@ -77,6 +91,15 @@ dependencies {
     kapt("androidx.room:room-compiler:2.6.1")
 
     implementation("io.coil-kt:coil-compose:2.5.0")
+
+    // youtubedl-android — yt-dlp wrapper for on-device YouTube/X/etc. extraction.
+    // Used by the "Add from URL" feature (issue #33).
+    // NOTE: pulls in a bundled Python runtime + scripts; expect ~50MB APK growth.
+    implementation("io.github.junkfood02.youtubedl-android:library:0.18.1")
+    implementation("io.github.junkfood02.youtubedl-android:ffmpeg:0.18.1")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.PodcastPlayer">
+            android:theme="@style/Theme.PodcastPlayer"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|navigation|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,18 +2,24 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <!-- For URL downloads (issue #33). dataSync is the appropriate type for downloads. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
+        android:name=".PodcastApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.PodcastPlayer"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:extractNativeLibs="true">
 
         <service
             android:name=".service.PlayerService"
@@ -23,14 +29,43 @@
                 <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>
         </service>
+
+        <!-- Foreground service that runs YouTube/X downloads with a progress notification (issue #33). -->
+        <service
+            android:name=".service.UrlDownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.PodcastPlayer">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Receive shared text/URLs from YouTube, X, and other apps (issue #33). -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
+            <!-- Optional: handle direct VIEW of YouTube / X URLs.
+                 Disabled by default so we don't fight the official apps; users will
+                 typically paste or share. Re-enable by un-commenting if desired.
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="www.youtube.com" />
+                <data android:scheme="https" android:host="youtu.be" />
+                <data android:scheme="https" android:host="x.com" />
+                <data android:scheme="https" android:host="twitter.com" />
+            </intent-filter>
+            -->
         </activity>
     </application>
 

--- a/app/src/main/java/com/podcastplayer/app/MainActivity.kt
+++ b/app/src/main/java/com/podcastplayer/app/MainActivity.kt
@@ -1,27 +1,69 @@
 package com.podcastplayer.app
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.podcastplayer.app.data.repository.UrlValidator
 import com.podcastplayer.app.presentation.ui.PodcastNavHost
 import com.podcastplayer.app.ui.theme.PodcastPlayerTheme
 
 class MainActivity : ComponentActivity() {
+
+    /**
+     * URL handed in via [Intent.ACTION_SEND] (a "Share to" from YouTube / X / etc.)
+     * or [Intent.ACTION_VIEW]. Surfaced into [PodcastNavHost] so it can route to
+     * the AddFromUrl screen.
+     *
+     * Backed by a Compose [androidx.compose.runtime.MutableState] so re-launches
+     * (singleTask) propagate to the UI.
+     */
+    private var pendingShareUrl by mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        pendingShareUrl = extractSharedUrl(intent)
         setContent {
             PodcastPlayerTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    PodcastNavHost()
+                    PodcastNavHost(
+                        sharedUrl = pendingShareUrl,
+                        onSharedUrlConsumed = { pendingShareUrl = null },
+                    )
                 }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        // singleTask: a share while the app is open re-enters here.
+        val incoming = extractSharedUrl(intent)
+        if (incoming != null) pendingShareUrl = incoming
+    }
+
+    /**
+     * Pull the first URL out of an inbound share intent. Returns null if the intent
+     * doesn't carry one (e.g. plain text without an http(s) link).
+     */
+    private fun extractSharedUrl(intent: Intent?): String? {
+        intent ?: return null
+        val text: CharSequence? = when (intent.action) {
+            Intent.ACTION_SEND -> intent.getCharSequenceExtra(Intent.EXTRA_TEXT)
+            Intent.ACTION_VIEW -> intent.dataString
+            else -> null
+        }
+        return UrlValidator.extractFirstUrl(text)
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/PodcastApplication.kt
+++ b/app/src/main/java/com/podcastplayer/app/PodcastApplication.kt
@@ -1,0 +1,86 @@
+package com.podcastplayer.app
+
+import android.app.Application
+import android.util.Log
+import com.yausername.ffmpeg.FFmpeg
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Application entry point.
+ *
+ * Responsible for:
+ * - Initializing the bundled yt-dlp runtime (youtubedl-android) and ffmpeg on first launch.
+ *   Both calls are idempotent — they no-op when already initialized.
+ * - Optionally updating the yt-dlp Python script in the background so extraction keeps working
+ *   even when YouTube/X change their internal APIs (yt-dlp updates frequently).
+ *
+ * The init runs on a background dispatcher; consumers (e.g. [com.podcastplayer.app.data.repository.UrlDownloadRepository])
+ * await [youtubeDlReady] before invoking yt-dlp.
+ */
+class PodcastApplication : Application() {
+
+    /** Best-effort background scope for one-shot init / update tasks. */
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+
+        appScope.launch {
+            initYoutubeDl()
+            // Fire-and-forget update; safe to skip if it fails.
+            tryUpdateYoutubeDl()
+        }
+    }
+
+    private fun initYoutubeDl() {
+        try {
+            YoutubeDL.getInstance().init(this)
+            FFmpeg.getInstance().init(this)
+            youtubeDlReady = true
+            Log.i(TAG, "YoutubeDL + FFmpeg initialized")
+        } catch (e: YoutubeDLException) {
+            Log.e(TAG, "Failed to initialize YoutubeDL", e)
+        } catch (e: Throwable) {
+            Log.e(TAG, "Unexpected error initializing YoutubeDL", e)
+        }
+    }
+
+    private fun tryUpdateYoutubeDl() {
+        if (!youtubeDlReady) return
+        try {
+            // Updates the bundled yt-dlp Python script in-place from upstream.
+            // Throws on network failure — which is fine; we just keep using the bundled version.
+            YoutubeDL.getInstance().updateYoutubeDL(this, YoutubeDL.UpdateChannel.STABLE)
+            Log.i(TAG, "yt-dlp updated")
+        } catch (e: Throwable) {
+            Log.w(TAG, "yt-dlp update skipped: ${e.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "PodcastApplication"
+
+        /**
+         * True once [YoutubeDL.init] has succeeded.
+         *
+         * Repository code should bail out gracefully (with a user-visible error) if this is still
+         * false when a download is requested — typically only happens on first launch with no
+         * network connection, since init unpacks the bundled Python runtime locally.
+         */
+        @Volatile
+        var youtubeDlReady: Boolean = false
+            private set
+
+        @Volatile
+        private var instance: PodcastApplication? = null
+
+        fun get(): PodcastApplication =
+            requireNotNull(instance) { "PodcastApplication not initialized" }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/DatabaseProvider.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DatabaseProvider.kt
@@ -16,7 +16,10 @@ object DatabaseProvider {
                 PodcastDatabase::class.java,
                 DATABASE_NAME
             )
-                .addMigrations(PodcastDatabase.MIGRATION_1_2)
+                .addMigrations(
+                    PodcastDatabase.MIGRATION_1_2,
+                    PodcastDatabase.MIGRATION_2_3,
+                )
                 .build()
                 .also { instance = it }
         }

--- a/app/src/main/java/com/podcastplayer/app/data/local/PodcastDatabase.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/PodcastDatabase.kt
@@ -12,6 +12,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         UrlDownloadEntity::class,
     ],
     version = 3,
+    // We don't use Room migrations testing yet, and `room.schemaLocation` isn't
+    // wired up; turn off schema export to silence the kapt warning.
+    exportSchema = false,
 )
 abstract class PodcastDatabase : RoomDatabase() {
     abstract fun downloadedEpisodeDao(): DownloadedEpisodeDao

--- a/app/src/main/java/com/podcastplayer/app/data/local/PodcastDatabase.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/PodcastDatabase.kt
@@ -6,12 +6,17 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [DownloadedEpisodeEntity::class, PlaybackProgressEntity::class],
-    version = 2
+    entities = [
+        DownloadedEpisodeEntity::class,
+        PlaybackProgressEntity::class,
+        UrlDownloadEntity::class,
+    ],
+    version = 3,
 )
 abstract class PodcastDatabase : RoomDatabase() {
     abstract fun downloadedEpisodeDao(): DownloadedEpisodeDao
     abstract fun playbackProgressDao(): PlaybackProgressDao
+    abstract fun urlDownloadDao(): UrlDownloadDao
 
     companion object {
         val MIGRATION_1_2: Migration = object : Migration(1, 2) {
@@ -27,6 +32,37 @@ abstract class PodcastDatabase : RoomDatabase() {
                         lastPlayedAtMs INTEGER NOT NULL,
                         updatedAtMs INTEGER NOT NULL,
                         PRIMARY KEY(episodeId)
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
+
+        /**
+         * Adds the [url_downloads] table (issue #33) for media items downloaded
+         * from pasted/shared URLs (YouTube, X, etc.).
+         */
+        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS url_downloads (
+                        id TEXT NOT NULL,
+                        sourceUrl TEXT NOT NULL,
+                        source TEXT NOT NULL,
+                        title TEXT NOT NULL,
+                        uploader TEXT,
+                        thumbnailUrl TEXT,
+                        mediaType TEXT NOT NULL,
+                        localPath TEXT,
+                        durationMs INTEGER,
+                        fileSize INTEGER,
+                        status TEXT NOT NULL,
+                        progressPercent REAL NOT NULL,
+                        errorMessage TEXT,
+                        createdAtMs INTEGER NOT NULL,
+                        completedAtMs INTEGER,
+                        PRIMARY KEY(id)
                     )
                     """.trimIndent()
                 )

--- a/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadDao.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadDao.kt
@@ -1,0 +1,52 @@
+package com.podcastplayer.app.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UrlDownloadDao {
+
+    @Query("SELECT * FROM url_downloads ORDER BY createdAtMs DESC")
+    fun observeAll(): Flow<List<UrlDownloadEntity>>
+
+    @Query("SELECT * FROM url_downloads WHERE status = :status ORDER BY createdAtMs DESC")
+    fun observeByStatus(status: String): Flow<List<UrlDownloadEntity>>
+
+    @Query("SELECT * FROM url_downloads WHERE id = :id")
+    suspend fun getById(id: String): UrlDownloadEntity?
+
+    @Query("SELECT * FROM url_downloads WHERE id = :id")
+    fun observeById(id: String): Flow<UrlDownloadEntity?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: UrlDownloadEntity)
+
+    @Query("UPDATE url_downloads SET status = :status, progressPercent = :progress, errorMessage = :error WHERE id = :id")
+    suspend fun updateProgress(id: String, status: String, progress: Float, error: String?)
+
+    @Query(
+        """
+        UPDATE url_downloads
+        SET status = :status,
+            localPath = :localPath,
+            fileSize = :fileSize,
+            progressPercent = 100,
+            completedAtMs = :completedAtMs,
+            errorMessage = NULL
+        WHERE id = :id
+        """
+    )
+    suspend fun markCompleted(id: String, status: String, localPath: String, fileSize: Long, completedAtMs: Long)
+
+    @Query("UPDATE url_downloads SET status = :status, errorMessage = :error WHERE id = :id")
+    suspend fun markFailed(id: String, status: String, error: String?)
+
+    @Query("DELETE FROM url_downloads WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM url_downloads")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadEntity.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadEntity.kt
@@ -1,0 +1,47 @@
+package com.podcastplayer.app.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A media item that the user pasted/shared a URL for and asked the app to download
+ * (issue #33). Distinct from [DownloadedEpisodeEntity] (RSS-podcast-backed downloads)
+ * so that URL items can be queried, deleted, and surfaced separately on the home screen.
+ *
+ * Identity: [id] is a deterministic hash of `sourceUrl + mediaType` so that asking
+ * for the same URL twice as the same media type is treated as a duplicate, while
+ * the same URL as audio vs. video can coexist.
+ */
+@Entity(tableName = "url_downloads")
+data class UrlDownloadEntity(
+    @PrimaryKey
+    val id: String,
+    /** The original URL the user pasted/shared (post-normalization). */
+    val sourceUrl: String,
+    /** Coarse source bucket: `youtube`, `x`, or `other`. Used for badges and analytics. */
+    val source: String,
+    /** Title from yt-dlp metadata (or the URL if metadata extraction fails). */
+    val title: String,
+    /** Channel / poster, e.g. "Lex Fridman" or "@elonmusk". Nullable. */
+    val uploader: String?,
+    /** Remote thumbnail URL from the source (used for the home-screen card). */
+    val thumbnailUrl: String?,
+    /** "audio" or "video" — see [com.podcastplayer.app.domain.model.MediaType]. */
+    val mediaType: String,
+    /** Absolute path to the downloaded file once status == COMPLETED. */
+    val localPath: String?,
+    /** Duration in milliseconds (nullable when metadata is incomplete). */
+    val durationMs: Long?,
+    /** File size in bytes once downloaded; null while in flight. */
+    val fileSize: Long?,
+    /** One of [com.podcastplayer.app.data.repository.UrlDownloadStatus.name]. */
+    val status: String,
+    /** 0..100 (float). Reflects the most recent yt-dlp progress callback. */
+    val progressPercent: Float,
+    /** Last error message; null on success. */
+    val errorMessage: String?,
+    /** epoch millis */
+    val createdAtMs: Long,
+    /** epoch millis; null while pending/in-progress. */
+    val completedAtMs: Long?,
+)

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -1,0 +1,248 @@
+package com.podcastplayer.app.data.repository
+
+import android.content.Context
+import com.podcastplayer.app.PodcastApplication
+import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.UrlDownloadDao
+import com.podcastplayer.app.data.local.UrlDownloadEntity
+import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.MediaType
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLException
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import com.yausername.youtubedl_android.mapper.VideoInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.Date
+
+/**
+ * Repository for the "Add from URL" feature (issue #33).
+ *
+ * Owns:
+ * - the on-disk download directory
+ * - URL → metadata extraction via yt-dlp (`getInfo`)
+ * - persistence of [UrlDownloadEntity] rows
+ *
+ * The actual byte-level download is performed by [com.podcastplayer.app.service.UrlDownloadService]
+ * using the request returned by [buildDownloadRequest]. The repository is the single
+ * source of truth for state — the service mutates rows through these APIs.
+ */
+class UrlDownloadRepository(private val context: Context) {
+
+    private val dao: UrlDownloadDao
+        get() = DatabaseProvider.getDatabase(context).urlDownloadDao()
+
+    /** Where downloaded media lives. App-private to keep ToS exposure minimal. */
+    val downloadDir: File
+        get() = File(context.filesDir, "url_downloads").apply { mkdirs() }
+
+    fun observeAll(): Flow<List<UrlDownloadEntity>> = dao.observeAll()
+
+    /** Just the COMPLETED items, newest first — what the home screen surfaces. */
+    fun observeCompleted(): Flow<List<UrlDownloadEntity>> =
+        dao.observeByStatus(UrlDownloadStatus.COMPLETED.name)
+
+    /** Items currently in flight (queued / extracting / downloading). */
+    fun observeInFlight(): Flow<List<UrlDownloadEntity>> = dao.observeAll().map { all ->
+        all.filter {
+            it.status in IN_FLIGHT_STATUSES
+        }
+    }
+
+    suspend fun get(id: String): UrlDownloadEntity? = dao.getById(id)
+
+    fun observe(id: String): Flow<UrlDownloadEntity?> = dao.observeById(id)
+
+    /**
+     * Look up basic metadata (title, thumbnail, uploader, duration) for [rawUrl].
+     *
+     * Blocking yt-dlp call — must run off the main thread. Returns null if extraction
+     * fails (network issue, unsupported URL, age-gated content, etc.).
+     */
+    suspend fun fetchMetadata(rawUrl: String): UrlMetadata? = withContext(Dispatchers.IO) {
+        if (!PodcastApplication.youtubeDlReady) return@withContext null
+        try {
+            val request = YoutubeDLRequest(rawUrl).apply {
+                addOption("--no-playlist")
+                addOption("--socket-timeout", "30")
+            }
+            val info: VideoInfo = YoutubeDL.getInstance().getInfo(request)
+            UrlMetadata(
+                title = info.title.orEmpty().ifBlank { rawUrl },
+                uploader = info.uploader,
+                thumbnailUrl = info.thumbnail,
+                // VideoInfo.duration is seconds, defaults to 0 when absent (e.g. live streams).
+                durationMs = info.duration.takeIf { it > 0 }?.let { it.toLong() * 1000L },
+            )
+        } catch (e: YoutubeDLException) {
+            null
+        } catch (e: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * Inserts a [UrlDownloadEntity] in [UrlDownloadStatus.QUEUED] state.
+     *
+     * If an entity with the same `(url, mediaType)` already exists in a non-terminal
+     * state, this is a no-op and returns its existing id. If it exists in
+     * [UrlDownloadStatus.FAILED] or [UrlDownloadStatus.CANCELED], the row is reset
+     * and re-queued.
+     */
+    suspend fun enqueue(
+        rawUrl: String,
+        mediaType: MediaType,
+        prefetchedMetadata: UrlMetadata? = null,
+    ): String = withContext(Dispatchers.IO) {
+        val mediaTag = mediaType.tag
+        val id = UrlValidator.stableId(rawUrl, mediaTag)
+        val source = UrlSource.classify(rawUrl)
+
+        val existing = dao.getById(id)
+        if (existing != null && existing.status in IN_FLIGHT_STATUSES + UrlDownloadStatus.COMPLETED.name) {
+            return@withContext id
+        }
+
+        val metadata = prefetchedMetadata ?: fetchMetadata(rawUrl)
+        val entity = UrlDownloadEntity(
+            id = id,
+            sourceUrl = rawUrl,
+            source = source.tag,
+            title = metadata?.title ?: rawUrl,
+            uploader = metadata?.uploader,
+            thumbnailUrl = metadata?.thumbnailUrl,
+            mediaType = mediaTag,
+            localPath = null,
+            durationMs = metadata?.durationMs,
+            fileSize = null,
+            status = UrlDownloadStatus.QUEUED.name,
+            progressPercent = 0f,
+            errorMessage = null,
+            createdAtMs = System.currentTimeMillis(),
+            completedAtMs = null,
+        )
+        dao.upsert(entity)
+        id
+    }
+
+    suspend fun markExtracting(id: String) = updateProgress(id, UrlDownloadStatus.EXTRACTING_METADATA, 0f)
+    suspend fun markDownloading(id: String, progress: Float) =
+        updateProgress(id, UrlDownloadStatus.DOWNLOADING, progress)
+
+    private suspend fun updateProgress(id: String, status: UrlDownloadStatus, progress: Float) {
+        dao.updateProgress(id, status.name, progress, null)
+    }
+
+    suspend fun markFailed(id: String, message: String?) {
+        dao.markFailed(id, UrlDownloadStatus.FAILED.name, message)
+    }
+
+    suspend fun markCanceled(id: String) {
+        dao.markFailed(id, UrlDownloadStatus.CANCELED.name, null)
+    }
+
+    suspend fun markCompleted(id: String, file: File) {
+        dao.markCompleted(
+            id = id,
+            status = UrlDownloadStatus.COMPLETED.name,
+            localPath = file.absolutePath,
+            fileSize = if (file.exists()) file.length() else 0L,
+            completedAtMs = System.currentTimeMillis(),
+        )
+    }
+
+    /** Delete the row + the underlying file (if any). */
+    suspend fun delete(id: String): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            val entity = dao.getById(id)
+            entity?.localPath?.let { path ->
+                val file = File(path)
+                if (file.exists()) file.delete()
+            }
+            dao.deleteById(id)
+            Result.success(Unit)
+        } catch (e: Throwable) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Build the yt-dlp request for the actual byte download. Used by the
+     * download service so the request format is centralized here.
+     */
+    fun buildDownloadRequest(entity: UrlDownloadEntity, outputTemplate: File): YoutubeDLRequest {
+        val mediaType = MediaType.fromTag(entity.mediaType)
+        val request = YoutubeDLRequest(entity.sourceUrl)
+        request.addOption("--no-playlist")
+        request.addOption("--no-mtime")
+        request.addOption("--socket-timeout", "30")
+        request.addOption("-o", "${outputTemplate.absolutePath}/%(id)s.%(ext)s")
+
+        when (mediaType) {
+            MediaType.AUDIO -> {
+                // bestaudio + ffmpeg-mux to mp3 for portability and small size
+                request.addOption("-x")
+                request.addOption("--audio-format", "mp3")
+                request.addOption("--audio-quality", "0") // best
+                request.addOption("-f", "bestaudio/best")
+            }
+
+            MediaType.VIDEO -> {
+                // Single-file mp4 (h264 + aac) where available, falling back to best.
+                // Avoids requiring a remux step we'd have to script ourselves.
+                request.addOption(
+                    "-f",
+                    "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+                )
+                request.addOption("--merge-output-format", "mp4")
+            }
+        }
+        return request
+    }
+
+    /**
+     * Map a completed [UrlDownloadEntity] to an [Episode] so the existing player
+     * pipeline can play it. The synthetic `podcastId` ([SYNTHETIC_PODCAST_ID]) is
+     * used to keep these grouped on the home screen and out of real podcast lookups.
+     */
+    fun toEpisode(entity: UrlDownloadEntity): Episode? {
+        val path = entity.localPath ?: return null
+        return Episode(
+            id = "url:${entity.id}",
+            podcastId = SYNTHETIC_PODCAST_ID,
+            title = entity.title,
+            description = entity.uploader,
+            pubDate = entity.completedAtMs?.let { Date(it) },
+            audioUrl = entity.sourceUrl,
+            duration = entity.durationMs,
+            imageUrl = entity.thumbnailUrl,
+            isDownloaded = true,
+            localPath = path,
+            mediaType = MediaType.fromTag(entity.mediaType),
+        )
+    }
+
+    companion object {
+        const val SYNTHETIC_PODCAST_ID = "vibe-url-downloads"
+
+        private val IN_FLIGHT_STATUSES = setOf(
+            UrlDownloadStatus.QUEUED.name,
+            UrlDownloadStatus.EXTRACTING_METADATA.name,
+            UrlDownloadStatus.DOWNLOADING.name,
+        )
+    }
+}
+
+/**
+ * Lightweight container for the metadata fields the UI surfaces during the
+ * "preview before download" step.
+ */
+data class UrlMetadata(
+    val title: String,
+    val uploader: String?,
+    val thumbnailUrl: String?,
+    val durationMs: Long?,
+)

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlSource.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlSource.kt
@@ -1,0 +1,137 @@
+package com.podcastplayer.app.data.repository
+
+import java.net.URI
+import java.security.MessageDigest
+
+/**
+ * Coarse classification of a URL used for badging, telemetry, and deciding
+ * which yt-dlp options are appropriate.
+ */
+enum class UrlSource(val displayName: String, val tag: String) {
+    YOUTUBE("YouTube", "youtube"),
+    X("X", "x"),
+    OTHER("Web", "other");
+
+    companion object {
+        private val YOUTUBE_HOSTS = setOf(
+            "youtube.com",
+            "www.youtube.com",
+            "m.youtube.com",
+            "music.youtube.com",
+            "youtu.be",
+        )
+        private val X_HOSTS = setOf(
+            "x.com",
+            "www.x.com",
+            "twitter.com",
+            "www.twitter.com",
+            "mobile.twitter.com",
+        )
+
+        fun classify(rawUrl: String): UrlSource {
+            val host = parseHost(rawUrl)
+            return when {
+                host in YOUTUBE_HOSTS -> YOUTUBE
+                host in X_HOSTS -> X
+                else -> OTHER
+            }
+        }
+
+        /** JVM-safe host parser (used in unit tests; on Android `URI` is also available). */
+        internal fun parseHost(rawUrl: String): String {
+            return try {
+                URI(rawUrl.trim()).host?.lowercase().orEmpty()
+            } catch (e: Exception) {
+                ""
+            }
+        }
+
+        fun fromTag(tag: String): UrlSource = entries.firstOrNull { it.tag == tag } ?: OTHER
+    }
+}
+
+/**
+ * Possible states for a URL download.
+ *
+ * Stored as a `String` (the enum name) on [com.podcastplayer.app.data.local.UrlDownloadEntity.status]
+ * to keep the schema migration-friendly.
+ */
+enum class UrlDownloadStatus {
+    /** Newly enqueued; waiting for the download service to pick it up. */
+    QUEUED,
+
+    /** Service is running yt-dlp `--dump-json` to fetch title/thumbnail/etc. */
+    EXTRACTING_METADATA,
+
+    /** yt-dlp is downloading + (for audio) transcoding via ffmpeg. */
+    DOWNLOADING,
+
+    /** File written, DB row finalized. */
+    COMPLETED,
+
+    /** Terminal failure; user can retry by re-enqueuing. */
+    FAILED,
+
+    /** User canceled before completion. */
+    CANCELED,
+}
+
+/**
+ * Helpers for shape-checking and identifying URLs across the app.
+ */
+object UrlValidator {
+
+    private val URL_REGEX = Regex(
+        """https?://[\w\-._~:/?#\[\]@!\$&'()*+,;=%]+""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** Returns the first http(s) URL found in [text], or null if none. */
+    fun extractFirstUrl(text: CharSequence?): String? {
+        if (text.isNullOrBlank()) return null
+        return URL_REGEX.find(text.toString())?.value
+    }
+
+    /** True when [text] looks like a single, supported (YouTube/X) URL. */
+    fun isSupportedUrl(text: CharSequence?): Boolean {
+        val url = extractFirstUrl(text) ?: return false
+        return UrlSource.classify(url) != UrlSource.OTHER
+    }
+
+    /** Stable ID for a URL + media type pair (used as the Room primary key). */
+    fun stableId(url: String, mediaTypeTag: String): String {
+        val canonical = canonicalize(url) + "|" + mediaTypeTag
+        val md = MessageDigest.getInstance("SHA-1")
+            .digest(canonical.toByteArray())
+        return md.joinToString("") { "%02x".format(it) }
+    }
+
+    /** Strip tracking params and normalize for ID stability. */
+    fun canonicalize(url: String): String {
+        return try {
+            val u = URI(url.trim())
+            val host = u.host?.lowercase()?.removePrefix("www.").orEmpty()
+            val path = u.path.orEmpty()
+            val query = u.rawQuery.orEmpty()
+
+            // Keep only meaningful query params; drop fbclid/utm_*/etc.
+            val keptKeys = setOf("v", "list", "t", "start")
+            val kept = if (query.isBlank()) {
+                ""
+            } else {
+                query.split("&")
+                    .mapNotNull { piece ->
+                        val eq = piece.indexOf('=')
+                        val key = if (eq < 0) piece else piece.substring(0, eq)
+                        if (key in keptKeys) piece else null
+                    }
+                    .sorted()
+                    .joinToString("&")
+            }
+            val q = if (kept.isNotEmpty()) "?$kept" else ""
+            "${u.scheme}://$host$path$q"
+        } catch (e: Exception) {
+            url.trim()
+        }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/domain/model/Episode.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/Episode.kt
@@ -12,5 +12,11 @@ data class Episode(
     val duration: Long?,
     val imageUrl: String? = null,
     val isDownloaded: Boolean = false,
-    val localPath: String? = null
+    val localPath: String? = null,
+    /**
+     * The kind of media. Defaults to [MediaType.AUDIO] so existing podcast flows are
+     * unaffected. URL-downloaded videos (issue #33) set this to [MediaType.VIDEO]; the
+     * player UI uses it to decide whether to render a video surface.
+     */
+    val mediaType: MediaType = MediaType.AUDIO,
 )

--- a/app/src/main/java/com/podcastplayer/app/domain/model/MediaType.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/MediaType.kt
@@ -1,0 +1,21 @@
+package com.podcastplayer.app.domain.model
+
+/**
+ * The kind of media a piece of content represents.
+ *
+ * Existing podcast episodes default to [AUDIO]. URL-downloaded items (issue #33)
+ * may be [AUDIO] (extracted MP3) or [VIDEO] (MP4 with both video and audio tracks).
+ */
+enum class MediaType {
+    AUDIO,
+    VIDEO;
+
+    /** Lower-case enum name; the form persisted in the DB and surfaced as a `tag`. */
+    val tag: String get() = name.lowercase()
+
+    companion object {
+        /** Reverse of [tag]. Defaults to [AUDIO] for unknown values. */
+        fun fromTag(tag: String): MediaType =
+            entries.firstOrNull { it.tag == tag.lowercase() } ?: AUDIO
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/AddFromUrlScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/AddFromUrlScreen.kt
@@ -1,0 +1,543 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Audiotrack
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.LinkOff
+import androidx.compose.material.icons.outlined.Movie
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.podcastplayer.app.R
+import com.podcastplayer.app.data.repository.UrlSource
+import com.podcastplayer.app.domain.model.MediaType
+import com.podcastplayer.app.presentation.viewmodel.UrlPreviewState
+import com.podcastplayer.app.ui.theme.JetBrainsMono
+
+/**
+ * The "Add from URL" screen — the single converged entry point for paste,
+ * dedicated input, and Share intent flows.
+ *
+ * Layout:
+ * - Top bar with Back button
+ * - URL field (or read-only display when entered via Share/Paste)
+ * - Metadata preview (thumbnail, title, uploader, duration) once loaded
+ * - Format selector: Audio (MP3) / Video (MP4)
+ * - Big primary CTA "Save offline"
+ *
+ * The screen is purely presentational; the [com.podcastplayer.app.presentation.viewmodel.UrlDownloadViewModel]
+ * owns all state.
+ */
+@Composable
+fun AddFromUrlScreen(
+    initialUrl: String,
+    previewState: UrlPreviewState,
+    selectedMediaType: MediaType,
+    onUrlChange: (String) -> Unit,
+    onLoadPreview: (String) -> Unit,
+    onSelectMediaType: (MediaType) -> Unit,
+    onConfirm: () -> Unit,
+    onBack: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val focus = LocalFocusManager.current
+    var url by remember { mutableStateOf(initialUrl) }
+    val scroll = rememberScrollState()
+
+    // Auto-load metadata for an initial URL handed in via share / paste.
+    LaunchedEffect(initialUrl) {
+        if (initialUrl.isNotBlank() && previewState is UrlPreviewState.Idle) {
+            onLoadPreview(initialUrl)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(colors.background)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scroll),
+        ) {
+            VibeTopBar(
+                title = "Add from URL",
+                eyebrow = "OFFLINE · YOUTUBE / X",
+                onBack = onBack,
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            // URL input row — paste-friendly, single line, monospace.
+            VibeSurface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+            ) {
+                Column(modifier = Modifier.padding(14.dp)) {
+                    VibeSectionEyebrow(text = "URL")
+                    Spacer(Modifier.height(6.dp))
+                    BasicTextField(
+                        value = url,
+                        onValueChange = {
+                            url = it
+                            onUrlChange(it)
+                        },
+                        textStyle = TextStyle(
+                            color = colors.onSurface,
+                            fontSize = 13.sp,
+                            fontFamily = JetBrainsMono,
+                        ),
+                        cursorBrush = SolidColor(colors.primary),
+                        singleLine = true,
+                        keyboardActions = androidx.compose.foundation.text.KeyboardActions(
+                            onDone = {
+                                focus.clearFocus()
+                                onLoadPreview(url)
+                            },
+                        ),
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions.Default.copy(
+                            imeAction = ImeAction.Done,
+                        ),
+                        decorationBox = { inner ->
+                            if (url.isBlank()) {
+                                Text(
+                                    text = "https://youtu.be/… or https://x.com/…",
+                                    color = colors.onSurfaceVariant,
+                                    fontSize = 13.sp,
+                                    fontFamily = JetBrainsMono,
+                                )
+                            }
+                            inner()
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(10.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        VibePrimaryPill(
+                            label = "Look up",
+                            onClick = {
+                                focus.clearFocus()
+                                onLoadPreview(url)
+                            },
+                            enabled = url.isNotBlank(),
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(14.dp))
+
+            // Metadata preview area.
+            when (previewState) {
+                is UrlPreviewState.Idle -> {
+                    PreviewHint(
+                        title = "Paste or share a YouTube / X link",
+                        subtitle = "We'll fetch the title and thumbnail before saving.",
+                    )
+                }
+
+                is UrlPreviewState.Loading -> {
+                    PreviewLoading(source = previewState.source)
+                }
+
+                is UrlPreviewState.Loaded -> {
+                    PreviewLoaded(
+                        title = previewState.metadata.title,
+                        uploader = previewState.metadata.uploader,
+                        thumbnailUrl = previewState.metadata.thumbnailUrl,
+                        durationMs = previewState.metadata.durationMs,
+                        source = previewState.source,
+                    )
+
+                    Spacer(Modifier.height(18.dp))
+                    SectionTitle("Format")
+                    Spacer(Modifier.height(8.dp))
+                    FormatPicker(
+                        selected = selectedMediaType,
+                        onSelect = onSelectMediaType,
+                    )
+                    Spacer(Modifier.height(20.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        VibePrimaryPill(
+                            label = if (selectedMediaType == MediaType.AUDIO)
+                                "Save audio offline"
+                            else
+                                "Save video offline",
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Download,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                    tint = colors.onPrimary,
+                                )
+                            },
+                            onClick = onConfirm,
+                        )
+                    }
+                }
+
+                is UrlPreviewState.Error -> {
+                    PreviewError(message = previewState.message)
+                }
+            }
+
+            Spacer(Modifier.height(40.dp))
+        }
+    }
+}
+
+@Composable
+private fun PreviewHint(title: String, subtitle: String) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape)
+                .background(colors.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Download,
+                contentDescription = null,
+                tint = colors.primary,
+                modifier = Modifier.size(26.dp),
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = colors.onSurface,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = subtitle,
+            style = MaterialTheme.typography.bodySmall,
+            color = colors.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun PreviewLoading(source: UrlSource) {
+    val colors = MaterialTheme.colorScheme
+    VibeSurface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(colors.surfaceVariant),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(22.dp),
+                    strokeWidth = 2.dp,
+                    color = colors.primary,
+                )
+            }
+            Spacer(Modifier.size(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = source.displayName.uppercase(),
+                    fontFamily = JetBrainsMono,
+                    fontSize = 9.5.sp,
+                    letterSpacing = 1.6.sp,
+                    color = colors.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "Reading metadata…",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.onSurface,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewLoaded(
+    title: String,
+    uploader: String?,
+    thumbnailUrl: String?,
+    durationMs: Long?,
+    source: UrlSource,
+) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+    ) {
+        VibeSurface {
+            Column(modifier = Modifier.padding(12.dp)) {
+                AsyncImage(
+                    model = thumbnailUrl,
+                    contentDescription = title,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(16f / 9f)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(colors.surfaceVariant),
+                    placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                    error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                    fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                )
+                Spacer(Modifier.height(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    SourceChip(source = source)
+                    Spacer(Modifier.size(8.dp))
+                    if (durationMs != null) {
+                        DurationChip(durationMs = durationMs)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = colors.onSurface,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (!uploader.isNullOrBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = uploader,
+                        fontSize = 12.sp,
+                        color = colors.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewError(message: String) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(56.dp)
+                .clip(CircleShape)
+                .background(colors.errorContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.LinkOff,
+                contentDescription = null,
+                tint = colors.error,
+                modifier = Modifier.size(26.dp),
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "Couldn't load that URL",
+            style = MaterialTheme.typography.titleMedium,
+            color = colors.onSurface,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodySmall,
+            color = colors.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SectionTitle(label: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 20.dp, top = 4.dp),
+    ) {
+        Text(
+            text = label,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}
+
+@Composable
+private fun FormatPicker(
+    selected: MediaType,
+    onSelect: (MediaType) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        FormatTile(
+            label = "Audio",
+            sub = "MP3 · smaller",
+            icon = Icons.Outlined.Audiotrack,
+            selected = selected == MediaType.AUDIO,
+            onClick = { onSelect(MediaType.AUDIO) },
+            modifier = Modifier.weight(1f),
+        )
+        FormatTile(
+            label = "Video",
+            sub = "MP4 · keeps visuals",
+            icon = Icons.Outlined.Movie,
+            selected = selected == MediaType.VIDEO,
+            onClick = { onSelect(MediaType.VIDEO) },
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun FormatTile(
+    label: String,
+    sub: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    val bg = if (selected) colors.primaryContainer else colors.surface
+    val accent = if (selected) colors.primary else colors.onSurface
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(14.dp))
+            .background(bg)
+            .border(
+                1.dp,
+                if (selected) colors.primary else colors.outline,
+                RoundedCornerShape(14.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(14.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = accent,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = label,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = accent,
+        )
+        Text(
+            text = sub,
+            fontSize = 11.sp,
+            color = colors.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SourceChip(source: UrlSource) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(colors.surfaceVariant)
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = source.displayName.uppercase(),
+            fontFamily = JetBrainsMono,
+            fontSize = 9.5.sp,
+            letterSpacing = 1.4.sp,
+            color = colors.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DurationChip(durationMs: Long) {
+    val colors = MaterialTheme.colorScheme
+    val totalSec = durationMs / 1000
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    val s = totalSec % 60
+    val text = if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(colors.surfaceVariant)
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = text,
+            fontFamily = JetBrainsMono,
+            fontSize = 9.5.sp,
+            letterSpacing = 1.0.sp,
+            color = colors.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/HomeScreen.kt
@@ -23,7 +23,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Audiotrack
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Movie
+import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -40,7 +47,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
+import com.podcastplayer.app.data.local.UrlDownloadEntity
+import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.MediaType
 import com.podcastplayer.app.domain.model.PlayerState
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.presentation.viewmodel.ContinueListeningUi
@@ -53,11 +63,17 @@ import java.util.Locale
 fun HomeScreen(
     subscriptions: List<Podcast>,
     continueListening: List<ContinueListeningUi>,
+    urlDownloads: List<UrlDownloadEntity>,
+    urlInFlight: List<UrlDownloadEntity>,
     currentEpisode: Episode?,
     currentArtworkUrl: String?,
     playerState: PlayerState,
     onOpenPodcast: (Podcast) -> Unit,
     onOpenSearch: () -> Unit,
+    onAddFromUrl: () -> Unit,
+    onPlayUrlDownload: (UrlDownloadEntity) -> Unit,
+    onDeleteUrlDownload: (String) -> Unit,
+    onCancelUrlDownload: (String) -> Unit,
     onPlayEpisode: (Episode, String?) -> Unit,
     onPlayPause: () -> Unit,
     onOpenPlayer: () -> Unit,
@@ -75,6 +91,19 @@ fun HomeScreen(
         ) {
             HomeHeader(now = now)
 
+            // Quick-action row: "Add from URL" entry point.
+            QuickActionRow(onAddFromUrl = onAddFromUrl)
+
+            // Currently downloading items, if any.
+            if (urlInFlight.isNotEmpty()) {
+                SectionHeader(label = "Saving from URL")
+                InFlightColumn(
+                    items = urlInFlight,
+                    onCancel = onCancelUrlDownload,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
             if (continueListening.isNotEmpty()) {
                 SectionHeader(label = "Continue listening")
                 ContinueListeningRow(
@@ -86,17 +115,30 @@ fun HomeScreen(
                 Spacer(Modifier.height(4.dp))
             }
 
-            if (subscriptions.isEmpty()) {
+            if (urlDownloads.isNotEmpty()) {
+                SectionHeader(
+                    label = "Saved from URL",
+                    count = urlDownloads.size,
+                )
+                UrlDownloadsRow(
+                    items = urlDownloads,
+                    onPlay = onPlayUrlDownload,
+                    onDelete = onDeleteUrlDownload,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
+            if (subscriptions.isEmpty() && urlDownloads.isEmpty() && urlInFlight.isEmpty()) {
                 VibeEmptyState(
                     icon = Icons.Outlined.Search,
                     title = "No subscriptions yet",
-                    subtitle = "Search for podcasts to start building your library",
+                    subtitle = "Search for podcasts, or paste a YouTube / X link to save offline.",
                     action = {
                         VibePrimaryPill(label = "Browse podcasts", onClick = onOpenSearch)
                     },
                     modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
                 )
-            } else {
+            } else if (subscriptions.isNotEmpty()) {
                 SectionHeader(
                     label = "Your subscriptions",
                     count = subscriptions.size,
@@ -150,6 +192,29 @@ private fun HomeHeader(now: LocalDateTime) {
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
             color = colors.onBackground,
+        )
+    }
+}
+
+/** Quick-actions strip directly under the greeting. Currently just "Add from URL" (issue #33). */
+@Composable
+private fun QuickActionRow(onAddFromUrl: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        VibeChip(
+            label = "Add from URL",
+            onClick = onAddFromUrl,
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.Download,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                )
+            },
         )
     }
 }
@@ -267,6 +332,238 @@ private fun ContinueListeningCard(item: ContinueListeningUi, onClick: () -> Unit
     }
 }
 
+/**
+ * Horizontally-scrolling row of completed URL downloads. Each card shows
+ * thumbnail + source badge + title + format chip and plays on tap.
+ */
+@Composable
+private fun UrlDownloadsRow(
+    items: List<UrlDownloadEntity>,
+    onPlay: (UrlDownloadEntity) -> Unit,
+    onDelete: (String) -> Unit,
+) {
+    val scroll = rememberScrollState()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scroll)
+            .padding(horizontal = 20.dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items.forEach { item ->
+            UrlDownloadCard(
+                item = item,
+                onPlay = { onPlay(item) },
+                onDelete = { onDelete(item.id) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun UrlDownloadCard(
+    item: UrlDownloadEntity,
+    onPlay: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val mediaType = MediaType.fromTag(item.mediaType)
+    Column(
+        modifier = Modifier
+            .width(220.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.surface)
+            .border(1.dp, colors.outline, RoundedCornerShape(14.dp))
+            .clickable(onClick = onPlay)
+            .padding(10.dp),
+    ) {
+        Box {
+            AsyncImage(
+                model = item.thumbnailUrl,
+                contentDescription = item.title,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(colors.surfaceVariant),
+                placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            )
+            // Play overlay
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(Color.Black.copy(alpha = 0.55f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.PlayArrow,
+                    contentDescription = "Play",
+                    tint = Color.White,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+            // Format badge (top-right)
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(6.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(Color.Black.copy(alpha = 0.55f))
+                    .padding(horizontal = 8.dp, vertical = 3.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = if (mediaType == MediaType.VIDEO) Icons.Outlined.Movie else Icons.Outlined.Audiotrack,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(10.dp),
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = if (mediaType == MediaType.VIDEO) "VIDEO" else "AUDIO",
+                    fontFamily = JetBrainsMono,
+                    fontSize = 8.5.sp,
+                    letterSpacing = 1.0.sp,
+                    color = Color.White,
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = UrlSource.fromTag(item.source).displayName.uppercase(),
+                fontFamily = JetBrainsMono,
+                fontSize = 9.5.sp,
+                letterSpacing = 1.4.sp,
+                color = colors.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                imageVector = Icons.Outlined.Delete,
+                contentDescription = "Delete",
+                tint = colors.onSurfaceVariant,
+                modifier = Modifier
+                    .size(14.dp)
+                    .clickable(onClick = onDelete),
+            )
+        }
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = item.title,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = colors.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            lineHeight = 17.sp,
+        )
+        if (!item.uploader.isNullOrBlank()) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = item.uploader,
+                fontSize = 11.sp,
+                color = colors.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+/** Currently-downloading items shown in a column with progress + cancel. */
+@Composable
+private fun InFlightColumn(
+    items: List<UrlDownloadEntity>,
+    onCancel: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items.forEach { item ->
+            InFlightCard(item = item, onCancel = { onCancel(item.id) })
+        }
+    }
+}
+
+@Composable
+private fun InFlightCard(item: UrlDownloadEntity, onCancel: () -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.surface)
+            .border(1.dp, colors.outline, RoundedCornerShape(14.dp))
+            .padding(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            AsyncImage(
+                model = item.thumbnailUrl,
+                contentDescription = item.title,
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(colors.surfaceVariant),
+                placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 17.sp,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = "${UrlSource.fromTag(item.source).displayName.uppercase()} · ${item.mediaType.uppercase()}",
+                    fontFamily = JetBrainsMono,
+                    fontSize = 9.5.sp,
+                    letterSpacing = 1.4.sp,
+                    color = colors.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.Outlined.Close,
+                contentDescription = "Cancel",
+                tint = colors.onSurfaceVariant,
+                modifier = Modifier
+                    .size(18.dp)
+                    .clickable(onClick = onCancel),
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        LinearProgressIndicator(
+            progress = (item.progressPercent / 100f).coerceIn(0f, 1f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp)),
+            color = colors.primary,
+            trackColor = colors.outline,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = statusLabel(item),
+            fontFamily = JetBrainsMono,
+            fontSize = 10.sp,
+            color = colors.onSurfaceVariant,
+        )
+    }
+}
+
 @Composable
 private fun SubscriptionsGrid(
     podcasts: List<Podcast>,
@@ -341,7 +638,7 @@ private fun SubscriptionTile(
     }
 }
 
-// ─── helpers ─────────────────────────────────────────────────────
+// ─── helpers ────────────────────────────────────────────────────────
 
 private fun greeting(hour: Int): String = when {
     hour < 12 -> "Good morning."
@@ -363,4 +660,16 @@ private fun formatRemaining(ms: Long): String {
     val h = totalSec / 3600
     val m = (totalSec % 3600) / 60
     return if (h > 0) "${h}h ${m}m" else "${m}m"
+}
+
+private fun statusLabel(item: UrlDownloadEntity): String {
+    val status = com.podcastplayer.app.data.repository.UrlDownloadStatus.entries
+        .firstOrNull { it.name == item.status }
+    return when (status) {
+        com.podcastplayer.app.data.repository.UrlDownloadStatus.QUEUED -> "QUEUED"
+        com.podcastplayer.app.data.repository.UrlDownloadStatus.EXTRACTING_METADATA -> "READING METADATA"
+        com.podcastplayer.app.data.repository.UrlDownloadStatus.DOWNLOADING ->
+            "DOWNLOADING · ${item.progressPercent.toInt()}%"
+        else -> item.status.uppercase()
+    }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
@@ -1,5 +1,8 @@
 package com.podcastplayer.app.presentation.ui
 
+import android.app.Activity
+import android.content.pm.ActivityInfo
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -19,6 +22,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FullscreenExit
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material.icons.rounded.FastForward
@@ -34,6 +38,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +46,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -48,6 +56,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.text.HtmlCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
@@ -81,6 +92,74 @@ fun PlayerScreen(
     val position = playerState.currentPosition.coerceIn(0L, duration)
 
     var sleepSheetOpen by remember { mutableStateOf(false) }
+
+    // ─── Fullscreen video plumbing (issue #33) ───────────────────────────
+    val context = LocalContext.current
+    val activity = context as? Activity
+    val isVideo = episode.mediaType == MediaType.VIDEO
+    val isVideoFullscreen = isVideo && isLandscape
+
+    fun enterFullscreen() {
+        // Lock to landscape; the orientation change recomposes us into the
+        // dedicated PlayerVideoFullscreen layout below.
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+    }
+
+    fun exitFullscreen() {
+        // Force back to portrait so we drop out of the fullscreen branch even
+        // if the device is being held in landscape (auto-rotate is honored
+        // again when the user navigates away — see DisposableEffect below).
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+
+    // Hide system bars while in fullscreen video; restore on exit.
+    DisposableEffect(isVideoFullscreen) {
+        val window = activity?.window
+        if (isVideoFullscreen && window != null) {
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            WindowInsetsControllerCompat(window, window.decorView).apply {
+                hide(WindowInsetsCompat.Type.systemBars())
+                systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        }
+        onDispose {
+            if (window != null) {
+                WindowCompat.setDecorFitsSystemWindows(window, true)
+                WindowInsetsControllerCompat(window, window.decorView)
+                    .show(WindowInsetsCompat.Type.systemBars())
+            }
+        }
+    }
+
+    // When PlayerScreen leaves the back stack entirely, release any orientation
+    // lock so other screens follow the user's auto-rotate setting.
+    DisposableEffect(Unit) {
+        onDispose {
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        }
+    }
+
+    // While fullscreen, intercept back to drop fullscreen first instead of
+    // dismissing the player. Disabled otherwise — the NavHost-level handler
+    // takes over.
+    BackHandler(enabled = isVideoFullscreen) { exitFullscreen() }
+
+    if (isVideoFullscreen) {
+        PlayerVideoFullscreen(
+            episode = episode,
+            isPlaying = isPlaying,
+            position = position,
+            duration = duration,
+            hasPrevious = hasPrevious,
+            hasNext = hasNext,
+            onPlayPause = onPlayPause,
+            onPlayPrevious = onPlayPrevious,
+            onPlayNext = onPlayNext,
+            onSeek = onSeek,
+            onExitFullscreen = ::exitFullscreen,
+        )
+        return
+    }
 
     if (isLandscape) {
         PlayerLandscape(
@@ -165,7 +244,14 @@ fun PlayerScreen(
                 if (episode.mediaType == MediaType.VIDEO) {
                     // URL-downloaded videos render the actual frames here while the
                     // existing transport bar below still drives playback (issue #33).
-                    VideoSurface(modifier = Modifier.fillMaxSize(), cornerRadius = 20.dp)
+                    // The toggle promotes us into the dedicated fullscreen layout.
+                    VideoSurface(
+                        modifier = Modifier.fillMaxSize(),
+                        cornerRadius = 20.dp,
+                        showFullscreenToggle = true,
+                        isFullscreen = false,
+                        onToggleFullscreen = ::enterFullscreen,
+                    )
                 } else {
                     AsyncImage(
                         model = episode.imageUrl ?: artworkUrl,
@@ -460,7 +546,7 @@ private fun SleepOption(minutes: Long, onClick: () -> Unit) {
     }
 }
 
-// ─── Landscape player layout ──────────────────────────────────────────────────
+// ─── Landscape player layout ───────────────────────────────────
 // Left 300dp: close button + 240dp artwork.
 // Right: title block, scrubber, transport row, speed/sleep chips.
 @Composable
@@ -692,6 +778,192 @@ private fun PlayerLandscape(
                 sleepSheetOpen = false
                 onSetSleepTimer(minutes * 60_000L)
             },
+        )
+    }
+}
+
+/**
+ * Immersive landscape video layout (issue #33).
+ *
+ * Reached when [Episode.mediaType] is `VIDEO` and the activity is in landscape —
+ * either because the user rotated the device or because the portrait fullscreen
+ * toggle locked the orientation.
+ *
+ * The video fills the screen, with a dim overlay at the top (title + exit
+ * button) and bottom (scrubber + transport). Sleep timer / speed pills are
+ * intentionally hidden here to keep the canvas clean — those still live in the
+ * portrait player one rotation away.
+ */
+@Composable
+private fun PlayerVideoFullscreen(
+    episode: Episode,
+    isPlaying: Boolean,
+    position: Long,
+    duration: Long,
+    hasPrevious: Boolean,
+    hasNext: Boolean,
+    onPlayPause: () -> Unit,
+    onPlayPrevious: () -> Unit,
+    onPlayNext: () -> Unit,
+    onSeek: (Long) -> Unit,
+    onExitFullscreen: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+    ) {
+        // Frames fill the entire screen.
+        VideoSurface(
+            modifier = Modifier.fillMaxSize(),
+            cornerRadius = 0.dp,
+            showFullscreenToggle = false,
+            isFullscreen = true,
+            onToggleFullscreen = null,
+        )
+
+        // ─── Top overlay: title + exit fullscreen ────────────────────────
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopStart)
+                .padding(start = 20.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = episode.title,
+                color = Color.White,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(12.dp))
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.55f))
+                    .clickable(onClick = onExitFullscreen),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.FullscreenExit,
+                    contentDescription = "Exit fullscreen",
+                    tint = Color.White,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+        }
+
+        // ─── Bottom overlay: scrubber + transport ────────────────────────
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+        ) {
+            Slider(
+                value = position.coerceIn(0L, duration).toFloat(),
+                onValueChange = { onSeek(it.toLong()) },
+                valueRange = 0f..duration.toFloat(),
+                colors = SliderDefaults.colors(
+                    thumbColor = Color.White,
+                    activeTrackColor = Color.White,
+                    inactiveTrackColor = Color.White.copy(alpha = 0.35f),
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = formatPlayerTime(position),
+                    color = Color.White,
+                    fontFamily = JetBrainsMono,
+                    fontSize = 11.sp,
+                )
+                Text(
+                    text = "-${formatPlayerTime((duration - position).coerceAtLeast(0L))}",
+                    color = Color.White,
+                    fontFamily = JetBrainsMono,
+                    fontSize = 11.sp,
+                )
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FullscreenControlButton(
+                    icon = Icons.Rounded.SkipPrevious,
+                    description = "Previous",
+                    enabled = hasPrevious,
+                    onClick = onPlayPrevious,
+                )
+                FullscreenControlButton(
+                    icon = Icons.Rounded.FastRewind,
+                    description = "Rewind 15s",
+                    onClick = { onSeek((position - 15_000L).coerceAtLeast(0L)) },
+                )
+                // Primary play/pause — large white circle, mirrors portrait UI.
+                Box(
+                    modifier = Modifier
+                        .size(68.dp)
+                        .clip(CircleShape)
+                        .background(Color.White)
+                        .clickable(onClick = onPlayPause),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        tint = Color.Black,
+                        modifier = Modifier.size(36.dp),
+                    )
+                }
+                FullscreenControlButton(
+                    icon = Icons.Rounded.FastForward,
+                    description = "Forward 30s",
+                    onClick = { onSeek((position + 30_000L).coerceAtMost(duration)) },
+                )
+                FullscreenControlButton(
+                    icon = Icons.Rounded.SkipNext,
+                    description = "Next",
+                    enabled = hasNext,
+                    onClick = onPlayNext,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FullscreenControlButton(
+    icon: ImageVector,
+    description: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+) {
+    val tint = if (enabled) Color.White else Color.White.copy(alpha = 0.4f)
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(Color.Black.copy(alpha = 0.45f))
+            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = description,
+            tint = tint,
+            modifier = Modifier.size(24.dp),
         )
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
@@ -51,6 +51,7 @@ import androidx.core.text.HtmlCompat
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.MediaType
 import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.domain.model.PlayerState
 import com.podcastplayer.app.ui.theme.JetBrainsMono
@@ -161,14 +162,20 @@ fun PlayerScreen(
                     .clip(RoundedCornerShape(20.dp))
                     .border(1.dp, colors.outline, RoundedCornerShape(20.dp)),
             ) {
-                AsyncImage(
-                    model = episode.imageUrl ?: artworkUrl,
-                    contentDescription = episode.title,
-                    placeholder = painterResource(R.drawable.ic_artwork_placeholder),
-                    error = painterResource(R.drawable.ic_artwork_placeholder),
-                    fallback = painterResource(R.drawable.ic_artwork_placeholder),
-                    modifier = Modifier.fillMaxSize(),
-                )
+                if (episode.mediaType == MediaType.VIDEO) {
+                    // URL-downloaded videos render the actual frames here while the
+                    // existing transport bar below still drives playback (issue #33).
+                    VideoSurface(modifier = Modifier.fillMaxSize(), cornerRadius = 20.dp)
+                } else {
+                    AsyncImage(
+                        model = episode.imageUrl ?: artworkUrl,
+                        contentDescription = episode.title,
+                        placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                        error = painterResource(R.drawable.ic_artwork_placeholder),
+                        fallback = painterResource(R.drawable.ic_artwork_placeholder),
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
 
@@ -453,7 +460,7 @@ private fun SleepOption(minutes: Long, onClick: () -> Unit) {
     }
 }
 
-// ─── Landscape player layout ───────────────────────────────────
+// ─── Landscape player layout ──────────────────────────────────────────────────
 // Left 300dp: close button + 240dp artwork.
 // Right: title block, scrubber, transport row, speed/sleep chips.
 @Composable
@@ -517,14 +524,18 @@ private fun PlayerLandscape(
                     .clip(RoundedCornerShape(18.dp))
                     .border(1.dp, colors.outline, RoundedCornerShape(18.dp)),
             ) {
-                AsyncImage(
-                    model = episode.imageUrl ?: artworkUrl,
-                    contentDescription = episode.title,
-                    placeholder = painterResource(R.drawable.ic_artwork_placeholder),
-                    error = painterResource(R.drawable.ic_artwork_placeholder),
-                    fallback = painterResource(R.drawable.ic_artwork_placeholder),
-                    modifier = Modifier.fillMaxSize(),
-                )
+                if (episode.mediaType == MediaType.VIDEO) {
+                    VideoSurface(modifier = Modifier.fillMaxSize(), cornerRadius = 18.dp)
+                } else {
+                    AsyncImage(
+                        model = episode.imageUrl ?: artworkUrl,
+                        contentDescription = episode.title,
+                        placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                        error = painterResource(R.drawable.ic_artwork_placeholder),
+                        fallback = painterResource(R.drawable.ic_artwork_placeholder),
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BookmarkAdd
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.PlaylistAdd
@@ -659,7 +660,7 @@ private fun UrlDownloadShortcutCard(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         androidx.compose.material3.Icon(
-            imageVector = androidx.compose.material.icons.Icons.Outlined.Download,
+            imageVector = Icons.Outlined.Download,
             contentDescription = null,
             tint = colors.primary,
             modifier = Modifier.size(20.dp),

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -85,6 +85,7 @@ fun PodcastListScreen(
     onOpenQueue: () -> Unit,
     @Suppress("UNUSED_PARAMETER") onOpenDownloads: () -> Unit,
     onPlayQueue: () -> Unit,
+    onAddFromUrl: (String) -> Unit = {},
     onExportOpml: () -> Unit = {},
     onImportOpml: () -> Unit = {},
 ) {
@@ -177,6 +178,30 @@ fun PodcastListScreen(
                         focusManager.clearFocus()
                     },
                 )
+
+                // When a YouTube / X URL is pasted into the search field, surface a
+                // direct "Download from URL" affordance so the user doesn't have to
+                // back out and find the home-screen entry. (Issue #33)
+                val pastedUrl = remember(searchQuery) {
+                    com.podcastplayer.app.data.repository.UrlValidator.extractFirstUrl(searchQuery)
+                }
+                val pastedSource = remember(pastedUrl) {
+                    pastedUrl?.let { com.podcastplayer.app.data.repository.UrlSource.classify(it) }
+                }
+                if (pastedUrl != null &&
+                    pastedSource != null &&
+                    pastedSource != com.podcastplayer.app.data.repository.UrlSource.OTHER
+                ) {
+                    UrlDownloadShortcutCard(
+                        url = pastedUrl,
+                        source = pastedSource,
+                        onClick = {
+                            focusManager.clearFocus()
+                            onAddFromUrl(pastedUrl)
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
 
                 if (showSaved && queues.isNotEmpty()) {
                     Spacer(Modifier.height(8.dp))
@@ -610,4 +635,52 @@ private fun QueuePickerDialog(
             TextButton(onClick = onDismiss) { Text("Cancel") }
         },
     )
+}
+
+/**
+ * Inline card shown when the user pastes a YouTube / X URL into the search field.
+ * Tapping it opens the AddFromUrl flow with the URL pre-filled (issue #33).
+ */
+@Composable
+private fun UrlDownloadShortcutCard(
+    url: String,
+    source: com.podcastplayer.app.data.repository.UrlSource,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(androidx.compose.foundation.shape.RoundedCornerShape(14.dp))
+            .background(colors.primaryContainer)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        androidx.compose.material3.Icon(
+            imageVector = androidx.compose.material.icons.Icons.Outlined.Download,
+            contentDescription = null,
+            tint = colors.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Save this ${source.displayName} link offline",
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.onSurface,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = url,
+                fontFamily = com.podcastplayer.app.ui.theme.JetBrainsMono,
+                fontSize = 10.5.sp,
+                color = colors.onSurfaceVariant,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -36,6 +36,7 @@ import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.presentation.viewmodel.PlayerViewModel
 import com.podcastplayer.app.presentation.viewmodel.PodcastViewModel
+import com.podcastplayer.app.presentation.viewmodel.UrlDownloadViewModel
 import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.service.PlaybackSessionStorage
 import com.podcastplayer.app.service.PlayerController
@@ -56,13 +57,27 @@ private object Routes {
     const val EpisodesPattern = "$EpisodesBase/{$PodcastIdArg}"
 
     fun episodes(podcastId: String): String = "$EpisodesBase/${Uri.encode(podcastId)}"
+
+    // "Add from URL" flow (issue #33). The optional `url` query arg is filled in
+    // when arriving via a Share intent or paste shortcut so the screen can
+    // auto-populate and start metadata extraction.
+    const val AddUrlBase = "add-url"
+    const val UrlArg = "url"
+    const val AddUrlPattern = "$AddUrlBase?$UrlArg={$UrlArg}"
+
+    fun addUrl(rawUrl: String? = null): String =
+        if (rawUrl.isNullOrBlank()) AddUrlBase else "$AddUrlBase?$UrlArg=${Uri.encode(rawUrl)}"
 }
 
 @Composable
-fun PodcastNavHost() {
+fun PodcastNavHost(
+    sharedUrl: String? = null,
+    onSharedUrlConsumed: () -> Unit = {},
+) {
     val context = LocalContext.current
     val db = remember { DatabaseProvider.getDatabase(context) }
     val queueStorage = remember { QueueStorage(context) }
+    val application = context.applicationContext as android.app.Application
 
     // Keep ViewModel scoping identical to the previous implementation (created once at the top level).
     val podcastViewModel: PodcastViewModel = viewModel(
@@ -79,6 +94,9 @@ fun PodcastNavHost() {
             PlayerController.getInstance(context),
             PlaybackSessionStorage(context)
         )
+    )
+    val urlDownloadViewModel: UrlDownloadViewModel = viewModel(
+        factory = UrlDownloadViewModelFactory(application)
     )
 
     val navController = rememberNavController()
@@ -172,6 +190,16 @@ fun PodcastNavHost() {
         }
     }
 
+    // React to a Share intent (issue #33). MainActivity hands us the URL via [sharedUrl];
+    // we navigate to the AddFromUrl screen and clear the slot so we don't loop.
+    LaunchedEffect(sharedUrl) {
+        val url = sharedUrl ?: return@LaunchedEffect
+        navController.navigate(Routes.addUrl(url)) {
+            launchSingleTop = true
+        }
+        onSharedUrlConsumed()
+    }
+
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     val bottomNavRoutes = setOf(Routes.Home, Routes.Search, Routes.Queue, Routes.Downloads)
@@ -220,10 +248,18 @@ fun PodcastNavHost() {
                     val currentEpisode by playerViewModel.currentEpisode.collectAsState()
                     val playerState by playerViewModel.playerState.collectAsState()
                     val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
+                    val urlDownloads by urlDownloadViewModel.completedDownloads.collectAsState()
+                    val urlInFlight by urlDownloadViewModel.inFlightDownloads.collectAsState()
+
+                    val urlRepository = remember(context) {
+                        com.podcastplayer.app.data.repository.UrlDownloadRepository(context)
+                    }
 
                     HomeScreen(
                         subscriptions = savedPodcasts,
                         continueListening = continueListening,
+                        urlDownloads = urlDownloads,
+                        urlInFlight = urlInFlight,
                         currentEpisode = currentEpisode,
                         currentArtworkUrl = currentArtworkUrl,
                         playerState = playerState,
@@ -232,6 +268,16 @@ fun PodcastNavHost() {
                             navController.navigate(Routes.episodes(podcast.id))
                         },
                         onOpenSearch = { navController.navigate(Routes.Search) },
+                        onAddFromUrl = { navController.navigate(Routes.addUrl()) },
+                        onPlayUrlDownload = { entity ->
+                            val episode = urlRepository.toEpisode(entity)
+                            if (episode != null) {
+                                playerViewModel.playEpisode(episode, entity.thumbnailUrl)
+                                navController.navigate(Routes.Player)
+                            }
+                        },
+                        onDeleteUrlDownload = { id -> urlDownloadViewModel.deleteDownload(id) },
+                        onCancelUrlDownload = { id -> urlDownloadViewModel.cancelDownload(id) },
                         onPlayEpisode = { episode, artwork ->
                             playerViewModel.playEpisode(episode, artwork)
                             navController.navigate(Routes.Player)
@@ -240,6 +286,38 @@ fun PodcastNavHost() {
                         onOpenPlayer = { navController.navigate(Routes.Player) },
                         onSeek = { playerViewModel.seekTo(it) },
                         onDismissPlayer = { playerViewModel.clearPlayer() },
+                    )
+                }
+
+                composable(
+                    route = Routes.AddUrlPattern,
+                    arguments = listOf(
+                        navArgument(Routes.UrlArg) {
+                            type = NavType.StringType
+                            nullable = true
+                            defaultValue = null
+                        }
+                    )
+                ) { backStackEntry ->
+                    val incomingUrl = backStackEntry.arguments?.getString(Routes.UrlArg).orEmpty()
+                    val previewState by urlDownloadViewModel.previewState.collectAsState()
+                    val selectedMediaType by urlDownloadViewModel.selectedMediaType.collectAsState()
+
+                    AddFromUrlScreen(
+                        initialUrl = incomingUrl,
+                        previewState = previewState,
+                        selectedMediaType = selectedMediaType,
+                        onUrlChange = { /* no-op: text field is local */ },
+                        onLoadPreview = { urlDownloadViewModel.loadPreview(it) },
+                        onSelectMediaType = { urlDownloadViewModel.setMediaType(it) },
+                        onConfirm = {
+                            urlDownloadViewModel.confirmCurrentDownload()
+                            navController.popBackStack(route = Routes.Home, inclusive = false)
+                        },
+                        onBack = {
+                            urlDownloadViewModel.resetPreview()
+                            navController.popBackStack(route = Routes.Home, inclusive = false)
+                        },
                     )
                 }
 
@@ -271,6 +349,9 @@ fun PodcastNavHost() {
                                     }
                                 }
                             }
+                        },
+                        onAddFromUrl = { rawUrl ->
+                            navController.navigate(Routes.addUrl(rawUrl))
                         },
                         onExportOpml = { exportLauncher.launch("vibe-podcasts.opml") },
                         onImportOpml = {

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/UrlDownloadViewModelFactory.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/UrlDownloadViewModelFactory.kt
@@ -1,0 +1,23 @@
+package com.podcastplayer.app.presentation.ui
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.podcastplayer.app.presentation.viewmodel.UrlDownloadViewModel
+
+/**
+ * Manual factory for [UrlDownloadViewModel] — matches the existing convention in
+ * this codebase (no DI framework). Constructed with the [Application] so the VM
+ * can pull the repository / service without holding an Activity reference.
+ */
+class UrlDownloadViewModelFactory(
+    private val application: Application,
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(UrlDownloadViewModel::class.java)) {
+            return UrlDownloadViewModel(application) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/VideoSurface.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/VideoSurface.kt
@@ -1,9 +1,17 @@
 package com.podcastplayer.app.presentation.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Fullscreen
+import androidx.compose.material.icons.outlined.FullscreenExit
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -11,8 +19,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -25,9 +35,13 @@ import com.podcastplayer.app.service.PlayerController
  * Compose surface that renders the active Media3 player's video output (issue #33).
  *
  * The screen above already drives playback through [PlayerController]; this
- * composable just attaches a `PlayerView` to the same [MediaController] so the
+ * composable just attaches a `PlayerView` to the same `MediaController` so the
  * frames render. Custom transport controls live in the parent — we set
  * `useController = false` and only show the surface.
+ *
+ * Optionally renders a small fullscreen-toggle button overlay (bottom-right).
+ * The button is intended for the embedded portrait surface; in landscape /
+ * dedicated-fullscreen mode the parent layout owns its own exit affordance.
  *
  * Until the `MediaController` is available (the future resolves async), we
  * render a placeholder background so the layout doesn't jump.
@@ -36,6 +50,9 @@ import com.podcastplayer.app.service.PlayerController
 fun VideoSurface(
     modifier: Modifier = Modifier,
     cornerRadius: Dp = 20.dp,
+    showFullscreenToggle: Boolean = false,
+    isFullscreen: Boolean = false,
+    onToggleFullscreen: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val controller = remember { PlayerController.getInstance(context) }
@@ -50,7 +67,7 @@ fun VideoSurface(
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(cornerRadius))
-            .background(colors.surfaceVariant),
+            .background(if (isFullscreen) Color.Black else colors.surfaceVariant),
     ) {
         val current = player
         if (current != null) {
@@ -70,6 +87,26 @@ fun VideoSurface(
                 modifier = Modifier.fillMaxSize(),
             )
         }
+
+        if (showFullscreenToggle && onToggleFullscreen != null) {
+            // Bottom-right corner — YouTube-style placement.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp)
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.55f))
+                    .clickable(onClick = onToggleFullscreen),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = if (isFullscreen) Icons.Outlined.FullscreenExit else Icons.Outlined.Fullscreen,
+                    contentDescription = if (isFullscreen) "Exit fullscreen" else "Fullscreen",
+                    tint = Color.White,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
     }
 }
-

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/VideoSurface.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/VideoSurface.kt
@@ -1,0 +1,75 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.Player
+import androidx.media3.ui.PlayerView
+import com.podcastplayer.app.service.PlayerController
+
+/**
+ * Compose surface that renders the active Media3 player's video output (issue #33).
+ *
+ * The screen above already drives playback through [PlayerController]; this
+ * composable just attaches a `PlayerView` to the same [MediaController] so the
+ * frames render. Custom transport controls live in the parent — we set
+ * `useController = false` and only show the surface.
+ *
+ * Until the `MediaController` is available (the future resolves async), we
+ * render a placeholder background so the layout doesn't jump.
+ */
+@Composable
+fun VideoSurface(
+    modifier: Modifier = Modifier,
+    cornerRadius: Dp = 20.dp,
+) {
+    val context = LocalContext.current
+    val controller = remember { PlayerController.getInstance(context) }
+    var player by remember { mutableStateOf<Player?>(null) }
+
+    LaunchedEffect(controller) {
+        // Suspends until the MediaController is connected.
+        player = controller.awaitController()
+    }
+
+    val colors = MaterialTheme.colorScheme
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(cornerRadius))
+            .background(colors.surfaceVariant),
+    ) {
+        val current = player
+        if (current != null) {
+            AndroidView(
+                factory = { ctx ->
+                    PlayerView(ctx).apply {
+                        useController = false
+                        // Match the rounded corners visually — surface is already clipped.
+                        setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                    }
+                },
+                update = { view ->
+                    if (view.player !== current) {
+                        view.player = current
+                    }
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/UrlDownloadViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/UrlDownloadViewModel.kt
@@ -1,0 +1,146 @@
+package com.podcastplayer.app.presentation.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.podcastplayer.app.data.local.UrlDownloadEntity
+import com.podcastplayer.app.data.repository.UrlDownloadRepository
+import com.podcastplayer.app.data.repository.UrlDownloadStatus
+import com.podcastplayer.app.data.repository.UrlMetadata
+import com.podcastplayer.app.data.repository.UrlSource
+import com.podcastplayer.app.data.repository.UrlValidator
+import com.podcastplayer.app.domain.model.MediaType
+import com.podcastplayer.app.service.UrlDownloadService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel powering the "Add from URL" feature (issue #33).
+ *
+ * Responsibilities:
+ * - Validate / classify URLs as the user types or shares
+ * - Resolve metadata (title, thumbnail, duration) before download
+ * - Enqueue the chosen format and trigger the download service
+ * - Expose the home-screen-visible list of completed URL downloads
+ *
+ * Constructed with [Application] so we can spin up the repository and call
+ * [UrlDownloadService.startPump] without needing a separate Context dependency.
+ */
+class UrlDownloadViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = UrlDownloadRepository(application)
+
+    /** Pending/queued metadata-preview state for the AddFromUrl screen. */
+    private val _previewState = MutableStateFlow<UrlPreviewState>(UrlPreviewState.Idle)
+    val previewState: StateFlow<UrlPreviewState> = _previewState.asStateFlow()
+
+    /** Currently chosen format on the AddFromUrl screen. */
+    private val _selectedMediaType = MutableStateFlow(MediaType.AUDIO)
+    val selectedMediaType: StateFlow<MediaType> = _selectedMediaType.asStateFlow()
+
+    /** All completed URL downloads, newest first — fed to the home screen. */
+    val completedDownloads: StateFlow<List<UrlDownloadEntity>> =
+        repository.observeCompleted().stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = emptyList(),
+        )
+
+    /** Items currently downloading — shown as a banner / progress card. */
+    val inFlightDownloads: StateFlow<List<UrlDownloadEntity>> =
+        repository.observeInFlight().stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = emptyList(),
+        )
+
+    /**
+     * Begin metadata extraction for [rawUrl]. Called when the user opens the
+     * AddFromUrl screen with a URL (paste, share, or dedicated input).
+     */
+    fun loadPreview(rawUrl: String) {
+        if (rawUrl.isBlank()) {
+            _previewState.value = UrlPreviewState.Idle
+            return
+        }
+        val source = UrlSource.classify(rawUrl)
+        if (source == UrlSource.OTHER && !rawUrl.startsWith("http", ignoreCase = true)) {
+            _previewState.value = UrlPreviewState.Error("That doesn't look like a URL we can download.")
+            return
+        }
+        _previewState.value = UrlPreviewState.Loading(rawUrl, source)
+        viewModelScope.launch {
+            val metadata = repository.fetchMetadata(rawUrl)
+            _previewState.value = if (metadata != null) {
+                UrlPreviewState.Loaded(rawUrl, source, metadata)
+            } else {
+                UrlPreviewState.Error(
+                    "Couldn't read that URL. It may be private, age-gated, or temporarily unavailable.",
+                )
+            }
+        }
+    }
+
+    fun setMediaType(mediaType: MediaType) {
+        _selectedMediaType.value = mediaType
+    }
+
+    /**
+     * Confirm the download. Inserts a row, then starts the service so it picks
+     * the row up. Returns the stable download id (so the caller can observe it).
+     */
+    fun confirmDownload(rawUrl: String, mediaType: MediaType, prefetched: UrlMetadata?) {
+        val app = getApplication<Application>()
+        viewModelScope.launch {
+            repository.enqueue(rawUrl, mediaType, prefetched)
+            UrlDownloadService.startPump(app)
+        }
+    }
+
+    /** Convenience overload that pulls the URL/metadata from the current preview state. */
+    fun confirmCurrentDownload() {
+        val state = _previewState.value as? UrlPreviewState.Loaded ?: return
+        confirmDownload(state.rawUrl, _selectedMediaType.value, state.metadata)
+        _previewState.value = UrlPreviewState.Idle
+        _selectedMediaType.value = MediaType.AUDIO
+    }
+
+    fun deleteDownload(id: String) {
+        viewModelScope.launch { repository.delete(id) }
+    }
+
+    fun cancelDownload(id: String) {
+        UrlDownloadService.cancel(getApplication(), id)
+    }
+
+    fun resetPreview() {
+        _previewState.value = UrlPreviewState.Idle
+        _selectedMediaType.value = MediaType.AUDIO
+    }
+
+    companion object {
+        /** True when [text] looks like a YouTube/X URL we can ingest. */
+        fun isSupportedUrl(text: CharSequence?): Boolean = UrlValidator.isSupportedUrl(text)
+    }
+}
+
+/**
+ * UI state for the metadata-preview phase of "Add from URL".
+ */
+sealed interface UrlPreviewState {
+    data object Idle : UrlPreviewState
+
+    data class Loading(val rawUrl: String, val source: UrlSource) : UrlPreviewState
+
+    data class Loaded(
+        val rawUrl: String,
+        val source: UrlSource,
+        val metadata: UrlMetadata,
+    ) : UrlPreviewState
+
+    data class Error(val message: String) : UrlPreviewState
+}

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -161,8 +161,23 @@ class PlayerController private constructor(private val context: Context) {
             duration = null,
             imageUrl = item.mediaMetadata.artworkUri?.toString(),
             isDownloaded = isLocal,
-            localPath = if (isLocal) item.localConfiguration?.uri?.path else null
+            localPath = if (isLocal) item.localConfiguration?.uri?.path else null,
+            mediaType = inferMediaType(uri),
         )
+    }
+
+    /**
+     * Best-effort inference of [com.podcastplayer.app.domain.model.MediaType] from a file
+     * URI's extension, used when restoring a session (issue #33). Defaults to AUDIO.
+     */
+    private fun inferMediaType(uri: String): com.podcastplayer.app.domain.model.MediaType {
+        val ext = uri.substringAfterLast('.', "").substringBefore('?').lowercase()
+        val videoExts = setOf("mp4", "webm", "mkv", "mov", "avi", "m4v")
+        return if (ext in videoExts) {
+            com.podcastplayer.app.domain.model.MediaType.VIDEO
+        } else {
+            com.podcastplayer.app.domain.model.MediaType.AUDIO
+        }
     }
 
     suspend fun restoreLastSessionIfNeeded(): com.podcastplayer.app.domain.model.Episode? {
@@ -195,6 +210,14 @@ class PlayerController private constructor(private val context: Context) {
         MediaController.releaseFuture(controllerFuture)
         executor.shutdown()
     }
+
+    /**
+     * Suspends until the underlying [MediaController] is available, then returns it.
+     *
+     * Used by the video player surface (issue #33) to bind an Android `PlayerView`
+     * to the same Player instance that drives audio playback.
+     */
+    suspend fun awaitController(): MediaController = controllerFuture.await()
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -62,7 +62,7 @@ class UrlDownloadService : Service() {
         when (action) {
             ACTION_START_PUMP -> startPumpIfNeeded()
             ACTION_CANCEL -> {
-                val id = intent.getStringExtra(EXTRA_DOWNLOAD_ID)
+                val id = intent?.getStringExtra(EXTRA_DOWNLOAD_ID)
                 if (id != null) cancelDownload(id)
             }
         }

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -1,0 +1,306 @@
+package com.podcastplayer.app.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.podcastplayer.app.MainActivity
+import com.podcastplayer.app.PodcastApplication
+import com.podcastplayer.app.data.repository.UrlDownloadRepository
+import com.podcastplayer.app.data.repository.UrlDownloadStatus
+import com.yausername.youtubedl_android.YoutubeDL
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Foreground service that drains the URL download queue (issue #33).
+ *
+ * Lifecycle:
+ * - Started via [enqueue], which inserts a row in the DB and (re)kicks the service.
+ * - Pulls newly-queued items via the repository's flow and processes them
+ *   serially. Concurrency is intentionally 1 so we don't oversubscribe the bundled
+ *   yt-dlp / ffmpeg processes on lower-end devices.
+ * - Notifies the user via a single foreground notification that updates with progress.
+ * - Stops itself when there are no more in-flight items.
+ *
+ * The repository owns DB state; this service just drives yt-dlp and reports back.
+ */
+class UrlDownloadService : Service() {
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val notifications by lazy { getSystemService(NOTIFICATION_SERVICE) as NotificationManager }
+    private val repository by lazy { UrlDownloadRepository(applicationContext) }
+
+    private val activeJobs = ConcurrentHashMap<String, Job>()
+    private val processIds = ConcurrentHashMap<String, String>()
+    private val pumpMutex = Mutex()
+    @Volatile private var stopRequested = false
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val action = intent?.action ?: ACTION_START_PUMP
+        when (action) {
+            ACTION_START_PUMP -> startPumpIfNeeded()
+            ACTION_CANCEL -> {
+                val id = intent.getStringExtra(EXTRA_DOWNLOAD_ID)
+                if (id != null) cancelDownload(id)
+            }
+        }
+        return START_STICKY
+    }
+
+    private fun startPumpIfNeeded() {
+        // Promote to foreground BEFORE starting any work so we don't get killed.
+        startInForeground(idle())
+        serviceScope.launch { pumpQueue() }
+    }
+
+    /**
+     * Drains the queue: while there are non-terminal rows, process them one at a time.
+     */
+    private suspend fun pumpQueue() {
+        pumpMutex.withLock {
+            while (!stopRequested) {
+                val nextId = nextQueuedId() ?: break
+                processOne(nextId)
+            }
+            // Nothing left to do — stop the service.
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        }
+    }
+
+    private suspend fun nextQueuedId(): String? {
+        // Snapshot the latest list and find the oldest queued row.
+        val current = repository.observeAll().first()
+        return current
+            .filter { it.status == UrlDownloadStatus.QUEUED.name }
+            .minByOrNull { it.createdAtMs }
+            ?.id
+    }
+
+    private suspend fun processOne(id: String) {
+        val entity = repository.get(id) ?: return
+        val processId = "url-dl-$id"
+        processIds[id] = processId
+
+        try {
+            // Mark extracting (a quick metadata pass) — repo already populated metadata
+            // when the row was enqueued, but we do a status flip for the UI.
+            repository.markExtracting(id)
+            updateNotification(buildProgressNotification(entity.title, 0f, "Preparing…"))
+
+            if (!PodcastApplication.youtubeDlReady) {
+                repository.markFailed(id, "Downloader not ready. Reopen the app and try again.")
+                return
+            }
+
+            val outDir = repository.downloadDir
+            val workdir = File(outDir, id).apply { mkdirs() }
+
+            val request = repository.buildDownloadRequest(entity, workdir)
+
+            repository.markDownloading(id, 0f)
+
+            // yt-dlp progress: 0..100, eta seconds, raw line.
+            YoutubeDL.getInstance().execute(request, processId) { progress, _, _ ->
+                // Coroutine launch so we don't block the streaming process.
+                serviceScope.launch {
+                    repository.markDownloading(id, progress)
+                    updateNotification(
+                        buildProgressNotification(
+                            title = entity.title,
+                            progress = progress,
+                            status = "Downloading… ${progress.toInt()}%",
+                        )
+                    )
+                }
+            }
+
+            // Locate the produced file. yt-dlp wrote into [workdir]; pick the largest
+            // playable file (the original media, not metadata sidecars).
+            val produced = pickProducedFile(workdir)
+            if (produced == null || !produced.exists()) {
+                repository.markFailed(id, "Download finished but no output file was produced.")
+                return
+            }
+
+            // Move into a flat name to keep paths predictable across reboots.
+            val finalFile = File(outDir, "${id}.${produced.extension}")
+            if (finalFile.exists()) finalFile.delete()
+            val moved = produced.renameTo(finalFile)
+            val output = if (moved) finalFile else produced
+
+            repository.markCompleted(id, output)
+            // Best-effort cleanup of leftover sidecar files.
+            workdir.listFiles()?.forEach { it.delete() }
+            workdir.delete()
+
+            updateNotification(
+                buildCompletedNotification(entity.title)
+            )
+        } catch (e: YoutubeDL.CanceledException) {
+            repository.markCanceled(id)
+        } catch (e: Throwable) {
+            Log.e(TAG, "Download $id failed", e)
+            repository.markFailed(id, e.message ?: e.javaClass.simpleName)
+        } finally {
+            activeJobs.remove(id)
+            processIds.remove(id)
+        }
+    }
+
+    private fun pickProducedFile(dir: File): File? {
+        val files = dir.listFiles()?.toList().orEmpty()
+        if (files.isEmpty()) return null
+        // Prefer mp4/mp3/m4a/webm in that order; fall back to largest.
+        val preferred = listOf("mp4", "mp3", "m4a", "webm", "opus", "aac")
+        val byPref = preferred.firstNotNullOfOrNull { ext ->
+            files.firstOrNull { it.extension.equals(ext, ignoreCase = true) }
+        }
+        return byPref ?: files.maxByOrNull { it.length() }
+    }
+
+    private fun cancelDownload(id: String) {
+        val processId = processIds[id]
+        if (processId != null) {
+            try {
+                YoutubeDL.getInstance().destroyProcessById(processId)
+            } catch (_: Throwable) {}
+        }
+        serviceScope.launch { repository.markCanceled(id) }
+    }
+
+    override fun onDestroy() {
+        stopRequested = true
+        serviceScope.coroutineContext[Job]?.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    // ─── notifications ───────────────────────────────────────────────
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val existing = notifications.getNotificationChannel(CHANNEL_ID)
+            if (existing == null) {
+                val channel = NotificationChannel(
+                    CHANNEL_ID,
+                    "URL downloads",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = "Progress for videos saved from URLs"
+                    setShowBadge(false)
+                }
+                notifications.createNotificationChannel(channel)
+            }
+        }
+    }
+
+    private fun startInForeground(notification: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun updateNotification(notification: Notification) {
+        notifications.notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun idle(): Notification = baseBuilder()
+        .setContentTitle("Vibe — preparing download")
+        .setContentText("Setting up…")
+        .setProgress(100, 0, true)
+        .setOngoing(true)
+        .build()
+
+    private fun buildProgressNotification(title: String, progress: Float, status: String): Notification {
+        return baseBuilder()
+            .setContentTitle(title.ifBlank { "Downloading" })
+            .setContentText(status)
+            .setProgress(100, progress.toInt().coerceIn(0, 100), false)
+            .setOngoing(true)
+            .build()
+    }
+
+    private fun buildCompletedNotification(title: String): Notification {
+        return baseBuilder()
+            .setContentTitle("Saved — $title")
+            .setContentText("Tap to open the home screen.")
+            .setOngoing(false)
+            .setAutoCancel(true)
+            .build()
+    }
+
+    private fun baseBuilder(): NotificationCompat.Builder {
+        val openIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pi = PendingIntent.getActivity(
+            this,
+            0,
+            openIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentIntent(pi)
+            .setOnlyAlertOnce(true)
+            .setSilent(true)
+    }
+
+    companion object {
+        private const val TAG = "UrlDownloadService"
+        private const val CHANNEL_ID = "url_downloads_channel"
+        private const val NOTIFICATION_ID = 4242
+
+        const val ACTION_START_PUMP = "com.podcastplayer.app.action.START_PUMP"
+        const val ACTION_CANCEL = "com.podcastplayer.app.action.CANCEL"
+        const val EXTRA_DOWNLOAD_ID = "download_id"
+
+        fun startPump(context: Context) {
+            val intent = Intent(context, UrlDownloadService::class.java)
+                .setAction(ACTION_START_PUMP)
+            // Foreground services started from background require startForegroundService on O+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun cancel(context: Context, downloadId: String) {
+            val intent = Intent(context, UrlDownloadService::class.java)
+                .setAction(ACTION_CANCEL)
+                .putExtra(EXTRA_DOWNLOAD_ID, downloadId)
+            context.startService(intent)
+        }
+    }
+}

--- a/app/src/test/java/com/podcastplayer/app/data/repository/UrlSourceTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/repository/UrlSourceTest.kt
@@ -1,0 +1,49 @@
+package com.podcastplayer.app.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Coverage for the URL → [UrlSource] classifier (issue #33).
+ */
+class UrlSourceTest {
+
+    @Test
+    fun `youtube com classifies as YOUTUBE`() {
+        assertEquals(UrlSource.YOUTUBE, UrlSource.classify("https://www.youtube.com/watch?v=abc"))
+        assertEquals(UrlSource.YOUTUBE, UrlSource.classify("https://m.youtube.com/watch?v=abc"))
+        assertEquals(UrlSource.YOUTUBE, UrlSource.classify("https://music.youtube.com/watch?v=abc"))
+    }
+
+    @Test
+    fun `youtu_be short link classifies as YOUTUBE`() {
+        assertEquals(UrlSource.YOUTUBE, UrlSource.classify("https://youtu.be/dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun `x com and twitter com classify as X`() {
+        assertEquals(UrlSource.X, UrlSource.classify("https://x.com/account/status/1"))
+        assertEquals(UrlSource.X, UrlSource.classify("https://twitter.com/account/status/1"))
+        assertEquals(UrlSource.X, UrlSource.classify("https://mobile.twitter.com/account/status/1"))
+    }
+
+    @Test
+    fun `unrelated hosts classify as OTHER`() {
+        assertEquals(UrlSource.OTHER, UrlSource.classify("https://example.com/anything"))
+        assertEquals(UrlSource.OTHER, UrlSource.classify("https://vimeo.com/123"))
+    }
+
+    @Test
+    fun `malformed input falls back to OTHER`() {
+        assertEquals(UrlSource.OTHER, UrlSource.classify(""))
+        assertEquals(UrlSource.OTHER, UrlSource.classify("not a url"))
+    }
+
+    @Test
+    fun `tag round-trips through fromTag`() {
+        assertEquals(UrlSource.YOUTUBE, UrlSource.fromTag("youtube"))
+        assertEquals(UrlSource.X, UrlSource.fromTag("x"))
+        assertEquals(UrlSource.OTHER, UrlSource.fromTag("other"))
+        assertEquals(UrlSource.OTHER, UrlSource.fromTag("unknown"))
+    }
+}

--- a/app/src/test/java/com/podcastplayer/app/data/repository/UrlValidatorTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/repository/UrlValidatorTest.kt
@@ -1,0 +1,84 @@
+package com.podcastplayer.app.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for URL utilities used by the "Add from URL" feature (issue #33).
+ *
+ * Pure JVM (no Android dependencies) — `Uri.parse` works on the JVM via the
+ * Robolectric-free shim in modern AGP. If the host JVM lacks `android.net.Uri`
+ * the relevant assertions are skipped via try/catch in [UrlValidator] itself.
+ */
+class UrlValidatorTest {
+
+    @Test
+    fun `extractFirstUrl returns null for blank input`() {
+        assertNull(UrlValidator.extractFirstUrl(null))
+        assertNull(UrlValidator.extractFirstUrl(""))
+        assertNull(UrlValidator.extractFirstUrl("   "))
+    }
+
+    @Test
+    fun `extractFirstUrl pulls a URL out of share-style text`() {
+        val text = "Check this out https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s 🔥"
+        val extracted = UrlValidator.extractFirstUrl(text)
+        assertNotNull(extracted)
+        assertTrue(extracted!!.startsWith("https://www.youtube.com"))
+    }
+
+    @Test
+    fun `extractFirstUrl handles youtu_be short links`() {
+        val extracted = UrlValidator.extractFirstUrl("Hey: https://youtu.be/abc-123")
+        assertEquals("https://youtu.be/abc-123", extracted)
+    }
+
+    @Test
+    fun `extractFirstUrl handles X com links`() {
+        val extracted = UrlValidator.extractFirstUrl("https://x.com/elonmusk/status/1234567890")
+        assertEquals("https://x.com/elonmusk/status/1234567890", extracted)
+    }
+
+    @Test
+    fun `isSupportedUrl recognizes YouTube and X`() {
+        assertTrue(UrlValidator.isSupportedUrl("https://www.youtube.com/watch?v=abc"))
+        assertTrue(UrlValidator.isSupportedUrl("https://youtu.be/abc"))
+        assertTrue(UrlValidator.isSupportedUrl("https://x.com/some/post"))
+        assertTrue(UrlValidator.isSupportedUrl("https://twitter.com/some/post"))
+    }
+
+    @Test
+    fun `isSupportedUrl rejects unrelated URLs`() {
+        assertFalse(UrlValidator.isSupportedUrl("https://example.com/article"))
+        assertFalse(UrlValidator.isSupportedUrl("https://vimeo.com/12345"))
+        assertFalse(UrlValidator.isSupportedUrl("not a url"))
+    }
+
+    @Test
+    fun `stableId returns the same hash for the same url and media type`() {
+        val a = UrlValidator.stableId("https://youtu.be/abc", "audio")
+        val b = UrlValidator.stableId("https://youtu.be/abc", "audio")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `stableId differentiates audio vs video for the same URL`() {
+        val audio = UrlValidator.stableId("https://youtu.be/abc", "audio")
+        val video = UrlValidator.stableId("https://youtu.be/abc", "video")
+        assertNotEquals(audio, video)
+    }
+
+    @Test
+    fun `canonicalize strips tracking params but keeps v and t`() {
+        val raw = "https://www.youtube.com/watch?v=abc&utm_source=tweet&utm_medium=share&t=120"
+        val canon = UrlValidator.canonicalize(raw)
+        assertTrue(canon.contains("v=abc"))
+        assertTrue(canon.contains("t=120"))
+        assertFalse(canon.contains("utm_"))
+    }
+}

--- a/app/src/test/java/com/podcastplayer/app/domain/model/MediaTypeTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/domain/model/MediaTypeTest.kt
@@ -1,0 +1,27 @@
+package com.podcastplayer.app.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MediaTypeTest {
+
+    @Test
+    fun `tag is the lower case enum name`() {
+        assertEquals("audio", MediaType.AUDIO.tag)
+        assertEquals("video", MediaType.VIDEO.tag)
+    }
+
+    @Test
+    fun `fromTag is round-trip safe`() {
+        assertEquals(MediaType.AUDIO, MediaType.fromTag("audio"))
+        assertEquals(MediaType.VIDEO, MediaType.fromTag("video"))
+        // Mixed case
+        assertEquals(MediaType.VIDEO, MediaType.fromTag("VIDEO"))
+    }
+
+    @Test
+    fun `fromTag falls back to AUDIO for unknown`() {
+        assertEquals(MediaType.AUDIO, MediaType.fromTag(""))
+        assertEquals(MediaType.AUDIO, MediaType.fromTag("garbage"))
+    }
+}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -49,3 +49,51 @@
 - **Home refinements:** hide Saved section on search focus; saved empty-state card with CTA.
 - **Episode detail improvements:** show episode image when available; strip HTML descriptions; show duration + date metadata.
 - **Sleep timer UX:** adjustable +/- controls, default 15 min; inline cancel when active.
+
+---
+
+# Podcast Player – Session Notes (2026-05-02)
+
+## Add from URL — YouTube / X offline downloads (issue #33)
+
+Shipped per [docs/specs/006-url-downloads.md](specs/006-url-downloads.md). Lets
+the user paste, share, or type a YouTube or X (Twitter) URL and save the audio
+(MP3) or video (MP4) for fully offline playback alongside podcast episodes.
+
+### Headlines
+
+- **Three converging entry points** — Share intent, search-paste shortcut card,
+  and a home-screen "Add from URL" chip — all open the same `AddFromUrlScreen`.
+- **On-device extraction** via [`youtubedl-android` 0.18.1](https://github.com/yausername/youtubedl-android)
+  (yt-dlp + ffmpeg). Initialized once in a new `PodcastApplication` class; the
+  yt-dlp Python script self-updates from upstream on launch.
+- **Foreground service (`dataSync`)** drains a serial queue with progress
+  notifications. Concurrency capped at 1.
+- **DB v2 → v3** — new `url_downloads` Room table, separate from
+  `downloaded_episodes`. Migration registered.
+- **Player video support** — `Episode` gains an optional `mediaType` field
+  (default `AUDIO`); `PlayerScreen` renders a Media3 `PlayerView`
+  (`VideoSurface`) in the artwork slot when the current episode is video.
+
+### Decisions (2026-05-02)
+
+- Personal/internal use only — Play Store ToS risk acknowledged and accepted.
+- Single converged screen (`AddFromUrlScreen`) for all three entry flows;
+  avoids a bottom-sheet / full-screen split.
+- Audio-default in the format picker (smaller files, podcast-like UX).
+- App-private storage at `filesDir/url_downloads/` (not external Downloads).
+- Stable IDs hash the canonicalized URL + media type so the same URL can exist
+  as audio AND video without colliding.
+- Synthetic `podcastId = "vibe-url-downloads"` keeps URL items out of
+  saved-podcast / queue logic.
+- Scope-trim: no Downloads-screen surfacing of URL items, no Wi-Fi-only
+  setting, no PiP, no cookie-auth — all flagged as v2 candidates in §15 of
+  the spec.
+
+### Open follow-ups
+
+- ABI splits for the youtubedl-android native libs to chop ~40MB off the APK.
+- Android 15 16KB-page-size verification of the bundled native libs.
+- Reconcile logic for orphaned `DOWNLOADING` rows on service start (process
+  death edge case).
+- `Downloads` screen surfacing of URL items (currently only Home).

--- a/docs/specs/006-url-downloads.md
+++ b/docs/specs/006-url-downloads.md
@@ -1,0 +1,700 @@
+# Spec: Add from URL — YouTube/X offline downloads
+
+Project: `vibe-podcast-android`
+
+Issue: [#33](https://github.com/thomasz-nyt/vibe-podcast-android/issues/33)
+
+Owner: TBD
+
+Last updated: 2026-05-02
+
+## 1) Summary
+
+Let the user paste, share, or type a YouTube or X (Twitter) URL into the app and
+save the audio (MP3) or video (MP4) for fully offline playback alongside
+podcast episodes. The new media is surfaced in a "Saved from URL" section on
+the home screen and plays through the existing Media3 pipeline.
+
+This spec keeps things on-device — no server component — and minimizes blast
+radius on the existing podcast flow by isolating URL-downloaded items in a
+separate Room table and a synthetic `podcastId`.
+
+> ⚠️ **Personal/internal use**. YouTube and X Terms of Service generally
+> prohibit unauthorized downloading. Distribution through the Play Store is
+> **not** recommended for builds with this feature enabled.
+
+---
+
+## 2) Goals
+
+1. **Three converging entry points**, all leading to the same flow:
+   - Android Share intent (`ACTION_SEND` text/plain) from YouTube / X / any app
+     that emits a URL.
+   - Pasting a URL into the existing search field → inline "Save offline" CTA.
+   - Dedicated "Add from URL" chip on the home screen.
+2. **Two output formats**, chosen by the user before download starts:
+   - Audio: extracted via ffmpeg → MP3.
+   - Video: muxed via ffmpeg → MP4 (h264 + aac when available, falling back to
+     yt-dlp's `best` selection).
+3. **Resilient downloads**:
+   - Run in a foreground service so they survive app backgrounding.
+   - Show progress in the notification shade and on the home screen.
+   - Cancelable mid-flight; failed items can be retried by re-enqueuing.
+4. **Familiar playback**:
+   - Audio items reuse the existing `PlayerScreen` (artwork + transport).
+   - Video items render a Media3 `PlayerView` in the artwork slot of the same
+     `PlayerScreen`; transport bar still drives playback.
+5. **Backward compatible**:
+   - Existing podcast download flow (`downloaded_episodes` table) is untouched.
+   - `Episode` data class extended with a default-valued `mediaType` field.
+
+---
+
+## 3) Non-goals
+
+- Cloud sync of saved URL items.
+- Captions / subtitles extraction.
+- Playlist / channel batch downloads (single video only; `--no-playlist`).
+- Authenticated downloads (e.g. age-gated YouTube content, X content behind a
+  login). Cookie support could be added later but is out of scope here.
+- Live-stream capture.
+- Picture-in-picture or background-audio-from-video hybrid modes.
+- Storage management UI beyond per-item delete (no global "X MB used" screen
+  in this iteration).
+
+---
+
+## 4) User Stories
+
+1. As a user, I tap **Share** on a YouTube video and pick this app, see a
+   preview of the title and thumbnail, choose audio or video, and tap save.
+2. As a user, I paste a YouTube URL into the search box and notice the
+   "Save offline" affordance — tapping it brings me into the same flow.
+3. As a user, I open the home screen and tap **"Add from URL"**, paste a URL,
+   and follow the same flow.
+4. As a user, I see in-flight downloads on the home screen with progress and
+   can cancel them.
+5. As a user, I tap a saved item and play it — audio plays in the existing
+   player; video items render frames inside the same player surface.
+6. As a user, I delete a saved item from the home screen and the underlying
+   file is reclaimed from disk.
+
+---
+
+## 5) Existing Architecture Touchpoints
+
+| Layer | File | Touchpoint |
+| --- | --- | --- |
+| App | `MainActivity.kt` | Add `ACTION_SEND` intent filter; route the URL into nav. |
+| App | `PodcastApplication.kt` (new) | Initialize `YoutubeDL` + `FFmpeg` on launch. |
+| Manifest | `AndroidManifest.xml` | New permissions, share filter, `UrlDownloadService` declaration, Application class. |
+| DB | `PodcastDatabase.kt` | Bump v2 → v3, add `url_downloads` entity. |
+| Domain | `Episode.kt`, `MediaType.kt` (new) | Optional `mediaType` field; new enum. |
+| Service | `UrlDownloadService.kt` (new) | Foreground (`dataSync`) service drains the queue. |
+| Service | `PlayerController.kt` | Expose `awaitController()` so video surface can bind. |
+| ViewModel | `UrlDownloadViewModel.kt` (new) | Owns preview state + completed/in-flight flows. |
+| UI | `AddFromUrlScreen.kt` (new) | Single converged entry point. |
+| UI | `VideoSurface.kt` (new) | Compose wrapper around Media3 `PlayerView`. |
+| UI | `HomeScreen.kt` | "Add from URL" chip; "Saving from URL" + "Saved from URL" sections. |
+| UI | `PodcastListScreen.kt` | Pasted-URL detection card. |
+| UI | `PodcastNavHost.kt` | New `add-url?url={url}` route; share-intent handoff. |
+
+---
+
+## 6) Data Model (Room)
+
+### 6.1 New entity: `UrlDownloadEntity`
+
+Stores one row per `(URL, mediaType)` pair. Distinct from `downloaded_episodes`
+so URL items can be queried, deleted, and surfaced separately on the home
+screen without polluting RSS-podcast flows.
+
+```kotlin
+@Entity(tableName = "url_downloads")
+data class UrlDownloadEntity(
+    @PrimaryKey
+    val id: String,                 // SHA-1 of canonical(URL) + "|" + mediaType
+    val sourceUrl: String,
+    val source: String,             // "youtube" | "x" | "other"
+    val title: String,
+    val uploader: String?,
+    val thumbnailUrl: String?,
+    val mediaType: String,          // "audio" | "video"
+    val localPath: String?,         // set once status == COMPLETED
+    val durationMs: Long?,
+    val fileSize: Long?,
+    val status: String,             // UrlDownloadStatus.name
+    val progressPercent: Float,     // 0..100
+    val errorMessage: String?,
+    val createdAtMs: Long,
+    val completedAtMs: Long?,
+)
+```
+
+**Identity**: `id = sha1(canonicalize(sourceUrl) + "|" + mediaType)`.
+- Same URL + same format ⇒ same id ⇒ duplicate downloads collapse.
+- Same URL but audio vs. video ⇒ two distinct rows can coexist.
+
+`canonicalize` strips `www.`, lowercases the host, and drops tracking params
+(`utm_*`, `fbclid`, etc.) while keeping meaningful ones (`v`, `list`, `t`,
+`start`).
+
+### 6.2 DAO
+
+```kotlin
+@Dao
+interface UrlDownloadDao {
+    @Query("SELECT * FROM url_downloads ORDER BY createdAtMs DESC")
+    fun observeAll(): Flow<List<UrlDownloadEntity>>
+
+    @Query("SELECT * FROM url_downloads WHERE status = :status ORDER BY createdAtMs DESC")
+    fun observeByStatus(status: String): Flow<List<UrlDownloadEntity>>
+
+    @Query("SELECT * FROM url_downloads WHERE id = :id")
+    suspend fun getById(id: String): UrlDownloadEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: UrlDownloadEntity)
+
+    @Query("UPDATE url_downloads SET status = :status, progressPercent = :progress, errorMessage = :error WHERE id = :id")
+    suspend fun updateProgress(id: String, status: String, progress: Float, error: String?)
+
+    @Query(
+        """
+        UPDATE url_downloads
+        SET status = :status, localPath = :localPath, fileSize = :fileSize,
+            progressPercent = 100, completedAtMs = :completedAtMs, errorMessage = NULL
+        WHERE id = :id
+        """
+    )
+    suspend fun markCompleted(id: String, status: String, localPath: String, fileSize: Long, completedAtMs: Long)
+
+    @Query("UPDATE url_downloads SET status = :status, errorMessage = :error WHERE id = :id")
+    suspend fun markFailed(id: String, status: String, error: String?)
+
+    @Query("DELETE FROM url_downloads WHERE id = :id")
+    suspend fun deleteById(id: String)
+}
+```
+
+### 6.3 Database changes
+
+```kotlin
+@Database(
+    entities = [
+        DownloadedEpisodeEntity::class,
+        PlaybackProgressEntity::class,
+        UrlDownloadEntity::class,
+    ],
+    version = 3,
+)
+abstract class PodcastDatabase : RoomDatabase() {
+    abstract fun urlDownloadDao(): UrlDownloadDao
+    // ...existing DAOs
+}
+```
+
+### 6.4 Migration v2 → v3
+
+```kotlin
+val MIGRATION_2_3 = object : Migration(2, 3) {
+  override fun migrate(db: SupportSQLiteDatabase) {
+    db.execSQL("""
+      CREATE TABLE IF NOT EXISTS url_downloads (
+        id TEXT NOT NULL,
+        sourceUrl TEXT NOT NULL,
+        source TEXT NOT NULL,
+        title TEXT NOT NULL,
+        uploader TEXT,
+        thumbnailUrl TEXT,
+        mediaType TEXT NOT NULL,
+        localPath TEXT,
+        durationMs INTEGER,
+        fileSize INTEGER,
+        status TEXT NOT NULL,
+        progressPercent REAL NOT NULL,
+        errorMessage TEXT,
+        createdAtMs INTEGER NOT NULL,
+        completedAtMs INTEGER,
+        PRIMARY KEY(id)
+      )
+    """.trimIndent())
+  }
+}
+```
+
+Registered in `DatabaseProvider.addMigrations(MIGRATION_1_2, MIGRATION_2_3)`.
+
+---
+
+## 7) Domain Model / Mapping
+
+### 7.1 New: `MediaType` enum
+
+```kotlin
+enum class MediaType {
+    AUDIO,
+    VIDEO;
+    val tag: String get() = name.lowercase()
+    companion object {
+        fun fromTag(tag: String): MediaType =
+            entries.firstOrNull { it.tag == tag.lowercase() } ?: AUDIO
+    }
+}
+```
+
+### 7.2 `Episode` extension
+
+```kotlin
+data class Episode(
+    // existing fields...
+    val mediaType: MediaType = MediaType.AUDIO,  // <-- new, default for back-compat
+)
+```
+
+The default keeps every existing call site source-compatible. URL-downloaded
+items set this to `MediaType.VIDEO` when the user picked the video format.
+
+### 7.3 Synthetic podcastId
+
+URL-downloaded items map to `Episode` with:
+
+- `id = "url:${entity.id}"` — distinct namespace from RSS episode ids.
+- `podcastId = "vibe-url-downloads"` — synthetic, never matches a real iTunes
+  podcast id, keeping queue and saved-podcast logic from accidentally picking
+  these up.
+- `localPath` set to the on-disk file.
+- `mediaType` derived from `entity.mediaType`.
+
+### 7.4 URL classification
+
+`UrlSource.classify(rawUrl)` returns `YOUTUBE | X | OTHER` based on host
+matching. Hosts include `youtube.com`, `m.youtube.com`, `music.youtube.com`,
+`youtu.be`, `x.com`, `twitter.com`, `mobile.twitter.com`.
+
+Unsupported URLs render an error in the AddFromUrl screen rather than
+attempting a download (yt-dlp can in principle handle far more sites, but we
+want a confident UX surface for v1).
+
+---
+
+## 8) Download Pipeline
+
+### 8.1 Native init (PodcastApplication)
+
+`PodcastApplication.onCreate` runs (off the main thread):
+
+1. `YoutubeDL.getInstance().init(this)` — unpacks the bundled Python runtime
+   and yt-dlp script on first launch (idempotent on subsequent launches).
+2. `FFmpeg.getInstance().init(this)` — unpacks the bundled ffmpeg.
+3. Best-effort `YoutubeDL.updateYoutubeDL(this, UpdateChannel.STABLE)` — pulls
+   the latest yt-dlp from upstream so platform changes don't break extraction.
+
+A volatile flag `PodcastApplication.youtubeDlReady` flips to `true` once init
+succeeds. The repository checks this gate before invoking yt-dlp and falls
+back to a user-visible error if false (typical only on first launch with no
+network).
+
+### 8.2 Repository (UrlDownloadRepository)
+
+Public surface:
+
+```kotlin
+class UrlDownloadRepository(context: Context) {
+    val downloadDir: File   // filesDir/url_downloads/
+
+    fun observeAll(): Flow<List<UrlDownloadEntity>>
+    fun observeCompleted(): Flow<List<UrlDownloadEntity>>
+    fun observeInFlight(): Flow<List<UrlDownloadEntity>>
+    fun observe(id: String): Flow<UrlDownloadEntity?>
+
+    suspend fun fetchMetadata(rawUrl: String): UrlMetadata?
+    suspend fun enqueue(rawUrl: String, mediaType: MediaType, prefetched: UrlMetadata? = null): String
+    suspend fun delete(id: String): Result<Unit>
+    fun toEpisode(entity: UrlDownloadEntity): Episode?
+
+    // mutators called by the service
+    suspend fun markExtracting(id: String)
+    suspend fun markDownloading(id: String, progress: Float)
+    suspend fun markFailed(id: String, message: String?)
+    suspend fun markCanceled(id: String)
+    suspend fun markCompleted(id: String, file: File)
+
+    fun buildDownloadRequest(entity: UrlDownloadEntity, outputTemplate: File): YoutubeDLRequest
+}
+```
+
+### 8.3 Format selection
+
+Encoded into the `YoutubeDLRequest` returned by `buildDownloadRequest`:
+
+| Media type | yt-dlp options |
+| --- | --- |
+| Audio | `-x`, `--audio-format mp3`, `--audio-quality 0`, `-f "bestaudio/best"` |
+| Video | `-f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"`, `--merge-output-format mp4` |
+
+Common: `--no-playlist`, `--no-mtime`, `--socket-timeout 30`,
+`-o "{outdir}/%(id)s.%(ext)s"`.
+
+### 8.4 Storage location
+
+App-private under `Context.filesDir/url_downloads/`. Each in-flight item
+downloads into a per-id subdirectory; on success the produced file is moved to
+`url_downloads/{id}.{ext}` and the workdir is deleted.
+
+App-private (rather than `Environment.DIRECTORY_DOWNLOADS`) keeps ToS exposure
+minimal — files aren't visible to other apps.
+
+### 8.5 Foreground service (UrlDownloadService)
+
+Single-instance foreground service with `foregroundServiceType="dataSync"` and
+the `FOREGROUND_SERVICE_DATA_SYNC` permission. Lifecycle:
+
+1. `enqueue` inserts a `QUEUED` row.
+2. `UrlDownloadService.startPump(context)` is called; the service promotes
+   itself to foreground with a generic "preparing…" notification.
+3. The pump (a single-flight coroutine) drains the queue serially:
+   - Find the oldest `QUEUED` row.
+   - Mark `EXTRACTING_METADATA`, then `DOWNLOADING`.
+   - Run `YoutubeDL.execute(request)` with a progress callback that updates
+     the DB row + the notification.
+   - On completion: locate the produced file (prefer mp4/mp3/m4a/webm,
+     fallback to largest), move it into `url_downloads/{id}.{ext}`, mark
+     `COMPLETED`.
+4. When no more `QUEUED` rows remain, the service stops itself.
+
+Concurrency is intentionally **1**: yt-dlp + ffmpeg are CPU-heavy and
+oversubscribing on lower-end devices is bad. (Future: configurable.)
+
+Cancel: `UrlDownloadService.cancel(context, id)` invokes
+`YoutubeDL.destroyProcessById("url-dl-$id")`, which kills the underlying
+process; the service catches `CanceledException` and marks the row `CANCELED`.
+
+### 8.6 Status state machine
+
+```
+QUEUED → EXTRACTING_METADATA → DOWNLOADING → COMPLETED
+                              ↘ FAILED
+                              ↘ CANCELED
+```
+
+Statuses are persisted as the enum's `name` (`String`) on `status` to keep the
+schema migration-friendly.
+
+---
+
+## 9) UI / UX Changes
+
+### 9.1 Routes
+
+`PodcastNavHost` adds a new route:
+
+```
+"add-url?url={url}"  → AddFromUrlScreen
+```
+
+`url` is optional. When entered via Share or paste, it's URL-encoded into the
+route arg; when entered via the dedicated chip, the screen opens with an
+empty field.
+
+### 9.2 AddFromUrlScreen
+
+Vertical stack:
+
+1. `VibeTopBar` with eyebrow "OFFLINE · YOUTUBE / X" + back button.
+2. URL input card (BasicTextField with monospace font).
+3. Metadata preview area, transitioning through:
+   - **Idle** — illustration + tagline.
+   - **Loading** — skeleton card with spinner.
+   - **Loaded** — thumbnail (16:9), source chip, duration chip, title (≤3
+     lines), uploader.
+   - **Error** — `LinkOff` glyph + message ("Couldn't read that URL. It may be
+     private, age-gated, or temporarily unavailable.").
+4. Format picker (when `Loaded`): two square tiles (`Audio` / `Video`) with a
+   selected accent. Audio is the default.
+5. Primary CTA pill: **"Save audio offline" / "Save video offline"** depending
+   on selection.
+
+### 9.3 Home screen sections
+
+Order (top to bottom):
+
+- Greeting header.
+- Quick-action row (currently just "Add from URL" chip).
+- "Saving from URL" — vertical column of in-flight items with progress bars
+  and cancel button. Hidden when empty.
+- "Continue listening" — existing.
+- "Saved from URL" — horizontally-scrolling row of completed URL downloads.
+  Each card has thumbnail, source badge, format badge (AUDIO/VIDEO), title,
+  uploader, and a tiny delete affordance. Hidden when empty.
+- "Your subscriptions" — existing (unless empty AND no URL items, in which
+  case the existing empty-state copy is broadened: "Search for podcasts, or
+  paste a YouTube / X link to save offline.").
+
+### 9.4 Search-screen URL detection
+
+When the user types/pastes text into the search field that matches a YouTube
+or X URL (`UrlValidator.extractFirstUrl` + `UrlSource.classify`), an inline
+`UrlDownloadShortcutCard` appears between the input and the results:
+
+```
+┌────────────────────────────────────────────┐
+│ [↓] Save this YouTube link offline         │
+│      https://youtu.be/dQw4w9WgXcQ          │
+└────────────────────────────────────────────┘
+```
+
+Tapping it clears focus and navigates to `add-url?url={url}`.
+
+### 9.5 Share intent
+
+`MainActivity` is `singleTask` and registers:
+
+```xml
+<intent-filter>
+  <action android:name="android.intent.action.SEND" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <data android:mimeType="text/plain" />
+</intent-filter>
+```
+
+`MainActivity.extractSharedUrl()` pulls the first http(s) URL out of
+`Intent.EXTRA_TEXT`. The activity exposes a `pendingShareUrl` Compose state;
+`PodcastNavHost`'s `LaunchedEffect(sharedUrl)` navigates to
+`add-url?url={url}` and clears the slot via `onSharedUrlConsumed`.
+
+A commented-out `ACTION_VIEW` filter exists in the manifest for direct
+URL-launch handling — left disabled by default to avoid fighting the official
+YouTube / X apps.
+
+### 9.6 Player screen — video support
+
+`PlayerScreen` checks `episode.mediaType`:
+
+- `AUDIO` (default) — renders the existing `AsyncImage` artwork box.
+- `VIDEO` — renders a new `VideoSurface()` composable in the same slot, both
+  for the portrait and landscape layouts.
+
+`VideoSurface` is an `AndroidView` wrapper around Media3's `PlayerView`. It
+awaits `PlayerController.awaitController()` (a new method exposing the
+underlying `MediaController`) and binds it as the view's player. The Media3
+`PlayerView`'s built-in controls are disabled (`useController = false`) so
+the existing custom transport bar continues to drive playback.
+
+`PlayerController.getCurrentEpisode()` infers `MediaType` from the file
+extension (`mp4`, `webm`, `mkv`, `mov`, `avi`, `m4v` → VIDEO; else AUDIO) so
+restored sessions render correctly even though `MediaItem` metadata doesn't
+carry a media-type marker.
+
+---
+
+## 10) Repository / ViewModel Integration
+
+### 10.1 ViewModel: `UrlDownloadViewModel : AndroidViewModel`
+
+```kotlin
+class UrlDownloadViewModel(application: Application) : AndroidViewModel(application) {
+    val previewState: StateFlow<UrlPreviewState>          // Idle | Loading | Loaded | Error
+    val selectedMediaType: StateFlow<MediaType>           // user toggle
+    val completedDownloads: StateFlow<List<UrlDownloadEntity>>
+    val inFlightDownloads: StateFlow<List<UrlDownloadEntity>>
+
+    fun loadPreview(rawUrl: String)
+    fun setMediaType(mediaType: MediaType)
+    fun confirmCurrentDownload()                          // enqueue + startPump
+    fun deleteDownload(id: String)
+    fun cancelDownload(id: String)
+    fun resetPreview()
+}
+```
+
+Constructed via a manual `UrlDownloadViewModelFactory(application)` mirroring
+the codebase convention (no DI).
+
+### 10.2 Manual factories
+
+`PodcastNavHost` builds three top-level ViewModels:
+
+| ViewModel | Factory | New? |
+| --- | --- | --- |
+| PodcastViewModel | PodcastViewModelFactory | existing |
+| PlayerViewModel | PlayerViewModelFactory | existing |
+| UrlDownloadViewModel | UrlDownloadViewModelFactory | new |
+
+All three remain scoped at the `PodcastNavHost` so state survives navigation.
+
+### 10.3 Wiring summary
+
+```
+[Share / Paste / Chip]
+        │
+        ▼
+PodcastNavHost ── nav("add-url?url=…") ──▶ AddFromUrlScreen
+        │                                          │
+        │                            confirmCurrentDownload()
+        │                                          │
+        ▼                                          ▼
+UrlDownloadViewModel ──── enqueue ──▶ UrlDownloadRepository ──▶ Room
+                                              │
+                                  startPump(context)
+                                              │
+                                              ▼
+                                   UrlDownloadService (FG)
+                                              │
+                            yt-dlp execute + progress callback
+                                              │
+                                  markDownloading / markCompleted
+                                              │
+                                              ▼
+                                          Room
+                                              │
+                  observeCompleted / observeInFlight (StateFlow)
+                                              │
+                                              ▼
+                                       HomeScreen renders
+```
+
+---
+
+## 11) Edge Cases / Rules
+
+- **Duplicate dedupe**: enqueue checks for an existing row in
+  `IN_FLIGHT_STATUSES + COMPLETED`; if found, returns the existing id with no
+  side effects. Repeat enqueues of failed/canceled items reset the row and
+  re-queue.
+- **Live streams / unknown duration**: `VideoInfo.duration` is `0` on absent;
+  treated as null in our model. The download itself still succeeds when
+  yt-dlp can resolve a finite stream; live streams are not supported.
+- **Auth-walled X content**: `fetchMetadata` returns null; the AddFromUrl
+  screen shows the generic error. Cookie-based auth is out of scope.
+- **Very large videos**: no hard size cap. Storage management UI is
+  intentionally minimal in v1 (per-item delete only).
+- **Concurrent shares**: `MainActivity` is `singleTask`. A second share while
+  the AddFromUrl screen is already open re-enters via `onNewIntent`, updates
+  `pendingShareUrl`, and the nav effect navigates to a fresh route arg.
+- **Process death during download**: the foreground service keeps the process
+  alive; if the OS still reaps it (unlikely for `dataSync`), the row is left
+  in `DOWNLOADING` state. The next time the service starts, it picks up only
+  `QUEUED` rows — orphan in-flight rows show up to the user as stuck. (Future:
+  reconcile non-`QUEUED` rows on service start.)
+- **yt-dlp binary outdated**: the `youtubeDlReady` gate ensures we don't
+  attempt extraction before init. The on-launch `updateYoutubeDL` call is
+  best-effort; a stale binary may cause 4xx-style errors that surface as
+  `FAILED`.
+
+---
+
+## 12) Performance & Storage
+
+- **APK size**: `youtubedl-android` 0.18.1 + ffmpeg adds ~50MB to the APK from
+  the bundled Python runtime + binaries. ABI splits could chop this in 4 — out
+  of scope for v1; flag for release builds.
+- **First-launch unpacking**: `YoutubeDL.init` writes ~20MB of unpacked
+  binaries to `noBackupFilesDir`. One-time cost per install.
+- **Concurrent downloads**: capped at 1 to avoid CPU/RAM oversubscription.
+  Sequential queue drains predictably even on low-end devices.
+- **Progress writes**: yt-dlp emits a progress callback at variable rates
+  (sub-second). We serialize each tick into a `UPDATE` query — minor write
+  amplification but bounded by the underlying media duration. Not enough to
+  warrant debouncing for v1.
+- **Notification updates**: `setOnlyAlertOnce(true)` and `setSilent(true)`
+  prevent buzz / sound spam.
+
+---
+
+## 13) Testing Checklist
+
+### 13.1 Unit tests (JVM)
+
+Located in `app/src/test/java/com/podcastplayer/app/`:
+
+- `UrlSourceTest`:
+  - YouTube hosts (incl. `m.`, `music.`, `youtu.be`) classify YOUTUBE.
+  - X / Twitter hosts classify X.
+  - Unrelated hosts classify OTHER.
+  - Malformed input falls back to OTHER.
+  - `tag` → `fromTag` round-trips.
+- `UrlValidatorTest`:
+  - `extractFirstUrl` returns null for blank input; pulls a URL out of
+    share-style text; handles `youtu.be` short links and X URLs.
+  - `isSupportedUrl` recognizes YouTube/X, rejects unrelated.
+  - `stableId` is deterministic and differentiates `audio` vs `video`.
+  - `canonicalize` strips `utm_*` but keeps `v` and `t`.
+- `MediaTypeTest`:
+  - `tag` is the lower-case enum name.
+  - `fromTag` is round-trip safe and falls back to `AUDIO` for unknown.
+
+### 13.2 Migration tests (instrumented)
+
+- Create v2 DB with `downloaded_episodes` + `playback_progress` populated.
+- Run migration 2→3.
+- Verify `url_downloads` table exists and existing tables are intact.
+
+### 13.3 Integration tests (instrumented; future)
+
+- Mock `YoutubeDL` and verify `UrlDownloadService` calls
+  `markDownloading`/`markCompleted` in the correct sequence.
+- Verify `enqueue` is idempotent for duplicate URL+mediaType pairs.
+- Verify `delete` removes both the row and the file.
+
+### 13.4 UI tests (Compose; future)
+
+- `AddFromUrlScreen`:
+  - Loaded state renders thumbnail, title, audio/video selector, CTA.
+  - Tapping CTA invokes `onConfirm`.
+- `HomeScreen` renders the URL-downloads section when items exist; empty when
+  none; in-flight column visible when downloads in progress.
+
+### 13.5 Manual QA checklist
+
+- Paste `https://www.youtube.com/watch?v=dQw4w9WgXcQ` into search → "Save
+  offline" affordance appears.
+- Tap it → metadata preview loads (title, thumbnail, duration).
+- Pick "Audio" → tap save → notification appears with progress.
+- In-flight row appears in home-screen "Saving from URL".
+- On completion, row moves to "Saved from URL"; tap to play in audio player.
+- Repeat with "Video" → `PlayerScreen` renders frames in the artwork slot.
+- Share a YouTube URL from the YouTube app → routes into AddFromUrl screen.
+- Share an X URL → metadata extraction works.
+- Cancel an in-flight download from the home-screen card → row disappears.
+- Delete a completed item → file is removed from `filesDir/url_downloads/`.
+- Restart app while video is playing → frames continue to render after
+  session restore.
+
+---
+
+## 14) Rollout Plan
+
+1. Land manifest + dependencies + Application class (Phase 1).
+2. Land `MediaType`, `Episode.mediaType`, `UrlDownloadEntity`, DAO, migration
+   v2→v3 (Phase 2).
+3. Land `UrlDownloadRepository`, `UrlSource`, `UrlValidator` (Phase 3).
+4. Land `UrlDownloadService` (Phase 4).
+5. Land share intent on `MainActivity` (Phase 5).
+6. Land search-screen URL detection (Phase 6).
+7. Land `AddFromUrlScreen` + ViewModel + factory (Phase 7).
+8. Land home-screen sections + nav route (Phase 8 + 9).
+9. Land `VideoSurface` + PlayerScreen integration (Phase 10).
+10. Unit tests (Phase 13).
+11. Update docs (this spec, README, CLAUDE.md) (Phase 14).
+
+All phases land in a single PR for #33 since the feature is meaningful only
+end-to-end.
+
+---
+
+## 15) Open Questions
+
+- Should the search-screen "Save offline" affordance also detect non-YouTube/X
+  URLs that yt-dlp supports (e.g. Vimeo, SoundCloud)? Currently we hide it for
+  `OTHER` to keep the UX confident.
+- Should `Downloads` screen also list URL items, or remain RSS-podcast only?
+  Currently the Home screen is the only surface; revisit if users get lost.
+- Should we expose a "Wi-Fi only" download preference? Out of scope for v1
+  but a likely follow-up.
+- Should we support "Download as both audio and video"? Today the user picks
+  one; the dedupe key allows both rows to coexist if they enqueue twice.
+- Should we add cookie support for X auth-walled content? Powerful but raises
+  the security/UX bar significantly.
+- Should we add picture-in-picture for video items? Native Android API exists
+  but requires Activity work.


### PR DESCRIPTION
## Summary

Closes #33. Lets users paste, share, or type a YouTube or X (Twitter) URL and save the audio (MP3) or video (MP4) for fully offline playback alongside podcast episodes.

Full design captured in [`docs/specs/006-url-downloads.md`](docs/specs/006-url-downloads.md).

## What's in this PR

**Three converging entry points** all open the same `AddFromUrlScreen`:
1. **Share intent** — `MainActivity` is `singleTask` and registers `ACTION_SEND` text/plain
2. **Search-screen paste** — pasting a YouTube/X URL surfaces a "Save offline" affordance
3. **Home-screen "Add from URL" chip**

**Pipeline**:
- `PodcastApplication` initializes yt-dlp + ffmpeg on first launch (and self-updates yt-dlp).
- `UrlDownloadRepository` extracts metadata via `yt-dlp --dump-json`, owns the `url_downloads` Room table (DB v3, with migration), and maps completed entities to `Episode`.
- `UrlDownloadService` is a foreground (`dataSync`) service that drains the queue serially with progress notifications.
- The user picks audio (MP3, extracted via ffmpeg) or video (MP4, h264+aac merged) at download time.

**Playback**:
- Completed items show in a "Saved from URL" home-screen section.
- `PlayerScreen` renders a Media3 `PlayerView` (`VideoSurface`) when the current episode is video; audio falls back to the existing artwork view.
- `PlayerController.getCurrentEpisode` infers `MediaType` from the file extension so restored sessions render correctly.

## Acceptance criteria (from #33)

- [x] user should be able to paste / share a video url into this app
- [x] the app should be able to download the X or Youtube video via the URL
- [x] the downloaded video/audio podcast should have a dedicate section in home screen
- [x] the downloaded video should be able to play with normal video play controls

## Test plan

- [x] On a clean install, paste `https://www.youtube.com/watch?v=...` into the search box; verify the "Save offline" affordance appears.
- [x] Tap it; verify metadata preview (title, thumbnail, duration) loads.
- [x] Pick "Audio"; tap save; verify a notification appears with progress, and a row shows in the home-screen "Saving from URL" section.
- [x] When complete, the row moves to "Saved from URL"; tap it to play through the existing player.
- [x] Repeat with "Video"; verify `PlayerScreen` renders frames in the artwork slot.
- [x] Share a YouTube URL from the YouTube app; verify it routes into the AddFromUrl screen.
- [x] Share an X URL; verify metadata extraction works.
- [x] Cancel an in-flight download from the home-screen card; verify the row clears.
- [x] Delete a completed item from the home-screen card; verify the file is removed from `filesDir/url_downloads/`.
- [x] Run `./gradlew test` — verifies `UrlSourceTest`, `UrlValidatorTest`, `MediaTypeTest` pass.

## Notes / risks

- ⚠️ **Personal/internal use** — YouTube/X ToS generally prohibits unauthorized downloading. Not recommended for Play Store distribution.
- APK size grows ~50MB from the bundled Python runtime.
- yt-dlp binary self-updates on launch; if YouTube/X change their internal APIs and an update isn't yet available, metadata extraction may fail until upstream catches up.
- 16KB-page-size compatibility on Android 15+ depends on `youtubedl-android` 0.18.1's native libs being rebuilt; verify before any release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)