### PR TITLE
feat: fix resume race, unify downloads via MediaStore, auto-download

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,9 @@ dependencies {
     implementation("androidx.room:room-ktx:2.6.1")
     kapt("androidx.room:room-compiler:2.6.1")
 
+    // WorkManager — used by auto-download (periodic feed refresh + new-episode downloads).
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+
     implementation("io.coil-kt:coil-compose:2.5.0")
 
     // youtubedl-android — yt-dlp wrapper for on-device YouTube/X/etc. extraction.

--- a/app/src/main/java/com/podcastplayer/app/PodcastApplication.kt
+++ b/app/src/main/java/com/podcastplayer/app/PodcastApplication.kt
@@ -2,6 +2,7 @@ package com.podcastplayer.app
 
 import android.app.Application
 import android.util.Log
+import com.podcastplayer.app.service.AutoDownloadWorker
 import com.yausername.ffmpeg.FFmpeg
 import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLException
@@ -36,6 +37,8 @@ class PodcastApplication : Application() {
             // Fire-and-forget update; safe to skip if it fails.
             tryUpdateYoutubeDl()
         }
+
+        AutoDownloadWorker.enqueuePeriodic(this)
     }
 
     private fun initYoutubeDl() {

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreSaver.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreSaver.kt
@@ -1,0 +1,167 @@
+package com.podcastplayer.app.data.local
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Saves audio / video files into the shared MediaStore so other apps (VLC, Files,
+ * Gallery, etc.) can discover them. On API < 29 we don't write to MediaStore
+ * directly (would require WRITE_EXTERNAL_STORAGE + a runtime permission flow);
+ * callers should fall back to app-private storage in that case.
+ *
+ * Identity is provided by the caller via [displayName] — duplicate names get an
+ * "(2)" suffix from the platform. The returned [SavedMedia.uri] is a content://
+ * URI suitable for both ExoPlayer (`MediaItem.setUri`) and ContentResolver.delete.
+ */
+object MediaStoreSaver {
+
+    const val AUDIO_SUBDIR = "Podcasts/VibePodcast"
+    const val VIDEO_SUBDIR = "Movies/VibePodcast"
+
+    /** True if the device supports scoped-storage MediaStore writes without runtime permission. */
+    fun isSupported(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+    data class SavedMedia(
+        val uri: Uri,
+        /**
+         * Absolute path on disk if obtainable — useful for callers that still want
+         * to inspect file size, but should not be used to open the file (use [uri]).
+         */
+        val path: String?,
+        val sizeBytes: Long,
+    )
+
+    /**
+     * Writes audio bytes from [source] into MediaStore.Audio. Returns null on
+     * failure (or on API < 29 — caller must fall back).
+     */
+    fun saveAudio(
+        context: Context,
+        displayName: String,
+        mimeType: String,
+        source: (OutputStream) -> Unit,
+    ): SavedMedia? = save(
+        context = context,
+        collection = MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY),
+        displayName = displayName,
+        mimeType = mimeType,
+        relativePath = AUDIO_SUBDIR,
+        source = source,
+    )
+
+    fun saveVideo(
+        context: Context,
+        displayName: String,
+        mimeType: String,
+        source: (OutputStream) -> Unit,
+    ): SavedMedia? = save(
+        context = context,
+        collection = MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY),
+        displayName = displayName,
+        mimeType = mimeType,
+        relativePath = VIDEO_SUBDIR,
+        source = source,
+    )
+
+    /** Convenience: stream a [File] into MediaStore audio. */
+    fun saveAudioFromFile(
+        context: Context,
+        displayName: String,
+        mimeType: String,
+        file: File,
+    ): SavedMedia? = saveAudio(context, displayName, mimeType) { out ->
+        file.inputStream().use { it.copyTo(out) }
+    }
+
+    fun saveVideoFromFile(
+        context: Context,
+        displayName: String,
+        mimeType: String,
+        file: File,
+    ): SavedMedia? = saveVideo(context, displayName, mimeType) { out ->
+        file.inputStream().use { it.copyTo(out) }
+    }
+
+    /**
+     * Delete a MediaStore entry by its content URI. Safe to call with non-content
+     * URIs — returns false in that case so the caller can fall back to File.delete.
+     */
+    fun deleteByUri(context: Context, contentUri: String): Boolean {
+        if (!contentUri.startsWith("content://")) return false
+        return try {
+            context.contentResolver.delete(Uri.parse(contentUri), null, null) > 0
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    private fun save(
+        context: Context,
+        collection: Uri,
+        displayName: String,
+        mimeType: String,
+        relativePath: String,
+        source: (OutputStream) -> Unit,
+    ): SavedMedia? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, sanitize(displayName))
+            put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+            put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
+            put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
+
+        val uri = resolver.insert(collection, values) ?: return null
+        var size = 0L
+        try {
+            resolver.openOutputStream(uri, "w")?.use { out ->
+                source(out)
+            } ?: run {
+                resolver.delete(uri, null, null)
+                return null
+            }
+            // Best-effort size lookup.
+            resolver.query(uri, arrayOf(MediaStore.MediaColumns.SIZE), null, null, null)?.use { c ->
+                if (c.moveToFirst()) size = c.getLong(0)
+            }
+        } catch (t: Throwable) {
+            resolver.delete(uri, null, null)
+            return null
+        }
+
+        // Mark visible.
+        val finalize = ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) }
+        resolver.update(uri, finalize, null, null)
+
+        return SavedMedia(uri = uri, path = resolveAbsolutePath(relativePath, displayName), sizeBytes = size)
+    }
+
+    private fun resolveAbsolutePath(relativePath: String, displayName: String): String? {
+        return try {
+            val root = Environment.getExternalStorageDirectory()
+            File(File(root, relativePath), sanitize(displayName)).absolutePath
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun sanitize(name: String): String =
+        name.replace(Regex("[\\\\/:*?\"<>|]"), "_").take(120).ifBlank { "vibe-media" }
+
+    /**
+     * Decide whether a [localPath] string points at a MediaStore entry (content://)
+     * or a regular file on disk.
+     */
+    fun isContentUri(localPath: String?): Boolean =
+        localPath != null && localPath.startsWith("content://")
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/QueueStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/QueueStorage.kt
@@ -16,7 +16,8 @@ class QueueStorage(context: Context) {
         val id: String,
         val name: String,
         val createdAt: Long,
-        val podcastIds: List<String>
+        val podcastIds: List<String>,
+        val autoDownload: Boolean = false,
     )
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -101,6 +102,13 @@ class QueueStorage(context: Context) {
             } else {
                 queue
             }
+        }
+        persist(updated)
+    }
+
+    suspend fun setAutoDownload(queueId: String, enabled: Boolean) = mutex.withLock {
+        val updated = _queues.value.map { queue ->
+            if (queue.id == queueId) queue.copy(autoDownload = enabled) else queue
         }
         persist(updated)
     }

--- a/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
@@ -41,6 +41,15 @@ class SavedPodcastsStorage(context: Context) {
         }
     }
 
+    suspend fun setAutoDownload(podcastId: String, enabled: Boolean) {
+        mutex.withLock {
+            val updated = _savedPodcasts.value.map { podcast ->
+                if (podcast.id == podcastId) podcast.copy(autoDownload = enabled) else podcast
+            }
+            persist(updated)
+        }
+    }
+
     suspend fun move(fromIndex: Int, toIndex: Int) {
         mutex.withLock {
             val list = _savedPodcasts.value.toMutableList()

--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -34,10 +34,16 @@ class DownloadManager(private val context: Context) {
 
     suspend fun downloadEpisode(
         episode: Episode,
+        podcastTitle: String? = null,
         onProgress: (Float) -> Unit = {}
     ): Result<String> = withContext(Dispatchers.IO) {
         try {
-            val fileName = buildSafeFileName(episode)
+            // Path-on-disk name still uses a hash for the legacy app-private path
+            // (deterministic, collision-free, FS-safe). The MediaStore display name
+            // is built from the human-readable title so users browsing in VLC /
+            // Files see context, not a hex string.
+            val legacyFileName = buildHashedFileName(episode)
+            val displayName = buildDisplayName(episode, podcastTitle)
 
             // Don't re-download an episode we've already saved. We key on the DB
             // row rather than file existence because the path may be a content://
@@ -48,7 +54,7 @@ class DownloadManager(private val context: Context) {
             }
 
             if (MediaStoreSaver.isSupported()) {
-                val saved = downloadIntoMediaStore(episode, fileName, onProgress)
+                val saved = downloadIntoMediaStore(episode, displayName, onProgress)
                     ?: return@withContext Result.failure(
                         java.io.IOException("Could not save audio to MediaStore"),
                     )
@@ -59,7 +65,7 @@ class DownloadManager(private val context: Context) {
                 // Pre-Q: fall back to app-private external dir (existing behavior).
                 // Files won't be visible to other apps, but neither would they without
                 // the legacy WRITE_EXTERNAL_STORAGE permission flow.
-                val localFile = File(downloadDir, fileName)
+                val localFile = File(downloadDir, legacyFileName)
                 if (localFile.exists()) return@withContext Result.success(localFile.absolutePath)
                 downloadIntoFile(episode, localFile, onProgress)
                 val entity = episode.toEntity(
@@ -241,13 +247,31 @@ class DownloadManager(private val context: Context) {
         return dao.getEpisodeById(episodeId)
     }
 
-    private fun buildSafeFileName(episode: Episode): String {
+    private fun buildHashedFileName(episode: Episode): String {
         val source = episode.id.takeIf { it.isNotBlank() } ?: episode.audioUrl
         val extension = guessExtension(episode.audioUrl) ?: "mp3"
         val hash = MessageDigest.getInstance("MD5")
             .digest(source.toByteArray())
             .joinToString("") { "%02x".format(it) }
         return "$hash.$extension"
+    }
+
+    /**
+     * Human-readable display name for the MediaStore row, so users see e.g.
+     * "Lex Fridman - Joe Rogan Interview.mp3" instead of a hex hash when they
+     * browse the Podcasts folder from another app. Sanitization (illegal chars,
+     * length cap) happens in [MediaStoreSaver].
+     */
+    private fun buildDisplayName(episode: Episode, podcastTitle: String?): String {
+        val extension = guessExtension(episode.audioUrl) ?: "mp3"
+        val rawTitle = episode.title.trim()
+        val base = when {
+            podcastTitle.isNullOrBlank() && rawTitle.isBlank() -> "episode"
+            podcastTitle.isNullOrBlank() -> rawTitle
+            rawTitle.isBlank() -> podcastTitle
+            else -> "$podcastTitle - $rawTitle"
+        }
+        return "$base.$extension"
     }
 
     private fun guessExtension(url: String): String? {

--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -6,6 +6,7 @@ import android.os.Environment
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.DownloadedEpisodeDao
 import com.podcastplayer.app.data.local.DownloadedEpisodeEntity
+import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.domain.model.Episode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -37,46 +38,111 @@ class DownloadManager(private val context: Context) {
     ): Result<String> = withContext(Dispatchers.IO) {
         try {
             val fileName = buildSafeFileName(episode)
-            val localFile = File(downloadDir, fileName)
 
-            if (localFile.exists()) {
-                return@withContext Result.success(localFile.absolutePath)
+            // Don't re-download an episode we've already saved. We key on the DB
+            // row rather than file existence because the path may be a content://
+            // URI from MediaStore.
+            val existing = dao.getEpisodeById(episode.id)
+            if (existing != null) {
+                return@withContext Result.success(existing.localPath)
             }
 
-            val connection = openWithRedirects(episode.audioUrl)
-            val totalBytes = connection.contentLengthLong
-
-            try {
-                connection.inputStream.use { input ->
-                    FileOutputStream(localFile).use { output ->
-                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                        var bytesRead: Int
-                        var downloaded = 0L
-                        while (input.read(buffer).also { bytesRead = it } >= 0) {
-                            output.write(buffer, 0, bytesRead)
-                            downloaded += bytesRead
-                            if (totalBytes > 0) {
-                                onProgress(downloaded.toFloat() / totalBytes.toFloat())
-                            }
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                if (localFile.exists()) localFile.delete()
-                throw e
-            } finally {
-                connection.disconnect()
+            if (MediaStoreSaver.isSupported()) {
+                val saved = downloadIntoMediaStore(episode, fileName, onProgress)
+                    ?: return@withContext Result.failure(
+                        java.io.IOException("Could not save audio to MediaStore"),
+                    )
+                val entity = episode.toEntity(localPath = saved.uri.toString(), fileSize = saved.sizeBytes)
+                dao.insertEpisode(entity)
+                Result.success(saved.uri.toString())
+            } else {
+                // Pre-Q: fall back to app-private external dir (existing behavior).
+                // Files won't be visible to other apps, but neither would they without
+                // the legacy WRITE_EXTERNAL_STORAGE permission flow.
+                val localFile = File(downloadDir, fileName)
+                if (localFile.exists()) return@withContext Result.success(localFile.absolutePath)
+                downloadIntoFile(episode, localFile, onProgress)
+                val entity = episode.toEntity(
+                    localPath = localFile.absolutePath,
+                    fileSize = localFile.length(),
+                )
+                dao.insertEpisode(entity)
+                Result.success(localFile.absolutePath)
             }
-
-            if (totalBytes > 0) {
-                onProgress(1f)
-            }
-
-            val entity = episode.toEntity(localFile.absolutePath)
-            dao.insertEpisode(entity)
-            Result.success(localFile.absolutePath)
         } catch (e: Exception) {
             Result.failure(e)
+        }
+    }
+
+    private fun downloadIntoFile(
+        episode: Episode,
+        localFile: File,
+        onProgress: (Float) -> Unit,
+    ) {
+        val connection = openWithRedirects(episode.audioUrl)
+        val totalBytes = connection.contentLengthLong
+        try {
+            connection.inputStream.use { input ->
+                FileOutputStream(localFile).use { output ->
+                    copyWithProgress(input, output, totalBytes, onProgress)
+                }
+            }
+        } catch (e: Exception) {
+            if (localFile.exists()) localFile.delete()
+            throw e
+        } finally {
+            connection.disconnect()
+        }
+        if (totalBytes > 0) onProgress(1f)
+    }
+
+    private fun downloadIntoMediaStore(
+        episode: Episode,
+        fileName: String,
+        onProgress: (Float) -> Unit,
+    ): MediaStoreSaver.SavedMedia? {
+        val mime = guessAudioMime(fileName)
+        val connection = openWithRedirects(episode.audioUrl)
+        val totalBytes = connection.contentLengthLong
+        try {
+            val saved = MediaStoreSaver.saveAudio(context, fileName, mime) { output ->
+                connection.inputStream.use { input ->
+                    copyWithProgress(input, output, totalBytes, onProgress)
+                }
+            }
+            if (totalBytes > 0 && saved != null) onProgress(1f)
+            return saved
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun copyWithProgress(
+        input: java.io.InputStream,
+        output: java.io.OutputStream,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ) {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var bytesRead: Int
+        var downloaded = 0L
+        while (input.read(buffer).also { bytesRead = it } >= 0) {
+            output.write(buffer, 0, bytesRead)
+            downloaded += bytesRead
+            if (totalBytes > 0) {
+                onProgress(downloaded.toFloat() / totalBytes.toFloat())
+            }
+        }
+    }
+
+    private fun guessAudioMime(fileName: String): String {
+        return when (fileName.substringAfterLast('.', "").lowercase(Locale.US)) {
+            "mp3" -> "audio/mpeg"
+            "m4a", "aac" -> "audio/mp4"
+            "ogg", "oga" -> "audio/ogg"
+            "opus" -> "audio/opus"
+            "wav" -> "audio/wav"
+            else -> "audio/mpeg"
         }
     }
 
@@ -144,10 +210,7 @@ class DownloadManager(private val context: Context) {
         try {
             val episode = dao.getEpisodeById(episodeId)
             if (episode != null) {
-                val file = File(episode.localPath)
-                if (file.exists()) {
-                    file.delete()
-                }
+                deleteLocalPayload(episode.localPath)
                 dao.deleteEpisodeById(episodeId)
             }
             Result.success(Unit)
@@ -159,17 +222,19 @@ class DownloadManager(private val context: Context) {
     suspend fun deleteAllDownloads(): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val episodes = dao.getAllEpisodes().first()
-            episodes.forEach { episode ->
-                val file = File(episode.localPath)
-                if (file.exists()) {
-                    file.delete()
-                }
-            }
+            episodes.forEach { episode -> deleteLocalPayload(episode.localPath) }
             dao.deleteAll()
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }
+    }
+
+    /** Delete either a MediaStore content row or a local file, depending on the path scheme. */
+    private fun deleteLocalPayload(localPath: String) {
+        if (MediaStoreSaver.deleteByUri(context, localPath)) return
+        val file = File(localPath)
+        if (file.exists()) file.delete()
     }
 
     suspend fun getDownloadedEpisode(episodeId: String): DownloadedEpisodeEntity? {
@@ -195,7 +260,7 @@ class DownloadManager(private val context: Context) {
         }
     }
 
-    private fun Episode.toEntity(localPath: String): DownloadedEpisodeEntity {
+    private fun Episode.toEntity(localPath: String, fileSize: Long): DownloadedEpisodeEntity {
         return DownloadedEpisodeEntity(
             id = id,
             podcastId = podcastId,
@@ -205,7 +270,7 @@ class DownloadManager(private val context: Context) {
             audioUrl = audioUrl,
             duration = duration,
             localPath = localPath,
-            fileSize = File(localPath).length(),
+            fileSize = fileSize,
             downloadDate = System.currentTimeMillis()
         )
     }

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -3,6 +3,7 @@ package com.podcastplayer.app.data.repository
 import android.content.Context
 import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.data.local.UrlDownloadDao
 import com.podcastplayer.app.data.local.UrlDownloadEntity
 import com.podcastplayer.app.domain.model.Episode
@@ -144,12 +145,12 @@ class UrlDownloadRepository(private val context: Context) {
         dao.markFailed(id, UrlDownloadStatus.CANCELED.name, null)
     }
 
-    suspend fun markCompleted(id: String, file: File) {
+    suspend fun markCompleted(id: String, localPath: String, fileSize: Long) {
         dao.markCompleted(
             id = id,
             status = UrlDownloadStatus.COMPLETED.name,
-            localPath = file.absolutePath,
-            fileSize = if (file.exists()) file.length() else 0L,
+            localPath = localPath,
+            fileSize = fileSize,
             completedAtMs = System.currentTimeMillis(),
         )
     }
@@ -159,8 +160,10 @@ class UrlDownloadRepository(private val context: Context) {
         try {
             val entity = dao.getById(id)
             entity?.localPath?.let { path ->
-                val file = File(path)
-                if (file.exists()) file.delete()
+                if (!MediaStoreSaver.deleteByUri(context, path)) {
+                    val file = File(path)
+                    if (file.exists()) file.delete()
+                }
             }
             dao.deleteById(id)
             Result.success(Unit)

--- a/app/src/main/java/com/podcastplayer/app/domain/model/Podcast.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/Podcast.kt
@@ -5,5 +5,11 @@ data class Podcast(
     val title: String,
     val artist: String,
     val artworkUrl: String?,
-    val feedUrl: String?
+    val feedUrl: String?,
+    /**
+     * When true, the auto-download worker will fetch the latest episode for this
+     * podcast on its periodic run. Gson treats missing fields as default, so
+     * older serialized rows safely deserialize to `false`.
+     */
+    val autoDownload: Boolean = false,
 )

--- a/app/src/main/java/com/podcastplayer/app/domain/model/PodcastQueue.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/PodcastQueue.kt
@@ -3,5 +3,6 @@ package com.podcastplayer.app.domain.model
 data class PodcastQueue(
     val id: String,
     val name: String,
-    val createdAt: Long
+    val createdAt: Long,
+    val autoDownload: Boolean = false,
 )

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -20,8 +20,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.Audiotrack
 import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Movie
+import androidx.compose.material.icons.outlined.Podcasts
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -42,14 +45,33 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
-import com.podcastplayer.app.presentation.viewmodel.DownloadedEpisodeUi
+import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.ui.theme.JetBrainsMono
+
+/**
+ * Shape for a single row in the Downloads tab. Sources include RSS podcast
+ * downloads ([Kind.PODCAST]) and "Add from URL" downloads ([Kind.URL_AUDIO] /
+ * [Kind.URL_VIDEO]). The NavHost is responsible for building this list by
+ * combining the two underlying ViewModels — keeping the screen oblivious to
+ * the persistence split between Room tables.
+ */
+data class DownloadEntryUi(
+    val id: String,
+    val kind: Kind,
+    val title: String,
+    val subtitle: String?,
+    val artworkUrl: String?,
+    /** Playable Episode — used by the play handler regardless of source. */
+    val episode: Episode,
+) {
+    enum class Kind { PODCAST, URL_AUDIO, URL_VIDEO }
+}
 
 @Composable
 fun DownloadsScreen(
-    downloads: List<DownloadedEpisodeUi>,
-    onPlayEpisode: (DownloadedEpisodeUi) -> Unit,
-    onDeleteEpisode: (String) -> Unit,
+    entries: List<DownloadEntryUi>,
+    onPlay: (DownloadEntryUi) -> Unit,
+    onDelete: (DownloadEntryUi) -> Unit,
     onDeleteAll: () -> Unit,
     @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
@@ -61,7 +83,7 @@ fun DownloadsScreen(
                 title = "Downloads",
                 eyebrow = "Offline",
                 actions = {
-                    if (downloads.isNotEmpty()) {
+                    if (entries.isNotEmpty()) {
                         VibeChip(
                             label = "Remove all",
                             onClick = { showDeleteAllDialog = true },
@@ -78,7 +100,7 @@ fun DownloadsScreen(
                 },
             )
 
-            if (downloads.isEmpty()) {
+            if (entries.isEmpty()) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -88,7 +110,7 @@ fun DownloadsScreen(
                     VibeEmptyState(
                         icon = Icons.Outlined.CloudDownload,
                         title = "No downloads",
-                        subtitle = "Download episodes to listen offline",
+                        subtitle = "Save podcast episodes or paste YouTube / X links to listen offline.",
                     )
                 }
             } else {
@@ -98,9 +120,9 @@ fun DownloadsScreen(
                         .padding(horizontal = 16.dp, vertical = 6.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    VibeSectionEyebrow(text = "Saved episodes", modifier = Modifier.weight(1f))
+                    VibeSectionEyebrow(text = "Saved", modifier = Modifier.weight(1f))
                     Text(
-                        text = "${downloads.size}",
+                        text = "${entries.size}",
                         fontFamily = JetBrainsMono,
                         fontSize = 11.sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -116,11 +138,11 @@ fun DownloadsScreen(
                     ),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    items(downloads, key = { it.episode.id }) { item ->
+                    items(entries, key = { it.id }) { entry ->
                         DownloadRow(
-                            item = item,
-                            onPlay = { onPlayEpisode(item) },
-                            onDelete = { onDeleteEpisode(item.episode.id) },
+                            entry = entry,
+                            onPlay = { onPlay(entry) },
+                            onDelete = { onDelete(entry) },
                         )
                     }
                 }
@@ -132,7 +154,7 @@ fun DownloadsScreen(
         AlertDialog(
             onDismissRequest = { showDeleteAllDialog = false },
             title = { Text("Remove all downloads") },
-            text = { Text("This will delete all downloaded audio files.") },
+            text = { Text("This will delete every downloaded file from this device.") },
             confirmButton = {
                 TextButton(onClick = {
                     onDeleteAll()
@@ -153,7 +175,7 @@ fun DownloadsScreen(
 
 @Composable
 private fun DownloadRow(
-    item: DownloadedEpisodeUi,
+    entry: DownloadEntryUi,
     onPlay: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -170,8 +192,8 @@ private fun DownloadRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(
-            model = item.episode.imageUrl ?: item.podcastArtworkUrl,
-            contentDescription = item.episode.title,
+            model = entry.artworkUrl,
+            contentDescription = entry.title,
             modifier = Modifier
                 .size(60.dp)
                 .clip(RoundedCornerShape(10.dp)),
@@ -181,21 +203,25 @@ private fun DownloadRow(
         )
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
-            item.podcastTitle?.let {
-                Text(
-                    text = it.uppercase(),
-                    fontFamily = JetBrainsMono,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Medium,
-                    letterSpacing = 1.4.sp,
-                    color = colors.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(Modifier.height(2.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                KindBadge(entry.kind)
+                if (!entry.subtitle.isNullOrBlank()) {
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = entry.subtitle.uppercase(),
+                        fontFamily = JetBrainsMono,
+                        fontSize = 9.5.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 1.2.sp,
+                        color = colors.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
+            Spacer(Modifier.height(4.dp))
             Text(
-                text = item.episode.title,
+                text = entry.title,
                 style = MaterialTheme.typography.titleSmall,
                 color = colors.onSurface,
                 maxLines = 2,
@@ -218,6 +244,39 @@ private fun DownloadRow(
             size = 40.dp,
             iconSize = 22.dp,
             tinted = true,
+        )
+    }
+}
+
+@Composable
+private fun KindBadge(kind: DownloadEntryUi.Kind) {
+    val colors = MaterialTheme.colorScheme
+    val (label, icon) = when (kind) {
+        DownloadEntryUi.Kind.PODCAST -> "PODCAST" to Icons.Outlined.Podcasts
+        DownloadEntryUi.Kind.URL_AUDIO -> "AUDIO" to Icons.Outlined.Audiotrack
+        DownloadEntryUi.Kind.URL_VIDEO -> "VIDEO" to Icons.Outlined.Movie
+    }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(colors.surfaceVariant)
+            .padding(horizontal = 7.dp, vertical = 2.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = colors.onSurfaceVariant,
+            modifier = Modifier.size(11.dp),
+        )
+        Spacer(Modifier.width(4.dp))
+        Text(
+            text = label,
+            fontFamily = JetBrainsMono,
+            fontSize = 9.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 1.2.sp,
+            color = colors.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.DownloadDone
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -92,6 +93,13 @@ fun EpisodeListScreen(
     val currentEpisode by playerViewModel.currentEpisode.collectAsState()
     val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
     val playerState by playerViewModel.playerState.collectAsState()
+    val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
+    val isSubscribed = remember(savedPodcasts, podcast?.id) {
+        savedPodcasts.any { it.id == podcast?.id }
+    }
+    val autoDownload = remember(savedPodcasts, podcast?.id) {
+        savedPodcasts.firstOrNull { it.id == podcast?.id }?.autoDownload == true
+    }
     val scope = rememberCoroutineScope()
 
     if (isLandscape) {
@@ -128,6 +136,31 @@ fun EpisodeListScreen(
                     eyebrow = podcast?.artist,
                     onBack = onBack,
                 )
+
+                if (isSubscribed && podcast != null) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        VibeChip(
+                            label = if (autoDownload) "Auto-download on" else "Auto-download new",
+                            active = autoDownload,
+                            onClick = {
+                                podcastViewModel.setPodcastAutoDownload(podcast.id, !autoDownload)
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.CloudDownload,
+                                    contentDescription = null,
+                                    tint = if (autoDownload) colors.primary else colors.onSurface,
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            },
+                        )
+                    }
+                }
 
                 Box(modifier = Modifier.weight(1f)) {
                     when (val state = episodesState) {
@@ -367,6 +400,25 @@ private fun EpisodeListLandscape(
                         color = if (subscribed) colors.onSurface else colors.onPrimary,
                     )
                 }
+            }
+
+            if (subscribed && podcast != null) {
+                val savedPodcasts by podcastViewModel.savedPodcasts.collectAsState()
+                val autoDownload = savedPodcasts.firstOrNull { it.id == podcast.id }?.autoDownload == true
+                VibeChip(
+                    label = if (autoDownload) "Auto-download on" else "Auto-download new",
+                    active = autoDownload,
+                    onClick = { podcastViewModel.setPodcastAutoDownload(podcast.id, !autoDownload) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.CloudDownload,
+                            contentDescription = null,
+                            tint = if (autoDownload) colors.primary else colors.onSurface,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -435,6 +436,9 @@ fun PodcastNavHost(
                             }
                         },
                         onDismissPlayer = { playerViewModel.clearPlayer() },
+                        onToggleAutoDownload = { id, enabled ->
+                            podcastViewModel.setQueueAutoDownload(id, enabled)
+                        },
                         onBack = {
                             navController.popBackStack(route = Routes.Home, inclusive = false)
                         }
@@ -443,18 +447,69 @@ fun PodcastNavHost(
 
                 composable(Routes.Downloads) {
                     val scope = rememberCoroutineScope()
-                    val downloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
+                    val podcastDownloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
+                    val urlDownloads by urlDownloadViewModel.completedDownloads.collectAsState()
+
+                    val urlRepository = remember(context) {
+                        com.podcastplayer.app.data.repository.UrlDownloadRepository(context)
+                    }
+
+                    val entries = remember(podcastDownloads, urlDownloads) {
+                        buildList {
+                            podcastDownloads.forEach { item ->
+                                add(
+                                    DownloadEntryUi(
+                                        id = "podcast:${item.episode.id}",
+                                        kind = DownloadEntryUi.Kind.PODCAST,
+                                        title = item.episode.title,
+                                        subtitle = item.podcastTitle,
+                                        artworkUrl = item.episode.imageUrl ?: item.podcastArtworkUrl,
+                                        episode = item.episode,
+                                    ),
+                                )
+                            }
+                            urlDownloads.forEach { entity ->
+                                val episode = urlRepository.toEpisode(entity) ?: return@forEach
+                                add(
+                                    DownloadEntryUi(
+                                        id = "url:${entity.id}",
+                                        kind = if (entity.mediaType == "video")
+                                            DownloadEntryUi.Kind.URL_VIDEO
+                                        else DownloadEntryUi.Kind.URL_AUDIO,
+                                        title = entity.title,
+                                        subtitle = entity.uploader ?: entity.source.uppercase(),
+                                        artworkUrl = entity.thumbnailUrl,
+                                        episode = episode,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+
                     DownloadsScreen(
-                        downloads = downloads,
-                        onPlayEpisode = { item ->
-                            playerViewModel.playEpisode(item.episode, item.podcastArtworkUrl)
+                        entries = entries,
+                        onPlay = { entry ->
+                            playerViewModel.playEpisode(entry.episode, entry.artworkUrl)
                             navController.navigate(Routes.Player)
                         },
-                        onDeleteEpisode = { episodeId ->
-                            scope.launch { podcastViewModel.deleteDownload(episodeId) }
+                        onDelete = { entry ->
+                            scope.launch {
+                                when (entry.kind) {
+                                    DownloadEntryUi.Kind.PODCAST ->
+                                        podcastViewModel.deleteDownload(entry.episode.id)
+                                    DownloadEntryUi.Kind.URL_AUDIO,
+                                    DownloadEntryUi.Kind.URL_VIDEO -> {
+                                        // entry.id format: "url:<entity-id>"
+                                        urlDownloadViewModel.deleteDownload(entry.id.removePrefix("url:"))
+                                    }
+                                }
+                            }
                         },
                         onDeleteAll = {
-                            scope.launch { podcastViewModel.deleteAllDownloads() }
+                            scope.launch {
+                                podcastViewModel.deleteAllDownloads()
+                                urlDownloads.forEach { urlDownloadViewModel.deleteDownload(it.id) }
+                            }
                         },
                         onBack = { navController.popBackStack(route = Routes.Home, inclusive = false) }
                     )
@@ -468,6 +523,7 @@ fun PodcastNavHost(
                     val hasPrevious by playerViewModel.hasPrevious.collectAsState()
                     val hasNext by playerViewModel.hasNext.collectAsState()
                     val selectedPodcast by podcastViewModel.selectedPodcast.collectAsState()
+                    val resumedFromMs by playerViewModel.resumedFromMs.collectAsState()
 
                     fun goToEpisodesOrSearch() {
                         val podcastId = selectedPodcast?.id
@@ -486,23 +542,30 @@ fun PodcastNavHost(
                     }
 
                     currentEpisode?.let { episode ->
-                        PlayerScreen(
-                            episode = episode,
-                            playerState = playerState,
-                            artworkUrl = currentArtworkUrl ?: selectedPodcast?.artworkUrl,
-                            sleepTimerRemaining = sleepTimerRemaining,
-                            hasPrevious = hasPrevious,
-                            hasNext = hasNext,
-                            onPlayPause = { playerViewModel.togglePlayPause() },
-                            onPlayPrevious = { playerViewModel.playPrevious() },
-                            onPlayNext = { playerViewModel.playNext() },
-                            onSeek = { playerViewModel.seekTo(it) },
-                            onSpeedChange = { playerViewModel.setPlaybackSpeed(it) },
-                            onSetSleepTimer = { playerViewModel.setSleepTimer(it) },
-                            onCancelSleepTimer = { playerViewModel.cancelSleepTimer() },
-                            onDismiss = { goToEpisodesOrSearch() },
-                            isLandscape = isLandscape,
-                        )
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            PlayerScreen(
+                                episode = episode,
+                                playerState = playerState,
+                                artworkUrl = currentArtworkUrl ?: selectedPodcast?.artworkUrl,
+                                sleepTimerRemaining = sleepTimerRemaining,
+                                hasPrevious = hasPrevious,
+                                hasNext = hasNext,
+                                onPlayPause = { playerViewModel.togglePlayPause() },
+                                onPlayPrevious = { playerViewModel.playPrevious() },
+                                onPlayNext = { playerViewModel.playNext() },
+                                onSeek = { playerViewModel.seekTo(it) },
+                                onSpeedChange = { playerViewModel.setPlaybackSpeed(it) },
+                                onSetSleepTimer = { playerViewModel.setSleepTimer(it) },
+                                onCancelSleepTimer = { playerViewModel.cancelSleepTimer() },
+                                onDismiss = { goToEpisodesOrSearch() },
+                                isLandscape = isLandscape,
+                            )
+                            ResumeNotice(
+                                positionMs = resumedFromMs,
+                                onConsume = { playerViewModel.consumeResumeNotice() },
+                                modifier = Modifier.align(Alignment.TopCenter),
+                            )
+                        }
                     }
 
                     if (currentEpisode == null) {

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/QueueScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/QueueScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.QueueMusic
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -77,6 +78,7 @@ fun QueueScreen(
     onRemove: (String) -> Unit,
     onPlayQueue: () -> Unit,
     onDismissPlayer: () -> Unit,
+    onToggleAutoDownload: (String, Boolean) -> Unit = { _, _ -> },
     @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -132,6 +134,30 @@ fun QueueScreen(
                 onPlayQueue = onPlayQueue,
                 enabled = podcasts.isNotEmpty(),
             )
+
+            if (selectedQueue != null) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    VibeChip(
+                        label = if (selectedQueue.autoDownload) "Auto-download on" else "Auto-download new",
+                        active = selectedQueue.autoDownload,
+                        onClick = { onToggleAutoDownload(selectedQueue.id, !selectedQueue.autoDownload) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.CloudDownload,
+                                contentDescription = null,
+                                tint = if (selectedQueue.autoDownload) MaterialTheme.colorScheme.primary
+                                else MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        },
+                    )
+                }
+            }
 
             if (podcasts.isEmpty()) {
                 Box(

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/VibeComponents.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/VibeComponents.kt
@@ -22,7 +22,17 @@ import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.material.icons.outlined.HistoryToggleOff
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -258,6 +268,65 @@ fun VibeEmptyState(
             action()
         }
     }
+}
+
+/**
+ * Transient banner shown at the top of the player when a session resumed from a
+ * saved position. Auto-dismisses after ~3s. Stays a no-op until [positionMs] is
+ * non-null so the surrounding layout doesn't shift on every open of the screen.
+ */
+@Composable
+fun ResumeNotice(
+    positionMs: Long?,
+    onConsume: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val visible = positionMs != null && positionMs > 5_000L
+    LaunchedEffect(positionMs) {
+        if (positionMs != null) {
+            kotlinx.coroutines.delay(3_000)
+            onConsume()
+        }
+    }
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { -it }),
+        exit = fadeOut() + slideOutVertically(targetOffsetY = { -it }),
+        modifier = modifier,
+    ) {
+        val statusPad = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+        val colors = MaterialTheme.colorScheme
+        Row(
+            modifier = Modifier
+                .padding(top = statusPad + 8.dp, start = 16.dp, end = 16.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .background(colors.primaryContainer)
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.HistoryToggleOff,
+                contentDescription = null,
+                tint = colors.primary,
+                modifier = Modifier.size(14.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = "Resumed at ${formatResumeTime(positionMs ?: 0L)}",
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+private fun formatResumeTime(ms: Long): String {
+    val totalSec = (ms / 1000L).coerceAtLeast(0L)
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    val s = totalSec % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
 }
 
 /** Eyebrow label used to section content (e.g. "SUBSCRIPTIONS", "LATEST"). */

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
@@ -199,7 +199,17 @@ class PlayerViewModel(
     }
 
     private suspend fun refreshFromController() {
-        val episode = playerController.getCurrentEpisode()
+        val rebuilt = playerController.getCurrentEpisode()
+        // The controller reconstructs Episode from MediaItem URI, where mediaType
+        // has to be inferred. If we already had the same episode tracked here
+        // (set by playEpisode / queue listener), preserve its mediaType so the
+        // periodic refresh can't downgrade a known-video back to audio.
+        val prev = _currentEpisode.value
+        val episode = when {
+            rebuilt == null -> null
+            prev != null && rebuilt.id == prev.id -> rebuilt.copy(mediaType = prev.mediaType)
+            else -> rebuilt
+        }
         _currentEpisode.value = episode
         _currentArtworkUrl.value = playerController.getCurrentArtworkUrl() ?: episode?.imageUrl
         _hasPrevious.value = playerController.hasPrevious()

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
@@ -39,6 +39,14 @@ class PlayerViewModel(
     private val _hasNext = MutableStateFlow(false)
     val hasNext: StateFlow<Boolean> = _hasNext.asStateFlow()
 
+    /**
+     * Fires once after each manual playback start that resumed at a saved position.
+     * The UI consumes the value to show a "Resumed at MM:SS" snackbar/toast, then
+     * sets it back to null. Auto-advance through a queue does not raise this.
+     */
+    private val _resumedFromMs = MutableStateFlow<Long?>(null)
+    val resumedFromMs: StateFlow<Long?> = _resumedFromMs.asStateFlow()
+
     private var sleepTimerJob: Job? = null
 
     private var queueEpisodes: Map<String, Episode> = emptyMap()
@@ -70,10 +78,11 @@ class PlayerViewModel(
                 currentEpisode = episode
             )
             try {
-                playerController.playEpisode(episode, artworkUrl)
+                val startMs = playerController.playEpisode(episode, artworkUrl)
                 _playerState.value = _playerState.value.copy(
                     state = PlaybackState.PLAYING
                 )
+                if (startMs > 0L) _resumedFromMs.value = startMs
                 refreshFromController()
             } catch (e: Exception) {
                 _playerState.value = _playerState.value.copy(
@@ -98,13 +107,18 @@ class PlayerViewModel(
             )
 
             try {
-                playerController.playEpisodes(episodes, defaultArtworkUrl)
+                val startMs = playerController.playEpisodes(episodes, defaultArtworkUrl)
                 _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
+                if (startMs > 0L) _resumedFromMs.value = startMs
                 refreshFromController()
             } catch (e: Exception) {
                 _playerState.value = _playerState.value.copy(state = PlaybackState.ERROR)
             }
         }
+    }
+
+    fun consumeResumeNotice() {
+        _resumedFromMs.value = null
     }
 
     fun togglePlayPause() {

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -64,7 +64,7 @@ class PodcastViewModel(
     val selectedQueueId: StateFlow<String?> = _selectedQueueId.asStateFlow()
 
     val queues: StateFlow<List<PodcastQueue>> = queueStorage.queues
-        .map { list -> list.map { PodcastQueue(it.id, it.name, it.createdAt) } }
+        .map { list -> list.map { PodcastQueue(it.id, it.name, it.createdAt, it.autoDownload) } }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val selectedQueuePodcasts: StateFlow<List<Podcast>> = combine(
@@ -269,6 +269,14 @@ class PodcastViewModel(
 
     fun removeSavedPodcast(podcastId: String) {
         viewModelScope.launch { savedPodcastsStorage.remove(podcastId) }
+    }
+
+    fun setPodcastAutoDownload(podcastId: String, enabled: Boolean) {
+        viewModelScope.launch { savedPodcastsStorage.setAutoDownload(podcastId, enabled) }
+    }
+
+    fun setQueueAutoDownload(queueId: String, enabled: Boolean) {
+        viewModelScope.launch { queueStorage.setAutoDownload(queueId, enabled) }
     }
 
     fun moveSavedPodcast(fromIndex: Int, toIndex: Int) {

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -238,8 +238,12 @@ class PodcastViewModel(
     fun startDownload(episode: Episode) {
         if (_downloadProgress.value.containsKey(episode.id)) return
         _downloadProgress.value = _downloadProgress.value + (episode.id to 0f)
+        // Surface the podcast title to DownloadManager so the MediaStore display
+        // name reads as "<podcast> - <episode>.mp3" when browsed from VLC / Files.
+        val podcastTitle = _savedPodcasts.value.firstOrNull { it.id == episode.podcastId }?.title
+            ?: _selectedPodcast.value?.takeIf { it.id == episode.podcastId }?.title
         viewModelScope.launch {
-            val result = downloadManager.downloadEpisode(episode) { progress ->
+            val result = downloadManager.downloadEpisode(episode, podcastTitle) { progress ->
                 _downloadProgress.value = _downloadProgress.value + (episode.id to progress)
             }
             _downloadProgress.value = _downloadProgress.value - episode.id

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
@@ -120,7 +120,7 @@ class AutoDownloadWorker(
                     if (downloadedDao.isEpisodeDownloaded(episode.id)) continue
                     val withArtwork = ensureArtwork(episode, podcast)
                     // Result is ignored — periodic work; we'll try again next interval.
-                    downloadManager.downloadEpisode(withArtwork)
+                    downloadManager.downloadEpisode(withArtwork, podcastTitle = podcast.title)
                 }
             }
         }

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
@@ -1,0 +1,133 @@
+package com.podcastplayer.app.service
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.QueueStorage
+import com.podcastplayer.app.data.local.SavedPodcastsStorage
+import com.podcastplayer.app.data.remote.RssParser
+import com.podcastplayer.app.data.remote.iTunesApi
+import com.podcastplayer.app.data.repository.DownloadManager
+import com.podcastplayer.app.data.repository.PodcastRepository
+import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.Podcast
+import java.util.concurrent.TimeUnit
+
+/**
+ * Periodic background worker that auto-downloads new episodes for podcasts the
+ * user opted into.
+ *
+ * Sources of subscribed podcasts:
+ *  - [SavedPodcastsStorage] entries with `autoDownload = true`
+ *  - [QueueStorage] queues with `autoDownload = true` (transitively, all podcasts in them)
+ *
+ * For each candidate podcast we pull the RSS feed, then for episodes that are
+ * (a) newer than [MAX_AGE_DAYS] days, (b) not already in `downloaded_episodes`,
+ * we kick off a download via [DownloadManager]. This keeps the worker bounded
+ * even when a feed has years of backlog.
+ */
+class AutoDownloadWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            runAutoDownload(applicationContext)
+            Result.success()
+        } catch (t: Throwable) {
+            // Periodic work: retry on next run, no point hammering on transient failures.
+            Result.success()
+        }
+    }
+
+    companion object {
+        const val UNIQUE_WORK_NAME = "vibe.autodownload"
+
+        /** Default cadence. Picked in product chat — 24h hits new daily-show drops next morning. */
+        private val DEFAULT_INTERVAL_HOURS = 24L
+
+        /** Drop episodes older than this when auto-downloading; avoid pulling a 5-year backlog. */
+        private const val MAX_AGE_DAYS = 14L
+
+        /**
+         * Schedule the worker on app start. KEEP policy means we don't reset the
+         * timer on every cold start — once enrolled, it runs on its own schedule.
+         */
+        fun enqueuePeriodic(context: Context) {
+            // UNMETERED → Wi-Fi only by default. Auto-download can pull substantial
+            // bandwidth and we'd rather miss a day than burn the user's cellular data.
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+
+            val request = PeriodicWorkRequestBuilder<AutoDownloadWorker>(
+                DEFAULT_INTERVAL_HOURS, TimeUnit.HOURS,
+            )
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                UNIQUE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        /**
+         * Drive the auto-download loop directly. Exposed so the UI's "Refresh now"
+         * action can trigger an immediate run.
+         */
+        suspend fun runAutoDownload(context: Context) {
+            val savedStorage = SavedPodcastsStorage(context)
+            val queueStorage = QueueStorage(context)
+            val saved = savedStorage.savedPodcasts.value
+            val queues = queueStorage.queues.value
+
+            // De-dupe podcasts that are auto-downloaded via either the podcast flag or
+            // a queue that the podcast belongs to.
+            val savedById = saved.associateBy { it.id }
+            val fromPodcasts = saved.filter { it.autoDownload }
+            val fromQueues = queues.filter { it.autoDownload }
+                .flatMap { it.podcastIds }
+                .mapNotNull { savedById[it] }
+            val candidates = (fromPodcasts + fromQueues).distinctBy { it.id }
+            if (candidates.isEmpty()) return
+
+            val repository = PodcastRepository(iTunesApi.create(), RssParser())
+            val downloadManager = DownloadManager(context)
+            val downloadedDao = DatabaseProvider.getDatabase(context).downloadedEpisodeDao()
+
+            val cutoffMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_AGE_DAYS)
+
+            for (podcast in candidates) {
+                val feedUrl = podcast.feedUrl ?: continue
+                val episodes = repository.getEpisodes(feedUrl, podcast.id).getOrNull()
+                    ?: continue
+
+                val freshEpisodes = episodes.filter { ep ->
+                    val pubMs = ep.pubDate?.time ?: 0L
+                    pubMs >= cutoffMs
+                }
+
+                for (episode in freshEpisodes) {
+                    if (downloadedDao.isEpisodeDownloaded(episode.id)) continue
+                    val withArtwork = ensureArtwork(episode, podcast)
+                    // Result is ignored — periodic work; we'll try again next interval.
+                    downloadManager.downloadEpisode(withArtwork)
+                }
+            }
+        }
+
+        private fun ensureArtwork(episode: Episode, podcast: Podcast): Episode {
+            return if (episode.imageUrl != null) episode
+            else episode.copy(imageUrl = podcast.artworkUrl)
+        }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -6,9 +6,12 @@ import android.net.Uri
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import com.podcastplayer.app.data.local.DatabaseProvider
 import java.io.File
 import java.util.concurrent.Executors
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.withContext
 
 class PlayerController private constructor(private val context: Context) {
 
@@ -22,6 +25,9 @@ class PlayerController private constructor(private val context: Context) {
 
     private val executor = Executors.newSingleThreadExecutor()
     private val playbackSessionStorage = PlaybackSessionStorage(context)
+    private val playbackProgressDao by lazy {
+        DatabaseProvider.getDatabase(context).playbackProgressDao()
+    }
 
     private fun episodeToMediaItem(
         episode: com.podcastplayer.app.domain.model.Episode,
@@ -34,9 +40,8 @@ class PlayerController private constructor(private val context: Context) {
             .setArtworkUri(artworkUrl?.let { android.net.Uri.parse(it) })
             .build()
 
-        val mediaUri = episode.localPath?.takeIf { episode.isDownloaded }?.let {
-            Uri.fromFile(File(it))
-        } ?: Uri.parse(episode.audioUrl)
+        val mediaUri = episode.localPath?.takeIf { episode.isDownloaded }?.let { resolveLocalUri(it) }
+            ?: Uri.parse(episode.audioUrl)
 
         return androidx.media3.common.MediaItem.Builder()
             .setMediaId(episode.id)
@@ -45,18 +50,30 @@ class PlayerController private constructor(private val context: Context) {
             .build()
     }
 
-    suspend fun playEpisode(episode: com.podcastplayer.app.domain.model.Episode, artworkUrl: String?) {
+    /**
+     * Saved listen-position for [episodeId], or null if the user hasn't started it
+     * or already finished it. Looked up before `prepare()` so resume is baked into
+     * the MediaItem rather than racing the player's STATE_READY callback.
+     */
+    private suspend fun resumePositionFor(episodeId: String): Long? = withContext(Dispatchers.IO) {
+        val saved = playbackProgressDao.getByEpisodeId(episodeId) ?: return@withContext null
+        if (saved.completed || saved.positionMs <= 0L) null else saved.positionMs
+    }
+
+    suspend fun playEpisode(episode: com.podcastplayer.app.domain.model.Episode, artworkUrl: String?): Long {
         val controller = controllerFuture.await()
-        controller.setMediaItem(episodeToMediaItem(episode, artworkUrl))
+        val startMs = resumePositionFor(episode.id) ?: 0L
+        controller.setMediaItem(episodeToMediaItem(episode, artworkUrl), startMs)
         controller.prepare()
         controller.play()
+        return startMs
     }
 
     suspend fun playEpisodes(
         episodes: List<com.podcastplayer.app.domain.model.Episode>,
         defaultArtworkUrl: String?
-    ) {
-        if (episodes.isEmpty()) return
+    ): Long {
+        if (episodes.isEmpty()) return 0L
 
         val controller = controllerFuture.await()
         val items = episodes.map { episode ->
@@ -66,9 +83,13 @@ class PlayerController private constructor(private val context: Context) {
             )
         }
 
-        controller.setMediaItems(items)
+        val firstEpisodeId = episodes.first().id
+        val startMs = resumePositionFor(firstEpisodeId) ?: 0L
+
+        controller.setMediaItems(items, /* startIndex= */ 0, /* startPositionMs= */ startMs)
         controller.prepare()
         controller.play()
+        return startMs
     }
 
     suspend fun play() {
@@ -150,7 +171,7 @@ class PlayerController private constructor(private val context: Context) {
     suspend fun getCurrentEpisode(): com.podcastplayer.app.domain.model.Episode? {
         val item = controllerFuture.await().currentMediaItem ?: return null
         val uri = item.localConfiguration?.uri?.toString().orEmpty()
-        val isLocal = uri.startsWith("file://")
+        val isLocal = uri.startsWith("file://") || uri.startsWith("content://")
         return com.podcastplayer.app.domain.model.Episode(
             id = item.mediaId,
             podcastId = item.mediaMetadata.artist?.toString().orEmpty(),
@@ -161,10 +182,16 @@ class PlayerController private constructor(private val context: Context) {
             duration = null,
             imageUrl = item.mediaMetadata.artworkUri?.toString(),
             isDownloaded = isLocal,
-            localPath = if (isLocal) item.localConfiguration?.uri?.path else null,
+            localPath = if (isLocal) {
+                if (uri.startsWith("content://")) uri else item.localConfiguration?.uri?.path
+            } else null,
             mediaType = inferMediaType(uri),
         )
     }
+
+    /** Build a media URI from a stored path — handles file paths AND content:// URIs. */
+    private fun resolveLocalUri(localPath: String): Uri =
+        if (localPath.startsWith("content://")) Uri.parse(localPath) else Uri.fromFile(File(localPath))
 
     /**
      * Best-effort inference of [com.podcastplayer.app.domain.model.MediaType] from a file

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -194,10 +194,27 @@ class PlayerController private constructor(private val context: Context) {
         if (localPath.startsWith("content://")) Uri.parse(localPath) else Uri.fromFile(File(localPath))
 
     /**
-     * Best-effort inference of [com.podcastplayer.app.domain.model.MediaType] from a file
-     * URI's extension, used when restoring a session (issue #33). Defaults to AUDIO.
+     * Best-effort inference of [com.podcastplayer.app.domain.model.MediaType] from a
+     * media URI, used when restoring a session or reconstructing an Episode from the
+     * MediaController. We check the extension for `file://` URIs and ask the
+     * ContentResolver for `content://` URIs (e.g. MediaStore-published downloads,
+     * which don't carry a visible extension). Defaults to AUDIO.
      */
     private fun inferMediaType(uri: String): com.podcastplayer.app.domain.model.MediaType {
+        if (uri.startsWith("content://")) {
+            val mime = try {
+                context.contentResolver.getType(Uri.parse(uri))
+            } catch (_: Throwable) {
+                null
+            }
+            if (mime?.startsWith("video/") == true) {
+                return com.podcastplayer.app.domain.model.MediaType.VIDEO
+            }
+            if (mime?.startsWith("audio/") == true) {
+                return com.podcastplayer.app.domain.model.MediaType.AUDIO
+            }
+            // Fall through to extension sniffing if MIME isn't available.
+        }
         val ext = uri.substringAfterLast('.', "").substringBefore('?').lowercase()
         val videoExts = setOf("mp4", "webm", "mkv", "mov", "avi", "m4v")
         return if (ext in videoExts) {

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class PlayerService : MediaSessionService() {
 
@@ -38,7 +39,6 @@ class PlayerService : MediaSessionService() {
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(serviceJob + Dispatchers.Main)
     private var persistJob: Job? = null
-    private var pendingSeekToMs: Long? = null
 
     private val playbackProgressDao by lazy { DatabaseProvider.getDatabase(this).playbackProgressDao() }
     private val playbackSessionStorage by lazy { PlaybackSessionStorage(this) }
@@ -69,21 +69,29 @@ class PlayerService : MediaSessionService() {
                 override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                     val episodeId = mediaItem?.mediaId?.takeIf { it.isNotBlank() } ?: return
 
-                    serviceScope.launch(Dispatchers.IO) {
-                        val saved = playbackProgressDao.getByEpisodeId(episodeId)
-                        pendingSeekToMs = saved?.takeIf { !it.completed }?.positionMs
+                    // Resume position is already baked in when [PlayerController] calls
+                    // setMediaItem(item, startMs), so we only need to seek on auto-advance
+                    // through a queue or when the user pressed skip-next / skip-previous.
+                    val shouldResume = reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO ||
+                        reason == Player.MEDIA_ITEM_TRANSITION_REASON_SEEK
+                    if (shouldResume) {
+                        serviceScope.launch {
+                            val saved = withContext(Dispatchers.IO) {
+                                playbackProgressDao.getByEpisodeId(episodeId)
+                            }
+                            val resumeMs = saved
+                                ?.takeIf { !it.completed && it.positionMs > 0L }
+                                ?.positionMs
+                            // User may have skipped during IO — only seek if still on this item.
+                            if (resumeMs != null && player?.currentMediaItem?.mediaId == episodeId) {
+                                player?.seekTo(resumeMs)
+                            }
+                        }
                     }
                     persistPlaybackSession(isCompleted = false)
                 }
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
-                    if (playbackState == Player.STATE_READY) {
-                        val seek = pendingSeekToMs
-                        if (seek != null && seek > 0) {
-                            pendingSeekToMs = null
-                            player?.seekTo(seek)
-                        }
-                    }
                     if (playbackState == Player.STATE_ENDED) {
                         persistProgress(markCompleted = true)
                         persistPlaybackSession(isCompleted = true)
@@ -259,7 +267,7 @@ class PlayerService : MediaSessionService() {
             .build()
 
         val mediaUri = episode.localPath?.takeIf { episode.isDownloaded }?.let {
-            Uri.fromFile(File(it))
+            if (it.startsWith("content://")) Uri.parse(it) else Uri.fromFile(File(it))
         } ?: Uri.parse(episode.audioUrl)
         val mediaItem = MediaItem.Builder()
             .setMediaId(episode.id)

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -14,8 +14,10 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.podcastplayer.app.MainActivity
 import com.podcastplayer.app.PodcastApplication
+import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.data.repository.UrlDownloadRepository
 import com.podcastplayer.app.data.repository.UrlDownloadStatus
+import com.podcastplayer.app.domain.model.MediaType
 import com.yausername.youtubedl_android.YoutubeDL
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -145,13 +147,24 @@ class UrlDownloadService : Service() {
                 return
             }
 
-            // Move into a flat name to keep paths predictable across reboots.
-            val finalFile = File(outDir, "${id}.${produced.extension}")
-            if (finalFile.exists()) finalFile.delete()
-            val moved = produced.renameTo(finalFile)
-            val output = if (moved) finalFile else produced
+            // Try to publish to MediaStore (Android 10+) so VLC, Files, and the
+            // Gallery can discover the file. Falls back to app-private storage on
+            // older devices.
+            val mediaType = MediaType.fromTag(entity.mediaType)
+            val displayName = buildDisplayName(entity.title, produced.extension)
+            val saved = publishToMediaStore(produced, mediaType, displayName)
 
-            repository.markCompleted(id, output)
+            if (saved != null) {
+                repository.markCompleted(id, saved.uri.toString(), saved.sizeBytes)
+                produced.delete()
+            } else {
+                // Move into a flat name to keep paths predictable across reboots.
+                val finalFile = File(outDir, "${id}.${produced.extension}")
+                if (finalFile.exists()) finalFile.delete()
+                val moved = produced.renameTo(finalFile)
+                val output = if (moved) finalFile else produced
+                repository.markCompleted(id, output.absolutePath, output.length())
+            }
             // Best-effort cleanup of leftover sidecar files.
             workdir.listFiles()?.forEach { it.delete() }
             workdir.delete()
@@ -168,6 +181,48 @@ class UrlDownloadService : Service() {
             activeJobs.remove(id)
             processIds.remove(id)
         }
+    }
+
+    /**
+     * Publish [produced] into MediaStore (audio or video). Returns null on API < 29
+     * or if MediaStore write fails, so the caller can fall back to a local file.
+     */
+    private fun publishToMediaStore(
+        produced: File,
+        mediaType: MediaType,
+        displayName: String,
+    ): MediaStoreSaver.SavedMedia? {
+        if (!MediaStoreSaver.isSupported()) return null
+        val ext = produced.extension.lowercase()
+        return when (mediaType) {
+            MediaType.AUDIO -> {
+                val mime = when (ext) {
+                    "mp3" -> "audio/mpeg"
+                    "m4a", "aac" -> "audio/mp4"
+                    "ogg", "oga" -> "audio/ogg"
+                    "opus" -> "audio/opus"
+                    "wav" -> "audio/wav"
+                    else -> "audio/mpeg"
+                }
+                MediaStoreSaver.saveAudioFromFile(applicationContext, displayName, mime, produced)
+            }
+            MediaType.VIDEO -> {
+                val mime = when (ext) {
+                    "mp4", "m4v" -> "video/mp4"
+                    "webm" -> "video/webm"
+                    "mkv" -> "video/x-matroska"
+                    else -> "video/mp4"
+                }
+                MediaStoreSaver.saveVideoFromFile(applicationContext, displayName, mime, produced)
+            }
+        }
+    }
+
+    /** Sanitize + append the source extension. Caps length so MediaStore is happy. */
+    private fun buildDisplayName(title: String, extension: String): String {
+        val safe = title.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().take(80)
+        val base = if (safe.isBlank()) "vibe-clip" else safe
+        return "$base.${extension.ifBlank { "mp4" }}"
     }
 
     private fun pickProducedFile(dir: File): File? {

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -151,7 +151,7 @@ class UrlDownloadService : Service() {
             // Gallery can discover the file. Falls back to app-private storage on
             // older devices.
             val mediaType = MediaType.fromTag(entity.mediaType)
-            val displayName = buildDisplayName(entity.title, produced.extension)
+            val displayName = buildDisplayName(entity.title, entity.uploader, produced.extension)
             val saved = publishToMediaStore(produced, mediaType, displayName)
 
             if (saved != null) {
@@ -218,10 +218,21 @@ class UrlDownloadService : Service() {
         }
     }
 
-    /** Sanitize + append the source extension. Caps length so MediaStore is happy. */
-    private fun buildDisplayName(title: String, extension: String): String {
-        val safe = title.replace(Regex("[\\\\/:*?\"<>|]"), "_").trim().take(80)
-        val base = if (safe.isBlank()) "vibe-clip" else safe
+    /**
+     * Display name written to MediaStore. Prefixes the uploader (channel / poster)
+     * when available so files browsed from VLC / Gallery read e.g.
+     * "Lex Fridman - Joe Rogan #1.mp4" rather than just the bare video title.
+     * Sanitization (illegal chars, length cap) happens inside [MediaStoreSaver].
+     */
+    private fun buildDisplayName(title: String, uploader: String?, extension: String): String {
+        val rawTitle = title.trim()
+        val rawUploader = uploader?.trim()?.removePrefix("@")?.trim()
+        val base = when {
+            rawUploader.isNullOrBlank() && rawTitle.isBlank() -> "vibe-clip"
+            rawUploader.isNullOrBlank() -> rawTitle
+            rawTitle.isBlank() -> rawUploader
+            else -> "$rawUploader - $rawTitle"
+        }
         return "$base.${extension.ifBlank { "mp4" }}"
     }
 


### PR DESCRIPTION
Three reported issues bundled together:

1. Last-position resume was racing the player's STATE_READY callback. The IO
   lookup for saved progress sometimes finished after the player started, so
   the seek was silently dropped and playback began from 0. Now the resume
   position is fetched before prepare() and baked into the MediaItem via
   setMediaItem(item, startPositionMs). The PlayerService listener only
   re-applies progress on auto-advance / user skip, where the position can't
   be known up front. A transient "Resumed at MM:SS" notice surfaces on the
   player when a session resumed from a saved position.

2. RSS podcast and URL (YouTube / X) downloads now publish to MediaStore on
   Android 10+, so VLC, Files, and the Gallery discover them automatically.
   The Downloads tab now shows a unified list with type badges instead of
   hiding URL videos behind the home screen. Pre-Q falls back to app-private
   storage (no permission prompt added).

3. New auto-download path: subscribed podcasts and queues can opt in via a
   chip on the EpisodeList / Queue screens. A WorkManager periodic worker
   wakes daily on Wi-Fi, diffs each opted-in feed against the downloaded
   episodes table, and pulls new entries (capped at 14 days of backlog).