### PR TITLE
perf: debounce podcast search by 300ms

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -127,7 +127,14 @@ fun PodcastListScreen(
         viewModel.clearOpmlResult()
     }
 
+    // Debounce search so we don't hammer the iTunes API on every keystroke.
+    // 300ms feels responsive while skipping intermediate states for fast typing.
     LaunchedEffect(searchQuery) {
+        if (searchQuery.isBlank()) {
+            viewModel.searchPodcasts("")
+            return@LaunchedEffect
+        }
+        kotlinx.coroutines.delay(300)
         viewModel.searchPodcasts(searchQuery)
     }
 


### PR DESCRIPTION
## Summary
`LaunchedEffect(searchQuery)` was firing on every keystroke, which sent a fresh iTunes search request per character — typing "running" issued seven network calls when the user only cared about the result for the final string. 300ms debounce so we only hit the API once typing settles.

## Test plan
- [ ] Type a multi-word search — Network Inspector shows one request, not N
- [ ] Backspacing through to empty clears results immediately (no debounce on clear)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_