### PR TITLE
feat: mark-as-played + refresh feed action on Episodes screen

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.DownloadDone
+import androidx.compose.material.icons.outlined.MoreHoriz
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -135,6 +137,13 @@ fun EpisodeListScreen(
                     title = podcast?.title ?: "Episodes",
                     eyebrow = podcast?.artist,
                     onBack = onBack,
+                    actions = {
+                        VibeCircleIconButton(
+                            icon = Icons.Outlined.Refresh,
+                            description = "Refresh episodes",
+                            onClick = { podcastViewModel.refreshSelectedPodcastEpisodes() },
+                        )
+                    },
                 )
 
                 if (isSubscribed && podcast != null) {
@@ -232,6 +241,8 @@ fun EpisodeListScreen(
                                         onDelete = {
                                             scope.launch { podcastViewModel.deleteDownload(episode.id) }
                                         },
+                                        onMarkPlayed = { podcastViewModel.markEpisodePlayed(episode) },
+                                        onMarkUnplayed = { podcastViewModel.markEpisodeUnplayed(episode) },
                                     )
                                 }
                             }
@@ -651,10 +662,13 @@ private fun EpisodeRow(
     onClick: () -> Unit,
     onDownload: () -> Unit,
     onDelete: () -> Unit,
+    onMarkPlayed: () -> Unit = {},
+    onMarkUnplayed: () -> Unit = {},
 ) {
     val colors = MaterialTheme.colorScheme
     val description = remember(episode.description) { episode.description.stripHtml() }
     var expanded by remember { mutableStateOf(false) }
+    var menuOpen by remember { mutableStateOf(false) }
 
     VibeSurface(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(14.dp)) {
@@ -707,6 +721,39 @@ private fun EpisodeRow(
                     }
                 }
                 Spacer(Modifier.width(8.dp))
+                Box {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(RoundedCornerShape(999.dp))
+                            .clickable { menuOpen = true },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.MoreHoriz,
+                            contentDescription = "Episode actions",
+                            tint = colors.onSurfaceVariant,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                    androidx.compose.material3.DropdownMenu(
+                        expanded = menuOpen,
+                        onDismissRequest = { menuOpen = false },
+                    ) {
+                        if (isCompleted) {
+                            androidx.compose.material3.DropdownMenuItem(
+                                text = { Text("Mark as unplayed") },
+                                onClick = { menuOpen = false; onMarkUnplayed() },
+                            )
+                        } else {
+                            androidx.compose.material3.DropdownMenuItem(
+                                text = { Text("Mark as played") },
+                                onClick = { menuOpen = false; onMarkPlayed() },
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.width(4.dp))
                 Box(
                     modifier = Modifier
                         .size(40.dp)

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -267,6 +267,45 @@ class PodcastViewModel(
         return result
     }
 
+    /**
+     * Mark an episode as played without actually playing it. Stamps the
+     * playback_progress row so it appears in the "completed" filter and
+     * doesn't get auto-downloaded again.
+     */
+    fun markEpisodePlayed(episode: Episode) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val durationMs = episode.duration ?: 0L
+            val now = System.currentTimeMillis()
+            playbackProgressDao.upsert(
+                PlaybackProgressEntity(
+                    episodeId = episode.id,
+                    podcastId = episode.podcastId,
+                    positionMs = durationMs,
+                    durationMs = durationMs,
+                    completed = true,
+                    lastPlayedAtMs = now,
+                    updatedAtMs = now,
+                )
+            )
+        }
+    }
+
+    /**
+     * Reset the "played" state for an episode. Drops the progress row entirely
+     * so it surfaces back in feeds and is eligible for auto-download.
+     */
+    fun markEpisodeUnplayed(episode: Episode) {
+        viewModelScope.launch(Dispatchers.IO) {
+            playbackProgressDao.deleteByEpisodeId(episode.id)
+        }
+    }
+
+    /** Re-fetch the RSS feed for the currently-selected podcast. */
+    fun refreshSelectedPodcastEpisodes() {
+        val podcast = _selectedPodcast.value ?: return
+        loadEpisodes(podcast)
+    }
+
     fun savePodcast(podcast: Podcast) {
         viewModelScope.launch { savedPodcastsStorage.save(podcast) }
     }


### PR DESCRIPTION
## Summary
Two common podcast-app features that were missing.

- **Mark as played** — tap the new "⋯" icon on each episode row to toggle the completed state. Marking played stamps the `playback_progress` row to the episode duration with `completed = true`, so it behaves identically to "listened to the end" — auto-download won't re-fetch it and the "Played" badge appears in the list.
- **Refresh** — circle icon in the `EpisodeListScreen` top bar reruns the RSS fetch. Useful when a feed updates and you don't want to wait for the next auto-download tick.

Implementation:
- `PodcastViewModel.markEpisodePlayed(episode)` / `markEpisodeUnplayed(episode)`
- `PodcastViewModel.refreshSelectedPodcastEpisodes()` reloads the currently-selected podcast feed

## Test plan
- [ ] Long-press / more-menu → "Mark as played" → episode shows "Played" badge + greyed
- [ ] "Mark as unplayed" reverses it and the row goes back to active
- [ ] Refresh icon → feed reloads, new entries appear without restarting the app
- [ ] Marked-played episode is **not** auto-downloaded on the next worker tick

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_