### PR TITLE
feat: lightweight observability — logger + crash recorder

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/PodcastApplication.kt
+++ b/app/src/main/java/com/podcastplayer/app/PodcastApplication.kt
@@ -3,6 +3,7 @@ package com.podcastplayer.app
 import android.app.Application
 import android.util.Log
 import com.podcastplayer.app.service.AutoDownloadWorker
+import com.podcastplayer.app.util.CrashRecorder
 import com.yausername.ffmpeg.FFmpeg
 import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLException
@@ -31,6 +32,10 @@ class PodcastApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         instance = this
+
+        // Install before anything else so we capture crashes that happen during
+        // early init (e.g. yt-dlp unpacking, Room DB open, WorkManager scheduling).
+        CrashRecorder.install(this)
 
         appScope.launch {
             initYoutubeDl()

--- a/app/src/main/java/com/podcastplayer/app/util/CrashRecorder.kt
+++ b/app/src/main/java/com/podcastplayer/app/util/CrashRecorder.kt
@@ -1,0 +1,64 @@
+package com.podcastplayer.app.util
+
+import android.content.Context
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Catches uncaught exceptions and appends a structured record to a rolling
+ * file in `filesDir/crashes.log`. Always defers to the previously-installed
+ * default handler after writing, so we don't suppress system behavior
+ * (like Android's "App keeps stopping" dialog or Play Console crash reporting).
+ *
+ * Intentionally avoids any third-party crash SDK — keeps APK size flat and
+ * doesn't require user consent for analytics. The user-visible value is
+ * via a future "Send crash log" action in settings (TODO).
+ */
+object CrashRecorder {
+
+    private const val LOG_FILE = "crashes.log"
+    private const val MAX_BYTES = 256 * 1024 // 256 KB rolling cap
+
+    fun install(context: Context) {
+        val appContext = context.applicationContext
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try {
+                appendCrash(appContext, thread, throwable)
+            } catch (_: Throwable) {
+                // Best-effort — don't shadow the original crash with an IO error.
+            }
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
+    /** Returns the on-disk crash log (may not exist if there's nothing to report). */
+    fun crashLogFile(context: Context): File = File(context.filesDir, LOG_FILE)
+
+    private fun appendCrash(context: Context, thread: Thread, throwable: Throwable) {
+        val file = crashLogFile(context)
+
+        // Roll the file if it's grown past the cap — simplest implementation that
+        // keeps the most recent crash visible without unbounded growth.
+        if (file.exists() && file.length() > MAX_BYTES) file.delete()
+
+        val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+        val stack = StringWriter().also { throwable.printStackTrace(PrintWriter(it)) }.toString()
+
+        file.appendText(
+            """
+            |── $timestamp ──
+            |thread: ${thread.name}
+            |error: ${throwable.javaClass.simpleName}: ${throwable.message}
+            |
+            |$stack
+            |
+            """.trimMargin(),
+        )
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/util/Logger.kt
+++ b/app/src/main/java/com/podcastplayer/app/util/Logger.kt
@@ -1,0 +1,30 @@
+package com.podcastplayer.app.util
+
+import android.util.Log
+
+/**
+ * Thin logging facade so we don't sprinkle `android.util.Log` everywhere.
+ *
+ * Debug logs are gated by [Log.isLoggable] — clear `logcat` of `Vibe:D` lines
+ * in production by default, but flip on locally with:
+ *     adb shell setprop log.tag.Vibe DEBUG
+ *
+ * Warnings + errors always log so user-reported issues are diagnosable from
+ * `adb logcat` output.
+ */
+object Logger {
+
+    private const val DEFAULT_TAG = "Vibe"
+
+    fun d(message: String, tag: String = DEFAULT_TAG) {
+        if (Log.isLoggable(tag, Log.DEBUG)) Log.d(tag, message)
+    }
+
+    fun w(message: String, throwable: Throwable? = null, tag: String = DEFAULT_TAG) {
+        if (throwable != null) Log.w(tag, message, throwable) else Log.w(tag, message)
+    }
+
+    fun e(message: String, throwable: Throwable? = null, tag: String = DEFAULT_TAG) {
+        if (throwable != null) Log.e(tag, message, throwable) else Log.e(tag, message)
+    }
+}


### PR DESCRIPTION
## Summary
Two small, dependency-free additions to make crashes diagnosable when users report issues.

- **`Logger`** — thin facade over `android.util.Log`. Debug messages gated via `Log.isLoggable(tag, DEBUG)`: silent by default in production, flippable for local debugging with `adb shell setprop log.tag.Vibe DEBUG`.
- **`CrashRecorder`** — installs an `UncaughtExceptionHandler` that appends a timestamped stack trace to `filesDir/crashes.log` (256 KB rolling cap) before delegating to the previously-installed handler. That delegation preserves Play Console's native crash reporting and the system "App keeps stopping" dialog.

Installed in `PodcastApplication.onCreate` before any other init so we capture crashes that happen during yt-dlp unpacking, Room DB open, or WorkManager scheduling.

## Why no Firebase / Crashlytics
- Keeps APK size flat
- Avoids any consent/analytics surface — log stays on-device
- A "Send crash log" affordance in settings will land in a follow-up

## Test plan
- [ ] `Logger.d` is silent by default; `setprop log.tag.Vibe DEBUG` makes it visible
- [ ] Forcing a crash writes a record to `filesDir/crashes.log`
- [ ] Subsequent crashes append; file rolls when it exceeds 256 KB
- [ ] System "App keeps stopping" dialog still appears (default handler isn't swallowed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_