### PR TITLE
feat: show total disk usage on the Downloads screen

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -212,6 +212,10 @@ class DownloadManager(private val context: Context) {
         }
     }
 
+    /** Raw entities, useful when callers need file-size or other metadata that
+     *  the domain [Episode] doesn't carry. */
+    fun getAllDownloadedEntitiesFlow(): Flow<List<DownloadedEpisodeEntity>> = dao.getAllEpisodes()
+
     suspend fun deleteEpisode(episodeId: String): Result<Unit> = withContext(Dispatchers.IO) {
         try {
             val episode = dao.getEpisodeById(episodeId)

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -63,25 +63,50 @@ data class DownloadEntryUi(
     val artworkUrl: String?,
     /** Playable Episode — used by the play handler regardless of source. */
     val episode: Episode,
+    /** On-disk byte count for this entry. 0 if unknown. */
+    val sizeBytes: Long = 0L,
 ) {
     enum class Kind { PODCAST, URL_AUDIO, URL_VIDEO }
+}
+
+/** Human-readable byte count: "456 KB", "1.2 GB", etc. Binary (1024-based) units. */
+private fun formatBytes(bytes: Long): String {
+    if (bytes <= 0L) return "0 B"
+    val units = arrayOf("B", "KB", "MB", "GB", "TB")
+    var value = bytes.toDouble()
+    var unit = 0
+    while (value >= 1024.0 && unit < units.lastIndex) {
+        value /= 1024.0
+        unit++
+    }
+    return if (unit == 0 || value >= 100.0) {
+        "%.0f %s".format(value, units[unit])
+    } else {
+        "%.1f %s".format(value, units[unit])
+    }
 }
 
 @Composable
 fun DownloadsScreen(
     entries: List<DownloadEntryUi>,
+    totalBytes: Long,
     onPlay: (DownloadEntryUi) -> Unit,
     onDelete: (DownloadEntryUi) -> Unit,
     onDeleteAll: () -> Unit,
     @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
     var showDeleteAllDialog by remember { mutableStateOf(false) }
+    val eyebrow = if (entries.isEmpty()) {
+        "Offline"
+    } else {
+        "Offline · ${entries.size} item${if (entries.size == 1) "" else "s"} · ${formatBytes(totalBytes)}"
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
             VibeTopBar(
                 title = "Downloads",
-                eyebrow = "Offline",
+                eyebrow = eyebrow,
                 actions = {
                     if (entries.isNotEmpty()) {
                         VibeChip(

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -42,6 +42,7 @@ import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.service.PlaybackSessionStorage
 import com.podcastplayer.app.service.PlayerController
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.produceState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -449,12 +450,21 @@ fun PodcastNavHost(
                     val scope = rememberCoroutineScope()
                     val podcastDownloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
                     val urlDownloads by urlDownloadViewModel.completedDownloads.collectAsState()
+                    // Raw entities give us fileSize, which the UI flows above don't carry.
+                    val podcastEntities by produceState<List<com.podcastplayer.app.data.local.DownloadedEpisodeEntity>>(
+                        initialValue = emptyList(),
+                    ) {
+                        com.podcastplayer.app.data.repository.DownloadManager(context)
+                            .getAllDownloadedEntitiesFlow()
+                            .collect { value = it }
+                    }
 
                     val urlRepository = remember(context) {
                         com.podcastplayer.app.data.repository.UrlDownloadRepository(context)
                     }
 
-                    val entries = remember(podcastDownloads, urlDownloads) {
+                    val entries = remember(podcastDownloads, urlDownloads, podcastEntities) {
+                        val sizeById = podcastEntities.associate { it.id to it.fileSize }
                         buildList {
                             podcastDownloads.forEach { item ->
                                 add(
@@ -465,6 +475,7 @@ fun PodcastNavHost(
                                         subtitle = item.podcastTitle,
                                         artworkUrl = item.episode.imageUrl ?: item.podcastArtworkUrl,
                                         episode = item.episode,
+                                        sizeBytes = sizeById[item.episode.id] ?: 0L,
                                     ),
                                 )
                             }
@@ -480,14 +491,17 @@ fun PodcastNavHost(
                                         subtitle = entity.uploader ?: entity.source.uppercase(),
                                         artworkUrl = entity.thumbnailUrl,
                                         episode = episode,
+                                        sizeBytes = entity.fileSize ?: 0L,
                                     ),
                                 )
                             }
                         }
                     }
+                    val totalBytes = remember(entries) { entries.sumOf { it.sizeBytes } }
 
                     DownloadsScreen(
                         entries = entries,
+                        totalBytes = totalBytes,
                         onPlay = { entry ->
                             playerViewModel.playEpisode(entry.episode, entry.artworkUrl)
                             navController.navigate(Routes.Player)


### PR DESCRIPTION
## Summary
The Downloads tab gave no indication of how much storage was in use. Helpful when 10 podcast episodes have eaten 2 GB and you want to decide what to keep.

- `DownloadManager.getAllDownloadedEntitiesFlow()` exposes the raw rows so callers that need `fileSize` don't have to refetch.
- `DownloadEntryUi` gets a `sizeBytes` field; NavHost populates it by joining the entity flow into the UI flow.
- `DownloadsScreen` renders **"Offline · N items · X.X GB"** in the top-bar eyebrow. Empty state stays "Offline".
- 1024-based `formatBytes` helper picks the right unit and drops decimals once the value crosses 100 (so we get "245 MB" not "245.3 MB").

## Test plan
- [ ] Empty downloads → eyebrow reads "Offline"
- [ ] Mix RSS + URL downloads → eyebrow shows accurate combined byte count
- [ ] Delete a download → total updates immediately

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_