### PR TITLE
feat: add settings screen (theme, default speed, cellular policy)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,8 @@ android {
 
     buildFeatures {
         compose = true
+        // Generate BuildConfig so we can surface versionName etc. in the UI.
+        buildConfig = true
     }
 
     composeOptions {

--- a/app/src/main/java/com/podcastplayer/app/MainActivity.kt
+++ b/app/src/main/java/com/podcastplayer/app/MainActivity.kt
@@ -7,11 +7,13 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.data.repository.UrlValidator
 import com.podcastplayer.app.presentation.ui.PodcastNavHost
 import com.podcastplayer.app.ui.theme.PodcastPlayerTheme
@@ -31,8 +33,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pendingShareUrl = extractSharedUrl(intent)
+        val settings = AppSettings.getInstance(this)
         setContent {
-            PodcastPlayerTheme {
+            val themeMode by settings.themeMode.collectAsState()
+            PodcastPlayerTheme(themeMode = themeMode) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/java/com/podcastplayer/app/data/local/AppSettings.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/AppSettings.kt
@@ -1,0 +1,83 @@
+package com.podcastplayer.app.data.local
+
+import android.content.Context
+import androidx.core.content.edit
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * App-wide user preferences. SharedPreferences-backed for simplicity (small,
+ * structured, doesn't need streaming). Each property is exposed as a
+ * `StateFlow<…>` so Compose can observe changes without an explicit refresh.
+ *
+ * Designed as a process-wide singleton; instantiating multiple instances
+ * with the same context backing them is safe (they read/write the same prefs)
+ * but only one will have a "live" flow tracking external writes — keep
+ * one instance per app process.
+ */
+class AppSettings private constructor(context: Context) {
+
+    private val prefs = context.applicationContext
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val _themeMode = MutableStateFlow(loadTheme())
+    val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
+
+    private val _defaultPlaybackSpeed = MutableStateFlow(loadSpeed())
+    val defaultPlaybackSpeed: StateFlow<Float> = _defaultPlaybackSpeed.asStateFlow()
+
+    private val _autoDownloadOnCellular = MutableStateFlow(loadAutoDlCellular())
+    val autoDownloadOnCellular: StateFlow<Boolean> = _autoDownloadOnCellular.asStateFlow()
+
+    fun setThemeMode(mode: ThemeMode) {
+        prefs.edit { putString(KEY_THEME, mode.name) }
+        _themeMode.value = mode
+    }
+
+    fun setDefaultPlaybackSpeed(speed: Float) {
+        val clamped = speed.coerceIn(MIN_SPEED, MAX_SPEED)
+        prefs.edit { putFloat(KEY_SPEED, clamped) }
+        _defaultPlaybackSpeed.value = clamped
+    }
+
+    fun setAutoDownloadOnCellular(enabled: Boolean) {
+        prefs.edit { putBoolean(KEY_AUTODL_CELL, enabled) }
+        _autoDownloadOnCellular.value = enabled
+    }
+
+    private fun loadTheme(): ThemeMode {
+        val raw = prefs.getString(KEY_THEME, null) ?: return ThemeMode.SYSTEM
+        return runCatching { ThemeMode.valueOf(raw) }.getOrDefault(ThemeMode.SYSTEM)
+    }
+
+    private fun loadSpeed(): Float = prefs.getFloat(KEY_SPEED, 1.0f).coerceIn(MIN_SPEED, MAX_SPEED)
+
+    private fun loadAutoDlCellular(): Boolean = prefs.getBoolean(KEY_AUTODL_CELL, false)
+
+    companion object {
+        const val MIN_SPEED = 0.5f
+        const val MAX_SPEED = 3.0f
+        val PLAYBACK_SPEEDS = floatArrayOf(0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+
+        private const val PREFS_NAME = "app_settings"
+        private const val KEY_THEME = "theme_mode"
+        private const val KEY_SPEED = "default_playback_speed"
+        private const val KEY_AUTODL_CELL = "autodownload_cellular"
+
+        @Volatile
+        private var instance: AppSettings? = null
+
+        fun getInstance(context: Context): AppSettings {
+            return instance ?: synchronized(this) {
+                instance ?: AppSettings(context.applicationContext).also { instance = it }
+            }
+        }
+    }
+}
+
+/**
+ * Theme override. `SYSTEM` follows the OS dark-mode setting; `LIGHT` and `DARK`
+ * lock the app regardless of OS.
+ */
+enum class ThemeMode { SYSTEM, LIGHT, DARK }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerViewModelFactory.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerViewModelFactory.kt
@@ -2,18 +2,20 @@ package com.podcastplayer.app.presentation.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.presentation.viewmodel.PlayerViewModel
 import com.podcastplayer.app.service.PlaybackSessionStorage
 import com.podcastplayer.app.service.PlayerController
 
 class PlayerViewModelFactory(
     private val playerController: PlayerController,
-    private val playbackSessionStorage: PlaybackSessionStorage
+    private val playbackSessionStorage: PlaybackSessionStorage,
+    private val appSettings: AppSettings,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(PlayerViewModel::class.java)) {
-            return PlayerViewModel(playerController, playbackSessionStorage) as T
+            return PlayerViewModel(playerController, playbackSessionStorage, appSettings) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -89,6 +89,7 @@ fun PodcastListScreen(
     onAddFromUrl: (String) -> Unit = {},
     onExportOpml: () -> Unit = {},
     onImportOpml: () -> Unit = {},
+    onOpenSettings: () -> Unit = {},
 ) {
     val colors = MaterialTheme.colorScheme
     var searchQuery by remember { mutableStateOf("") }
@@ -158,6 +159,10 @@ fun PodcastListScreen(
                                 expanded = overflowOpen,
                                 onDismissRequest = { overflowOpen = false },
                             ) {
+                                DropdownMenuItem(
+                                    text = { Text("Settings") },
+                                    onClick = { overflowOpen = false; onOpenSettings() },
+                                )
                                 DropdownMenuItem(
                                     text = { Text("Export subscriptions") },
                                     onClick = { overflowOpen = false; onExportOpml() },

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -26,6 +26,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.podcastplayer.app.BuildConfig
+import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
@@ -51,6 +53,7 @@ private object Routes {
     const val Queue = "queue"
     const val Downloads = "downloads"
     const val Player = "player"
+    const val Settings = "settings"
 
     const val EpisodesBase = "episodes"
     const val PodcastIdArg = "podcastId"
@@ -78,6 +81,7 @@ fun PodcastNavHost(
     val context = LocalContext.current
     val db = remember { DatabaseProvider.getDatabase(context) }
     val queueStorage = remember { QueueStorage(context) }
+    val appSettings = remember { AppSettings.getInstance(context) }
     val application = context.applicationContext as android.app.Application
 
     // Keep ViewModel scoping identical to the previous implementation (created once at the top level).
@@ -93,7 +97,8 @@ fun PodcastNavHost(
     val playerViewModel: PlayerViewModel = viewModel(
         factory = PlayerViewModelFactory(
             PlayerController.getInstance(context),
-            PlaybackSessionStorage(context)
+            PlaybackSessionStorage(context),
+            appSettings,
         )
     )
     val urlDownloadViewModel: UrlDownloadViewModel = viewModel(
@@ -357,7 +362,8 @@ fun PodcastNavHost(
                         onExportOpml = { exportLauncher.launch("vibe-podcasts.opml") },
                         onImportOpml = {
                             importLauncher.launch(arrayOf("text/x-opml", "text/xml", "application/xml", "*/*"))
-                        }
+                        },
+                        onOpenSettings = { navController.navigate(Routes.Settings) },
                     )
                 }
 
@@ -512,6 +518,29 @@ fun PodcastNavHost(
                             }
                         },
                         onBack = { navController.popBackStack(route = Routes.Home, inclusive = false) }
+                    )
+                }
+
+                composable(Routes.Settings) {
+                    val themeMode by appSettings.themeMode.collectAsState()
+                    val defaultSpeed by appSettings.defaultPlaybackSpeed.collectAsState()
+                    val autoDownloadOnCellular by appSettings.autoDownloadOnCellular.collectAsState()
+
+                    SettingsScreen(
+                        themeMode = themeMode,
+                        defaultPlaybackSpeed = defaultSpeed,
+                        autoDownloadOnCellular = autoDownloadOnCellular,
+                        appVersion = BuildConfig.VERSION_NAME,
+                        onThemeChange = appSettings::setThemeMode,
+                        onPlaybackSpeedChange = appSettings::setDefaultPlaybackSpeed,
+                        onAutoDownloadCellularChange = { enabled ->
+                            appSettings.setAutoDownloadOnCellular(enabled)
+                            // Re-schedule the worker so the new network constraint takes effect.
+                            com.podcastplayer.app.service.AutoDownloadWorker.reschedule(
+                                context, allowCellular = enabled,
+                            )
+                        },
+                        onBack = { navController.popBackStack() },
                     )
                 }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/SettingsScreen.kt
@@ -1,0 +1,337 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.outlined.DarkMode
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.LightMode
+import androidx.compose.material.icons.outlined.Smartphone
+import androidx.compose.material.icons.outlined.Speed
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.podcastplayer.app.data.local.AppSettings
+import com.podcastplayer.app.data.local.ThemeMode
+import com.podcastplayer.app.ui.theme.JetBrainsMono
+
+@Composable
+fun SettingsScreen(
+    themeMode: ThemeMode,
+    defaultPlaybackSpeed: Float,
+    autoDownloadOnCellular: Boolean,
+    appVersion: String,
+    onThemeChange: (ThemeMode) -> Unit,
+    onPlaybackSpeedChange: (Float) -> Unit,
+    onAutoDownloadCellularChange: (Boolean) -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        VibeTopBar(
+            title = "Settings",
+            eyebrow = "Preferences",
+            onBack = onBack,
+        )
+
+        SettingsGroup(label = "Appearance") {
+            ThemePicker(current = themeMode, onSelect = onThemeChange)
+        }
+
+        SettingsGroup(label = "Playback") {
+            SpeedPicker(current = defaultPlaybackSpeed, onSelect = onPlaybackSpeedChange)
+        }
+
+        SettingsGroup(label = "Downloads") {
+            SwitchRow(
+                icon = Icons.Outlined.CloudDownload,
+                title = "Auto-download on cellular",
+                subtitle = "When off, auto-download only runs on Wi-Fi.",
+                checked = autoDownloadOnCellular,
+                onCheckedChange = onAutoDownloadCellularChange,
+            )
+        }
+
+        SettingsGroup(label = "About") {
+            InfoRow(
+                icon = Icons.Outlined.Info,
+                title = "Vibe Podcast",
+                subtitle = "Version $appVersion",
+            )
+        }
+
+        Spacer(Modifier.height(120.dp))
+    }
+}
+
+@Composable
+private fun SettingsGroup(label: String, content: @Composable () -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        VibeSectionEyebrow(text = label, modifier = Modifier.padding(start = 4.dp, bottom = 8.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(14.dp))
+                .background(colors.surface)
+                .border(1.dp, colors.outline, RoundedCornerShape(14.dp))
+                .padding(vertical = 4.dp),
+        ) { content() }
+    }
+}
+
+@Composable
+private fun ThemePicker(current: ThemeMode, onSelect: (ThemeMode) -> Unit) {
+    val options = listOf(
+        ThemeOption(ThemeMode.SYSTEM, "System", Icons.Outlined.Smartphone),
+        ThemeOption(ThemeMode.LIGHT, "Light", Icons.Outlined.LightMode),
+        ThemeOption(ThemeMode.DARK, "Dark", Icons.Outlined.DarkMode),
+    )
+    Column {
+        options.forEachIndexed { index, opt ->
+            SelectableRow(
+                icon = opt.icon,
+                title = opt.label,
+                selected = current == opt.mode,
+                onClick = { onSelect(opt.mode) },
+            )
+            if (index != options.lastIndex) DividerHairline()
+        }
+    }
+}
+
+@Composable
+private fun SpeedPicker(current: Float, onSelect: (Float) -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    val speeds = AppSettings.PLAYBACK_SPEEDS
+    Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Outlined.Speed,
+                contentDescription = null,
+                tint = colors.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Default playback speed",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = colors.onSurface,
+                )
+                Text(
+                    text = "Applied each time you start an episode.",
+                    fontSize = 11.sp,
+                    color = colors.onSurfaceVariant,
+                )
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            speeds.forEach { speed ->
+                val active = kotlin.math.abs(current - speed) < 0.01f
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(32.dp)
+                        .clip(RoundedCornerShape(999.dp))
+                        .background(if (active) colors.primary else colors.surfaceVariant)
+                        .clickable { onSelect(speed) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = formatSpeedLabel(speed),
+                        fontFamily = JetBrainsMono,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (active) colors.onPrimary else colors.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectableRow(
+    icon: ImageVector,
+    title: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = if (selected) colors.primary else colors.onSurfaceVariant,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = title,
+            fontSize = 14.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            color = if (selected) colors.primary else colors.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+        if (selected) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(colors.primary),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SwitchRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = colors.onSurfaceVariant,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = colors.onSurface,
+            )
+            Text(
+                text = subtitle,
+                fontSize = 11.sp,
+                color = colors.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = colors.onPrimary,
+                checkedTrackColor = colors.primary,
+                uncheckedThumbColor = colors.surfaceVariant,
+                uncheckedTrackColor = colors.outline,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun InfoRow(icon: ImageVector, title: String, subtitle: String) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = colors.onSurfaceVariant,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                color = colors.onSurface,
+            )
+            Text(
+                text = subtitle,
+                fontSize = 11.sp,
+                fontFamily = JetBrainsMono,
+                color = colors.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DividerHairline() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp)
+            .height(1.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant),
+    )
+}
+
+private fun formatSpeedLabel(speed: Float): String {
+    return if (speed == speed.toInt().toFloat()) {
+        "${speed.toInt()}x"
+    } else {
+        // Drop trailing zero: 1.50 → 1.5
+        val trimmed = "%.2f".format(speed).trimEnd('0').trimEnd('.')
+        "${trimmed}x"
+    }
+}
+
+private data class ThemeOption(val mode: ThemeMode, val label: String, val icon: ImageVector)

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.domain.model.PlayerState
@@ -18,7 +19,8 @@ import kotlinx.coroutines.launch
 
 class PlayerViewModel(
     private val playerController: PlayerController,
-    private val playbackSessionStorage: PlaybackSessionStorage
+    private val playbackSessionStorage: PlaybackSessionStorage,
+    private val appSettings: AppSettings? = null,
 ) : ViewModel() {
 
     private val _playerState = MutableStateFlow(PlayerState())
@@ -79,6 +81,7 @@ class PlayerViewModel(
             )
             try {
                 val startMs = playerController.playEpisode(episode, artworkUrl)
+                applyDefaultSpeedIfNeeded()
                 _playerState.value = _playerState.value.copy(
                     state = PlaybackState.PLAYING
                 )
@@ -90,6 +93,18 @@ class PlayerViewModel(
                 )
             }
         }
+    }
+
+    /**
+     * Apply the user's preferred default playback speed, if a setting was wired in.
+     * Called after each manual play start; auto-advance through a queue keeps the
+     * currently-set speed.
+     */
+    private suspend fun applyDefaultSpeedIfNeeded() {
+        val speed = appSettings?.defaultPlaybackSpeed?.value ?: return
+        if (kotlin.math.abs(speed - 1.0f) < 0.01f) return
+        playerController.setPlaybackSpeed(speed)
+        _playerState.value = _playerState.value.copy(playbackSpeed = speed)
     }
 
     fun playEpisodesQueue(episodes: List<Episode>, defaultArtworkUrl: String?) {
@@ -108,6 +123,7 @@ class PlayerViewModel(
 
             try {
                 val startMs = playerController.playEpisodes(episodes, defaultArtworkUrl)
+                applyDefaultSpeedIfNeeded()
                 _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
                 if (startMs > 0L) _resumedFromMs.value = startMs
                 refreshFromController()

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
@@ -8,6 +8,7 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
@@ -59,12 +60,31 @@ class AutoDownloadWorker(
         /**
          * Schedule the worker on app start. KEEP policy means we don't reset the
          * timer on every cold start — once enrolled, it runs on its own schedule.
+         * Reads the cellular preference from [AppSettings].
          */
         fun enqueuePeriodic(context: Context) {
-            // UNMETERED → Wi-Fi only by default. Auto-download can pull substantial
-            // bandwidth and we'd rather miss a day than burn the user's cellular data.
+            val cellular = AppSettings.getInstance(context).autoDownloadOnCellular.value
+            enqueueInternal(context, cellular, ExistingPeriodicWorkPolicy.KEEP)
+        }
+
+        /**
+         * Force a re-schedule with the given network constraint. Used when the
+         * user flips the "auto-download on cellular" setting so the next run
+         * picks up the new policy.
+         */
+        fun reschedule(context: Context, allowCellular: Boolean) {
+            enqueueInternal(context, allowCellular, ExistingPeriodicWorkPolicy.UPDATE)
+        }
+
+        private fun enqueueInternal(
+            context: Context,
+            allowCellular: Boolean,
+            policy: ExistingPeriodicWorkPolicy,
+        ) {
+            val networkType = if (allowCellular) NetworkType.CONNECTED else NetworkType.UNMETERED
+
             val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .setRequiredNetworkType(networkType)
                 .build()
 
             val request = PeriodicWorkRequestBuilder<AutoDownloadWorker>(
@@ -75,7 +95,7 @@ class AutoDownloadWorker(
 
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 UNIQUE_WORK_NAME,
-                ExistingPeriodicWorkPolicy.KEEP,
+                policy,
                 request,
             )
         }

--- a/app/src/main/java/com/podcastplayer/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/podcastplayer/app/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.podcastplayer.app.data.local.ThemeMode
 
 private val VibeDarkColorScheme = darkColorScheme(
     primary = VibeDarkAccent,
@@ -69,9 +70,14 @@ private val VibeLightColorScheme = lightColorScheme(
 
 @Composable
 fun PodcastPlayerTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
     content: @Composable () -> Unit
 ) {
+    val darkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+    }
     val colorScheme = if (darkTheme) VibeDarkColorScheme else VibeLightColorScheme
 
     val view = LocalView.current


### PR DESCRIPTION
## Summary
The app had no settings surface. Adds a Material3 settings screen with:

- **Theme**: System / Light / Dark
- **Default playback speed**: applied at the start of each manually-initiated playback
- **Auto-download on cellular** toggle, reschedules the WorkManager constraint when flipped
- **About**: shows `versionName`

Architecture:
- `AppSettings` (SharedPreferences-backed singleton) exposes each property as a `StateFlow`
- `PodcastPlayerTheme` now takes a `ThemeMode` enum instead of an implicit boolean; `MainActivity` observes and rebuilds on change
- `PlayerViewModel` applies `defaultPlaybackSpeed` after each manual play (auto-advance keeps the current speed so the user isn't yanked back)
- `AutoDownloadWorker.reschedule(allowCellular)` reissues the periodic request with the new `NetworkType` when the toggle flips

Entry point: overflow menu on Search/Library screen.

## Test plan
- [ ] Toggle theme → entire app re-themes immediately
- [ ] Set default speed to 1.5x → next episode plays at 1.5x; auto-advance preserves it
- [ ] Toggle "auto-download on cellular" → worker is rescheduled (verifiable via `adb shell dumpsys jobscheduler`)
- [ ] About row shows correct `versionName`
- [ ] Settings persist across app restart

## Notes
Builds on but does not conflict with #40 (R8 + backup rules).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_