### PR TITLE
Add queue export/import support to OPML functionality

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/local/OpmlManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/OpmlManager.kt
@@ -7,13 +7,22 @@ import org.xmlpull.v1.XmlPullParserFactory
 import java.io.InputStream
 import java.io.OutputStream
 
+data class OpmlExportSummary(val podcastCount: Int, val queueCount: Int)
+data class OpmlImportData(val podcasts: List<Podcast>, val queues: List<QueueStorage.QueuePayload>)
+
 object OpmlManager {
 
     private const val NS_PODCASTPLAYER = "https://podcastplayer.com/opml"
 
-    fun writeOpml(podcasts: List<Podcast>, outputStream: OutputStream): Result<Int> {
+    fun writeOpml(
+        podcasts: List<Podcast>,
+        queues: List<QueueStorage.QueuePayload>,
+        outputStream: OutputStream,
+    ): Result<OpmlExportSummary> {
         return try {
             val exportable = podcasts.filter { it.feedUrl != null }
+            val exportableQueues = queues.filter { it.podcastIds.isNotEmpty() }
+
             val serializer = Xml.newSerializer()
             serializer.setOutput(outputStream, "UTF-8")
             serializer.startDocument("UTF-8", true)
@@ -41,19 +50,36 @@ object OpmlManager {
                 }
                 serializer.endTag(null, "outline")
             }
-            serializer.endTag(null, "body")
 
+            if (exportableQueues.isNotEmpty()) {
+                serializer.startTag(NS_PODCASTPLAYER, "queues")
+                for (queue in exportableQueues) {
+                    serializer.startTag(NS_PODCASTPLAYER, "queue")
+                    serializer.attribute(null, "id", queue.id)
+                    serializer.attribute(null, "name", queue.name)
+                    serializer.attribute(null, "createdAt", queue.createdAt.toString())
+                    for (podcastId in queue.podcastIds) {
+                        serializer.startTag(NS_PODCASTPLAYER, "item")
+                        serializer.attribute(null, "id", podcastId)
+                        serializer.endTag(NS_PODCASTPLAYER, "item")
+                    }
+                    serializer.endTag(NS_PODCASTPLAYER, "queue")
+                }
+                serializer.endTag(NS_PODCASTPLAYER, "queues")
+            }
+
+            serializer.endTag(null, "body")
             serializer.endTag(null, "opml")
             serializer.endDocument()
             serializer.flush()
 
-            Result.success(exportable.size)
+            Result.success(OpmlExportSummary(exportable.size, exportableQueues.size))
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 
-    fun readOpml(inputStream: InputStream): Result<List<Podcast>> {
+    fun readOpml(inputStream: InputStream): Result<OpmlImportData> {
         return try {
             val factory = XmlPullParserFactory.newInstance()
             factory.isNamespaceAware = true
@@ -61,37 +87,78 @@ object OpmlManager {
             parser.setInput(inputStream, null)
 
             val podcasts = mutableListOf<Podcast>()
+            val queues = mutableListOf<QueueStorage.QueuePayload>()
+
+            var currentQueueId: String? = null
+            var currentQueueName: String? = null
+            var currentQueueCreatedAt: Long? = null
+            val currentQueueItems = mutableListOf<String>()
+
             var eventType = parser.eventType
-
             while (eventType != XmlPullParser.END_DOCUMENT) {
-                if (eventType == XmlPullParser.START_TAG && parser.name == "outline") {
-                    val type = parser.getAttributeValue(null, "type")
-                    val xmlUrl = parser.getAttributeValue(null, "xmlUrl")
+                val ns = parser.namespace
+                val tag = parser.name
 
-                    if (type?.equals("rss", ignoreCase = true) == true && !xmlUrl.isNullOrBlank()) {
-                        val customId = parser.getAttributeValue(NS_PODCASTPLAYER, "id")
-                        val customArtist = parser.getAttributeValue(NS_PODCASTPLAYER, "artist")
-                        val customArtwork = parser.getAttributeValue(NS_PODCASTPLAYER, "artworkUrl")
-
-                        val text = parser.getAttributeValue(null, "text")
-                            ?: parser.getAttributeValue(null, "title")
-                            ?: ""
-
-                        podcasts.add(
-                            Podcast(
-                                id = customId ?: xmlUrl,
-                                title = text,
-                                artist = customArtist ?: "",
-                                artworkUrl = customArtwork,
-                                feedUrl = xmlUrl,
+                if (eventType == XmlPullParser.START_TAG) {
+                    when {
+                        tag == "outline" && ns.isNullOrEmpty() -> {
+                            val type = parser.getAttributeValue(null, "type")
+                            val xmlUrl = parser.getAttributeValue(null, "xmlUrl")
+                            if (type?.equals("rss", ignoreCase = true) == true && !xmlUrl.isNullOrBlank()) {
+                                val customId = parser.getAttributeValue(NS_PODCASTPLAYER, "id")
+                                val customArtist = parser.getAttributeValue(NS_PODCASTPLAYER, "artist")
+                                val customArtwork = parser.getAttributeValue(NS_PODCASTPLAYER, "artworkUrl")
+                                val text = parser.getAttributeValue(null, "text")
+                                    ?: parser.getAttributeValue(null, "title")
+                                    ?: ""
+                                podcasts.add(
+                                    Podcast(
+                                        id = customId ?: xmlUrl,
+                                        title = text,
+                                        artist = customArtist ?: "",
+                                        artworkUrl = customArtwork,
+                                        feedUrl = xmlUrl,
+                                    )
+                                )
+                            }
+                        }
+                        tag == "queue" && ns == NS_PODCASTPLAYER -> {
+                            currentQueueId = parser.getAttributeValue(null, "id")
+                            currentQueueName = parser.getAttributeValue(null, "name")
+                            currentQueueCreatedAt = parser.getAttributeValue(null, "createdAt")?.toLongOrNull()
+                            currentQueueItems.clear()
+                        }
+                        tag == "item" && ns == NS_PODCASTPLAYER -> {
+                            val podcastId = parser.getAttributeValue(null, "id")
+                            if (!podcastId.isNullOrBlank()) currentQueueItems.add(podcastId)
+                        }
+                    }
+                } else if (eventType == XmlPullParser.END_TAG) {
+                    if (tag == "queue" && ns == NS_PODCASTPLAYER) {
+                        val id = currentQueueId
+                        val name = currentQueueName
+                        val createdAt = currentQueueCreatedAt
+                        if (id != null && name != null && createdAt != null) {
+                            queues.add(
+                                QueueStorage.QueuePayload(
+                                    id = id,
+                                    name = name,
+                                    createdAt = createdAt,
+                                    podcastIds = currentQueueItems.toList(),
+                                )
                             )
-                        )
+                        }
+                        currentQueueId = null
+                        currentQueueName = null
+                        currentQueueCreatedAt = null
+                        currentQueueItems.clear()
                     }
                 }
+
                 eventType = parser.next()
             }
 
-            Result.success(podcasts)
+            Result.success(OpmlImportData(podcasts, queues))
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/podcastplayer/app/data/local/QueueStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/QueueStorage.kt
@@ -124,6 +124,19 @@ class QueueStorage(context: Context) {
         return _queues.value.filter { it.podcastIds.contains(podcastId) }.map { it.id }.toSet()
     }
 
+    suspend fun mergeImportedQueues(imported: List<QueuePayload>) = mutex.withLock {
+        if (imported.isEmpty()) return@withLock
+        val existing = _queues.value
+        // Drop the auto-created empty "Morning" if it's the only queue, to avoid duplicates.
+        val base = if (existing.size == 1 &&
+            existing[0].name == "Morning" &&
+            existing[0].podcastIds.isEmpty()
+        ) emptyList() else existing
+        val byId = base.associateBy { it.id }.toMutableMap()
+        for (q in imported) byId[q.id] = q
+        persist(byId.values.toList())
+    }
+
     private fun persist(list: List<QueuePayload>) {
         prefs.edit().putString(KEY_QUEUES, gson.toJson(list)).apply()
         _queues.value = list

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -117,8 +117,10 @@ fun PodcastListScreen(
     LaunchedEffect(opmlResult) {
         val result = opmlResult ?: return@LaunchedEffect
         val message = when (result) {
-            is OpmlResult.ExportSuccess -> "Exported ${result.count} subscriptions"
-            is OpmlResult.ImportSuccess -> "Imported ${result.count} subscriptions"
+            is OpmlResult.ExportSuccess -> "Exported ${result.podcastCount} subscriptions" +
+                if (result.queueCount > 0) " and ${result.queueCount} queues" else ""
+            is OpmlResult.ImportSuccess -> "Imported ${result.podcastCount} subscriptions" +
+                if (result.queueCount > 0) " and ${result.queueCount} queues" else ""
             is OpmlResult.Error -> "Error: ${result.message}"
         }
         snackbarHostState.showSnackbar(message)

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -2,6 +2,8 @@ package com.podcastplayer.app.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.podcastplayer.app.data.local.OpmlExportSummary
+import com.podcastplayer.app.data.local.OpmlImportData
 import com.podcastplayer.app.data.local.OpmlManager
 import com.podcastplayer.app.data.local.PlaybackProgressDao
 import com.podcastplayer.app.data.local.PlaybackProgressEntity
@@ -324,9 +326,11 @@ class PodcastViewModel(
 
     suspend fun exportOpml(outputStream: OutputStream) {
         withContext(Dispatchers.IO) {
-            OpmlManager.writeOpml(_savedPodcasts.value, outputStream)
+            OpmlManager.writeOpml(_savedPodcasts.value, queueStorage.queues.value, outputStream)
         }.fold(
-            onSuccess = { count -> _opmlResult.value = OpmlResult.ExportSuccess(count) },
+            onSuccess = { summary ->
+                _opmlResult.value = OpmlResult.ExportSuccess(summary.podcastCount, summary.queueCount)
+            },
             onFailure = { e -> _opmlResult.value = OpmlResult.Error(e.message ?: "Export failed") }
         )
     }
@@ -335,9 +339,10 @@ class PodcastViewModel(
         withContext(Dispatchers.IO) {
             OpmlManager.readOpml(inputStream)
         }.fold(
-            onSuccess = { podcasts ->
-                savedPodcastsStorage.saveAll(podcasts)
-                _opmlResult.value = OpmlResult.ImportSuccess(podcasts.size)
+            onSuccess = { data ->
+                savedPodcastsStorage.saveAll(data.podcasts)
+                queueStorage.mergeImportedQueues(data.queues)
+                _opmlResult.value = OpmlResult.ImportSuccess(data.podcasts.size, data.queues.size)
             },
             onFailure = { e -> _opmlResult.value = OpmlResult.Error(e.message ?: "Import failed") }
         )
@@ -418,7 +423,7 @@ sealed class EpisodesUiState {
 }
 
 sealed class OpmlResult {
-    data class ExportSuccess(val count: Int) : OpmlResult()
-    data class ImportSuccess(val count: Int) : OpmlResult()
+    data class ExportSuccess(val podcastCount: Int, val queueCount: Int) : OpmlResult()
+    data class ImportSuccess(val podcastCount: Int, val queueCount: Int) : OpmlResult()
     data class Error(val message: String) : OpmlResult()
 }


### PR DESCRIPTION
## Summary
Extended OPML export and import functionality to include podcast queues alongside podcast subscriptions. Users can now backup and restore their custom queues when exporting/importing their podcast library.

## Key Changes
- **OpmlManager**: 
  - Added `OpmlExportSummary` and `OpmlImportData` data classes to encapsulate export/import results with both podcast and queue counts
  - Extended `writeOpml()` to accept and serialize queues as custom XML elements under a namespaced `<queues>` tag
  - Extended `readOpml()` to parse queue data from OPML files and return both podcasts and queues
  - Implemented queue parsing logic with state tracking for queue attributes (id, name, createdAt) and contained podcast items

- **QueueStorage**:
  - Added `mergeImportedQueues()` method to intelligently merge imported queues with existing ones
  - Handles the special case of dropping the auto-created empty "Morning" queue when it's the only existing queue to avoid duplicates on import

- **PodcastViewModel**:
  - Updated `exportOpml()` to pass queues to the export function and handle the new `OpmlExportSummary` result type
  - Updated `importOpml()` to persist imported queues via `queueStorage.mergeImportedQueues()`
  - Updated `OpmlResult` sealed class to track both podcast and queue counts for export/import operations

- **PodcastListScreen**:
  - Enhanced user feedback messages to display both podcast and queue counts when exporting/importing
  - Messages now show queue count only when greater than 0

## Implementation Details
- Queues are serialized using a custom namespace (`https://podcastplayer.com/opml`) to maintain compatibility with standard OPML readers
- Queue structure includes metadata (id, name, createdAt) and a list of contained podcast IDs
- Import logic uses namespace-aware parsing to distinguish between standard OPML outline elements and custom queue elements
- Queue merging preserves existing queues while adding imported ones, with special handling for the default empty queue

https://claude.ai/code/session_01HwsqAPFDbRLTfceQ6UuRLj