### PR TITLE
chore: enable R8, backup rules, dedupe morning-queue effect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,18 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            // R8 full mode + resource shrinking. Together these typically cut 30-40%
+            // off the dex/resources for a Compose + Media3 app. Rules live in
+            // proguard-rules.pro; the default-optimize file ships sensible defaults
+            // for AndroidX libraries.
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+        debug {
+            // Lets debug + release sit side-by-side on the same device.
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,61 @@
+# Keep generic type info so Retrofit/Gson can deserialize.
+-keepattributes Signature
+-keepattributes *Annotation*
+
+# ─── Kotlin metadata ────────────────────────────────────────────────
+-keep class kotlin.Metadata { *; }
+-keep class kotlin.reflect.** { *; }
+
+# ─── Compose ────────────────────────────────────────────────────────
+# Compose runtime tooling references reflect into Composable singletons.
+-keep class androidx.compose.runtime.** { *; }
+-dontwarn androidx.compose.**
+
+# ─── AndroidX Media3 ────────────────────────────────────────────────
+# Media3 already ships consumer rules in newer versions, but pin a
+# few critical entries we depend on regardless.
+-keep class androidx.media3.** { *; }
+-dontwarn androidx.media3.**
+
+# ─── Retrofit / Gson / OkHttp ───────────────────────────────────────
+-keep class retrofit2.** { *; }
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# Gson uses reflection on serialized fields.
+-keep class com.google.gson.** { *; }
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+# Domain models that Gson serializes via TypeToken.
+-keep class com.podcastplayer.app.domain.model.** { *; }
+-keep class com.podcastplayer.app.data.local.QueueStorage$QueuePayload { *; }
+-keep class com.podcastplayer.app.data.remote.** { *; }
+
+# ─── Room ───────────────────────────────────────────────────────────
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+
+# ─── youtubedl-android / Python runtime ─────────────────────────────
+# The bundled Python runtime resolves classes by reflection at unpack time.
+-keep class com.yausername.** { *; }
+-dontwarn com.yausername.**
+
+# ─── WorkManager workers (reflective instantiation) ─────────────────
+-keep class * extends androidx.work.Worker
+-keep class * extends androidx.work.CoroutineWorker
+-keepclassmembers class * extends androidx.work.ListenableWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
+
+# ─── Application class / Services (manifest-referenced) ─────────────
+-keep class com.podcastplayer.app.PodcastApplication { *; }
+-keep class com.podcastplayer.app.MainActivity { *; }
+-keep class com.podcastplayer.app.service.** { *; }
+
+# Allow stripping noisy classes safely.
+-dontwarn javax.annotation.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <application
         android:name=".PodcastApplication"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -128,50 +128,19 @@ fun PodcastNavHost(
         }
     }
 
-    // Auto-play Morning queue when app is opened before 8:30 AM
+    // Auto-play Morning queue when app is opened before 8:30 AM (issue #4).
     LaunchedEffect(Unit) {
         val now = java.time.LocalTime.now()
         if (now >= java.time.LocalTime.of(8, 30)) return@LaunchedEffect
 
-        // Wait for session restore in PlayerViewModel.init to complete
+        // Wait for session restore in PlayerViewModel.init to complete.
         delay(2000)
 
-        // Don't override an existing/restored session
-        if (playerViewModel.currentEpisode.value != null) return@LaunchedEffect
-
-        // Find "Morning" queue and resolve its podcasts
-        val morningPayload = queueStorage.queues.value
-            .firstOrNull { it.name.equals("Morning", ignoreCase = true) }
-            ?: return@LaunchedEffect
-
-        val savedMap = podcastViewModel.savedPodcasts.value.associateBy { it.id }
-        val podcasts = morningPayload.podcastIds.mapNotNull { savedMap[it] }
-        if (podcasts.isEmpty()) return@LaunchedEffect
-
-        // Build unplayed episodes and start playback
-        val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(podcasts)
-        if (episodes.isNotEmpty()) {
-            playerViewModel.playEpisodesQueue(
-                episodes = episodes,
-                defaultArtworkUrl = podcasts.firstOrNull()?.artworkUrl
-            )
-            navController.navigate(Routes.Player)
-        }
-    }
-
-    // Auto-play Morning queue when app is opened before 8:30 AM
-    LaunchedEffect(Unit) {
-        val now = java.time.LocalTime.now()
-        if (now >= java.time.LocalTime.of(8, 30)) return@LaunchedEffect
-
-        // Wait for session restore in PlayerViewModel.init to complete
-        delay(2000)
-
-        // Only skip auto-play if something is actively playing/loading (not paused/restored)
+        // Only skip auto-play if something is actively playing/loading (not paused/restored).
         val playbackState = playerViewModel.playerState.value.state
         if (playbackState == PlaybackState.PLAYING || playbackState == PlaybackState.LOADING) return@LaunchedEffect
 
-        // Find "Morning" queue and resolve its podcasts
+        // Find "Morning" queue and resolve its podcasts.
         val morningPayload = queueStorage.queues.value
             .firstOrNull { it.name.equals("Morning", ignoreCase = true) }
             ?: return@LaunchedEffect
@@ -180,7 +149,6 @@ fun PodcastNavHost(
         val podcasts = morningPayload.podcastIds.mapNotNull { savedMap[it] }
         if (podcasts.isEmpty()) return@LaunchedEffect
 
-        // Build unplayed episodes and start playback
         val episodes = podcastViewModel.buildUnplayedEpisodesForPodcastQueue(podcasts)
         if (episodes.isNotEmpty()) {
             playerViewModel.playEpisodesQueue(

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Used by Auto Backup on API 23-30 (android:fullBackupContent).
+  Skips downloaded media + the player session — those are reproducible and
+  can be very large. Keep the SharedPreferences (subscriptions, queues,
+  auto-download flags) and the Room database (episode metadata + progress).
+-->
+<full-backup-content>
+    <exclude domain="external" path="Podcasts/episodes/" />
+    <exclude domain="file" path="url_downloads/" />
+    <exclude domain="sharedpref" path="player_session.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Used by Auto Backup on API 31+ (android:dataExtractionRules).
+  Same logic as backup_rules.xml — exclude bulky reproducible files so
+  user accounts don't accumulate gigabytes of cached audio in Drive.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="external" path="Podcasts/episodes/" />
+        <exclude domain="file" path="url_downloads/" />
+        <exclude domain="sharedpref" path="player_session.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="external" path="Podcasts/episodes/" />
+        <exclude domain="file" path="url_downloads/" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary
- Enable R8 + resource shrinking for release builds; add a proguard ruleset that keeps Compose, Media3, Retrofit/Gson, Room, WorkManager, and the bundled yt-dlp Python runtime safe.
- Add backup-extraction rules excluding downloaded media + player session from Auto Backup. Avoids ballooning users' Drive quotas with reproducible cache.
- Add `applicationIdSuffix = ".debug"` so debug + release builds can coexist on the same device.
- Remove a duplicate `LaunchedEffect` block in `PodcastNavHost` that ran the Morning queue auto-play twice (the second variant was the more correct one — kept that, dropped the first).

## Test plan
- [ ] `./gradlew assembleRelease` succeeds with R8 minification on
- [ ] Release APK launches and plays an episode (regression check: no class missed by proguard)
- [ ] Debug + release builds install side-by-side
- [ ] Auto Backup does not include `Podcasts/episodes/` or `url_downloads/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_