### PR TITLE
ci: also build APK on push to main

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - 'feature/instant-play'
       - 'claude/**'
   pull_request:
@@ -36,6 +37,8 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug-apk
+          # Suffix with the short SHA so artifacts from different builds
+          # (e.g. multiple main commits) don't collide in the run list.
+          name: app-debug-apk-${{ github.sha }}
           path: app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error


### PR DESCRIPTION
## Summary
The Build debug APK workflow triggered on push to `feature/instant-play` and `claude/**`, plus PRs into `main`. It did **not** fire on push to `main`, so the seven squash-merges yesterday produced no main-branch APK artifact.

This PR adds `main` to the push branch list. Merging this PR is itself a push to main, so the merge commit will trigger the first main-based APK build.

Also suffixes the artifact name with `${{ github.sha }}` so multiple main builds don't collide under the same name in the GitHub UI.

## Test plan
- [ ] PR build still works on this `claude/**` branch (CI runs as before)
- [ ] After merge, a new run appears against `main` with an `app-debug-apk-<sha>` artifact

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_