### PR TITLE
Improve subscriptions and offline UX

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/MainActivity.kt
+++ b/app/src/main/java/com/podcastplayer/app/MainActivity.kt
@@ -1,9 +1,13 @@
 package com.podcastplayer.app
 
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -32,6 +36,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestNotificationPermissionIfNeeded()
         pendingShareUrl = extractSharedUrl(intent)
         val settings = AppSettings.getInstance(this)
         setContent {
@@ -69,5 +74,23 @@ class MainActivity : ComponentActivity() {
             else -> null
         }
         return UrlValidator.extractFirstUrl(text)
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) return
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(android.Manifest.permission.POST_NOTIFICATIONS),
+            REQUEST_POST_NOTIFICATIONS,
+        )
+    }
+
+    companion object {
+        private const val REQUEST_POST_NOTIFICATIONS = 1001
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
@@ -22,7 +22,7 @@ class SavedPodcastsStorage(context: Context) {
 
     suspend fun save(podcast: Podcast) {
         mutex.withLock {
-            val updated = (_savedPodcasts.value + podcast).distinctBy { it.id }
+            val updated = mergeDistinct(_savedPodcasts.value + podcast)
             persist(updated)
         }
     }
@@ -36,7 +36,7 @@ class SavedPodcastsStorage(context: Context) {
 
     suspend fun saveAll(podcasts: List<Podcast>) {
         mutex.withLock {
-            val updated = (_savedPodcasts.value + podcasts).distinctBy { it.id }
+            val updated = mergeDistinct(_savedPodcasts.value + podcasts)
             persist(updated)
         }
     }
@@ -64,6 +64,18 @@ class SavedPodcastsStorage(context: Context) {
         val migrated = list.map { it.copy(artworkUrl = upgradeITunesArtwork(it.artworkUrl)) }
         prefs.edit().putString(KEY_PODCASTS, gson.toJson(migrated)).apply()
         _savedPodcasts.value = migrated
+    }
+
+    private fun mergeDistinct(list: List<Podcast>): List<Podcast> {
+        val seenIds = mutableSetOf<String>()
+        val seenFeeds = mutableSetOf<String>()
+        return list.filter { podcast ->
+            val idKey = podcast.id
+            val feedKey = podcast.feedUrl?.trim()?.lowercase()
+            val idNew = seenIds.add(idKey)
+            val feedNew = feedKey == null || seenFeeds.add(feedKey)
+            idNew && feedNew
+        }
     }
 
     private fun load(): List<Podcast> {

--- a/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadDao.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadDao.kt
@@ -44,6 +44,12 @@ interface UrlDownloadDao {
     @Query("UPDATE url_downloads SET status = :status, errorMessage = :error WHERE id = :id")
     suspend fun markFailed(id: String, status: String, error: String?)
 
+    @Query("UPDATE url_downloads SET status = :status, progressPercent = :progress, errorMessage = :error WHERE id = :id")
+    suspend fun resetForRetry(id: String, status: String, progress: Float, error: String?)
+
+    @Query("UPDATE url_downloads SET status = :toStatus, progressPercent = :progress, errorMessage = :error WHERE status IN (:fromStatuses)")
+    suspend fun resetStatuses(fromStatuses: List<String>, toStatus: String, progress: Float, error: String?)
+
     @Query("DELETE FROM url_downloads WHERE id = :id")
     suspend fun deleteById(id: String)
 

--- a/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
@@ -10,6 +10,72 @@ import java.util.Locale
 
 class RssParser {
 
+    fun parsePodcast(inputStream: InputStream, feedUrl: String): PodcastFeedMetadata {
+        val factory = XmlPullParserFactory.newInstance()
+        val parser = factory.newPullParser()
+        parser.setInput(inputStream, null)
+
+        var inChannel = false
+        var inItem = false
+        var currentTag: String? = null
+        val currentText = StringBuilder()
+        var title = ""
+        var author = ""
+        var imageUrl: String? = null
+
+        var eventType = parser.eventType
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            when (eventType) {
+                XmlPullParser.START_TAG -> {
+                    currentTag = parser.name
+                    when (currentTag) {
+                        "channel", "feed" -> inChannel = true
+                        "item", "entry" -> inItem = true
+                        "itunes:image" -> if (inChannel && !inItem) {
+                            imageUrl = parser.getAttributeValue(null, "href") ?: imageUrl
+                        }
+                        "image" -> if (inChannel && !inItem) {
+                            parser.getAttributeValue(null, "href")?.let { imageUrl = it }
+                        }
+                        "media:thumbnail" -> if (inChannel && !inItem) {
+                            imageUrl = parser.getAttributeValue(null, "url") ?: imageUrl
+                        }
+                    }
+                }
+
+                XmlPullParser.TEXT -> {
+                    if (inChannel && !inItem && currentTag != null) {
+                        currentText.append(parser.text)
+                    }
+                }
+
+                XmlPullParser.END_TAG -> {
+                    if (inChannel && !inItem) {
+                        when (parser.name) {
+                            "title" -> if (title.isBlank()) title = currentText.toString().trim()
+                            "itunes:author", "author", "name" ->
+                                if (author.isBlank()) author = currentText.toString().trim()
+                            "url" -> if (imageUrl.isNullOrBlank()) imageUrl = currentText.toString().trim()
+                        }
+                    }
+                    when (parser.name) {
+                        "item", "entry" -> inItem = false
+                        "channel", "feed" -> inChannel = false
+                    }
+                    currentText.clear()
+                    currentTag = null
+                }
+            }
+            eventType = parser.next()
+        }
+
+        return PodcastFeedMetadata(
+            title = title.ifBlank { feedUrl },
+            author = author,
+            artworkUrl = imageUrl?.takeIf { it.isNotBlank() },
+        )
+    }
+
     fun parseEpisodes(inputStream: InputStream, podcastId: String): List<Episode> {
         val factory = XmlPullParserFactory.newInstance()
         val parser = factory.newPullParser()
@@ -153,3 +219,9 @@ class RssParser {
         }
     }
 }
+
+data class PodcastFeedMetadata(
+    val title: String,
+    val author: String,
+    val artworkUrl: String?,
+)

--- a/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
@@ -1,12 +1,22 @@
 package com.podcastplayer.app.data.repository
 
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
 import com.podcastplayer.app.data.remote.upgradeITunesArtwork
+import com.podcastplayer.app.domain.model.MediaType
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.domain.model.PodcastDto
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLRequest
 import java.net.URL
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -31,10 +41,75 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
     suspend fun getEpisodes(feedUrl: String, podcastId: String): Result<List<Episode>> {
         return withContext(Dispatchers.IO) {
             try {
+                if (UrlSource.classify(feedUrl) == UrlSource.YOUTUBE) {
+                    return@withContext getYoutubeEpisodes(feedUrl, podcastId)
+                }
                 val url = URL(feedUrl)
                 url.openStream().use { inputStream ->
                     val episodes = rssParser.parseEpisodes(inputStream, podcastId)
                     Result.success(episodes)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    }
+
+    private fun getYoutubeEpisodes(url: String, podcastId: String): Result<List<Episode>> {
+        if (!PodcastApplication.youtubeDlReady) {
+            return Result.failure(Exception("YouTube subscription reader is still starting. Try again shortly."))
+        }
+        return try {
+            val request = YoutubeDLRequest(url).apply {
+                addOption("--flat-playlist")
+                addOption("--dump-single-json")
+                addOption("--playlist-end", "25")
+                addOption("--socket-timeout", "30")
+            }
+            val response = YoutubeDL.getInstance().execute(request)
+            val root = JsonParser().parse(response.out).asJsonObject
+            val entries = root.getAsJsonArray("entries") ?: return Result.success(emptyList())
+            val uploader = root.stringOrNull("uploader") ?: root.stringOrNull("channel")
+            val episodes = entries.mapNotNull { element ->
+                val item = element.asJsonObject
+                val id = item.stringOrNull("id") ?: item.stringOrNull("url") ?: return@mapNotNull null
+                val webpageUrl = item.stringOrNull("webpage_url")
+                    ?: item.stringOrNull("url")?.takeIf { it.startsWith("http", ignoreCase = true) }
+                    ?: "https://www.youtube.com/watch?v=$id"
+                Episode(
+                    id = "youtube:${stableHash(webpageUrl)}",
+                    podcastId = podcastId,
+                    title = item.stringOrNull("title") ?: webpageUrl,
+                    description = uploader,
+                    pubDate = item.dateOrNull(),
+                    audioUrl = webpageUrl,
+                    duration = item.longOrNull("duration")?.let { it * 1000L },
+                    imageUrl = item.stringOrNull("thumbnail"),
+                    mediaType = MediaType.VIDEO,
+                )
+            }
+            Result.success(episodes)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getPodcastFromFeed(feedUrl: String): Result<Podcast> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val normalized = feedUrl.trim()
+                val url = URL(normalized)
+                url.openStream().use { inputStream ->
+                    val metadata = rssParser.parsePodcast(inputStream, normalized)
+                    Result.success(
+                        Podcast(
+                            id = "rss:${stableHash(normalized)}",
+                            title = metadata.title,
+                            artist = metadata.author,
+                            artworkUrl = upgradeITunesArtwork(metadata.artworkUrl),
+                            feedUrl = normalized,
+                        )
+                    )
                 }
             } catch (e: Exception) {
                 Result.failure(e)
@@ -50,5 +125,32 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
             artworkUrl = upgradeITunesArtwork(artworkUrl600 ?: artworkUrl100),
             feedUrl = feedUrl
         )
+    }
+
+    private fun stableHash(value: String): String {
+        return MessageDigest.getInstance("SHA-1")
+            .digest(value.trim().lowercase().toByteArray())
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun JsonObject.stringOrNull(name: String): String? {
+        val value = get(name) ?: return null
+        if (value.isJsonNull) return null
+        return runCatching { value.asString }.getOrNull()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun JsonObject.longOrNull(name: String): Long? {
+        val value = get(name) ?: return null
+        if (value.isJsonNull) return null
+        return runCatching { value.asLong }.getOrNull()
+    }
+
+    private fun JsonObject.dateOrNull(): Date? {
+        longOrNull("timestamp")?.let { return Date(it * 1000L) }
+        longOrNull("release_timestamp")?.let { return Date(it * 1000L) }
+        val uploadDate = stringOrNull("upload_date") ?: return null
+        return runCatching {
+            SimpleDateFormat("yyyyMMdd", Locale.US).parse(uploadDate)
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -1,6 +1,8 @@
 package com.podcastplayer.app.data.repository
 
 import android.content.Context
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.MediaStoreSaver
@@ -8,6 +10,7 @@ import com.podcastplayer.app.data.local.UrlDownloadDao
 import com.podcastplayer.app.data.local.UrlDownloadEntity
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.MediaType
+import com.podcastplayer.app.service.UrlDownloadService
 import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLException
 import com.yausername.youtubedl_android.YoutubeDLRequest
@@ -53,6 +56,14 @@ class UrlDownloadRepository(private val context: Context) {
         }
     }
 
+    /** Failed or canceled items that need a visible retry/delete surface. */
+    fun observeNeedsAttention(): Flow<List<UrlDownloadEntity>> = dao.observeAll().map { all ->
+        all.filter {
+            it.status == UrlDownloadStatus.FAILED.name ||
+                it.status == UrlDownloadStatus.CANCELED.name
+        }
+    }
+
     suspend fun get(id: String): UrlDownloadEntity? = dao.getById(id)
 
     fun observe(id: String): Flow<UrlDownloadEntity?> = dao.observeById(id)
@@ -82,6 +93,29 @@ class UrlDownloadRepository(private val context: Context) {
             null
         } catch (e: Throwable) {
             null
+        }
+    }
+
+    suspend fun fetchYoutubeSubscriptionMetadata(rawUrl: String): UrlMetadata? = withContext(Dispatchers.IO) {
+        if (!PodcastApplication.youtubeDlReady) return@withContext null
+        if (UrlSource.classify(rawUrl) != UrlSource.YOUTUBE) return@withContext null
+        try {
+            val request = YoutubeDLRequest(rawUrl).apply {
+                addOption("--flat-playlist")
+                addOption("--dump-single-json")
+                addOption("--playlist-end", "1")
+                addOption("--socket-timeout", "30")
+            }
+            val response = YoutubeDL.getInstance().execute(request)
+            val root = JsonParser().parse(response.out).asJsonObject
+            UrlMetadata(
+                title = root.stringOrNull("title") ?: rawUrl,
+                uploader = root.stringOrNull("uploader") ?: root.stringOrNull("channel"),
+                thumbnailUrl = root.stringOrNull("thumbnail"),
+                durationMs = null,
+            )
+        } catch (e: Throwable) {
+            fetchMetadata(rawUrl)
         }
     }
 
@@ -129,6 +163,10 @@ class UrlDownloadRepository(private val context: Context) {
         id
     }
 
+    fun startPump() {
+        UrlDownloadService.startPump(context)
+    }
+
     suspend fun markExtracting(id: String) = updateProgress(id, UrlDownloadStatus.EXTRACTING_METADATA, 0f)
     suspend fun markDownloading(id: String, progress: Float) =
         updateProgress(id, UrlDownloadStatus.DOWNLOADING, progress)
@@ -143,6 +181,30 @@ class UrlDownloadRepository(private val context: Context) {
 
     suspend fun markCanceled(id: String) {
         dao.markFailed(id, UrlDownloadStatus.CANCELED.name, null)
+    }
+
+    suspend fun retry(id: String): Boolean = withContext(Dispatchers.IO) {
+        val entity = dao.getById(id) ?: return@withContext false
+        if (entity.status !in RETRYABLE_STATUSES) return@withContext false
+        dao.resetForRetry(
+            id = id,
+            status = UrlDownloadStatus.QUEUED.name,
+            progress = 0f,
+            error = null,
+        )
+        true
+    }
+
+    suspend fun requeueInterrupted() = withContext(Dispatchers.IO) {
+        dao.resetStatuses(
+            fromStatuses = listOf(
+                UrlDownloadStatus.EXTRACTING_METADATA.name,
+                UrlDownloadStatus.DOWNLOADING.name,
+            ),
+            toStatus = UrlDownloadStatus.QUEUED.name,
+            progress = 0f,
+            error = "Interrupted before completion. Retrying…",
+        )
     }
 
     suspend fun markCompleted(id: String, localPath: String, fileSize: Long) {
@@ -236,6 +298,17 @@ class UrlDownloadRepository(private val context: Context) {
             UrlDownloadStatus.EXTRACTING_METADATA.name,
             UrlDownloadStatus.DOWNLOADING.name,
         )
+
+        private val RETRYABLE_STATUSES = setOf(
+            UrlDownloadStatus.FAILED.name,
+            UrlDownloadStatus.CANCELED.name,
+        )
+    }
+
+    private fun JsonObject.stringOrNull(name: String): String? {
+        val value = get(name) ?: return null
+        if (value.isJsonNull) return null
+        return runCatching { value.asString }.getOrNull()?.takeIf { it.isNotBlank() }
     }
 }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/AddFeedScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/AddFeedScreen.kt
@@ -1,0 +1,271 @@
+package com.podcastplayer.app.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Link
+import androidx.compose.material.icons.outlined.RssFeed
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.podcastplayer.app.R
+import com.podcastplayer.app.data.repository.UrlSource
+import com.podcastplayer.app.presentation.viewmodel.FeedPreviewState
+import com.podcastplayer.app.ui.theme.JetBrainsMono
+
+@Composable
+fun AddFeedScreen(
+    initialUrl: String,
+    state: FeedPreviewState,
+    onLoad: (String) -> Unit,
+    onSubscribe: () -> Unit,
+    onBack: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val focus = LocalFocusManager.current
+    var url by remember(initialUrl) { mutableStateOf(initialUrl) }
+
+    LaunchedEffect(initialUrl) {
+        if (initialUrl.isNotBlank() && state is FeedPreviewState.Idle) {
+            onLoad(initialUrl)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.background)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        VibeTopBar(
+            title = "Add show",
+            eyebrow = "RSS or YouTube",
+            onBack = onBack,
+        )
+
+        VibeSurface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+        ) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                VibeSectionEyebrow("Feed URL")
+                Spacer(Modifier.height(6.dp))
+                BasicTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    textStyle = TextStyle(
+                        color = colors.onSurface,
+                        fontSize = 13.sp,
+                        fontFamily = JetBrainsMono,
+                    ),
+                    cursorBrush = SolidColor(colors.primary),
+                    singleLine = true,
+                    keyboardActions = androidx.compose.foundation.text.KeyboardActions(
+                        onDone = {
+                            focus.clearFocus()
+                            onLoad(url)
+                        },
+                    ),
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions.Default.copy(
+                        imeAction = ImeAction.Done,
+                    ),
+                    decorationBox = { inner ->
+                        if (url.isBlank()) {
+                            Text(
+                                text = "RSS feed or YouTube playlist/channel URL",
+                                color = colors.onSurfaceVariant,
+                                fontSize = 13.sp,
+                                fontFamily = JetBrainsMono,
+                            )
+                        }
+                        inner()
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(10.dp))
+                VibePrimaryPill(
+                    label = "Look up feed",
+                    onClick = {
+                        focus.clearFocus()
+                        onLoad(url)
+                    },
+                    enabled = url.isNotBlank(),
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Link,
+                            contentDescription = null,
+                            tint = colors.onPrimary,
+                            modifier = Modifier.size(15.dp),
+                        )
+                    },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        when (state) {
+            FeedPreviewState.Idle -> FeedHint()
+            is FeedPreviewState.Loading -> FeedLoading()
+            is FeedPreviewState.Loaded -> FeedPreview(state = state, onSubscribe = onSubscribe)
+            is FeedPreviewState.Saved -> FeedSaved(title = state.podcast.title)
+            is FeedPreviewState.Error -> FeedError(message = state.message)
+        }
+
+        Spacer(Modifier.height(40.dp))
+    }
+}
+
+@Composable
+private fun FeedHint() {
+    VibeEmptyState(
+        icon = Icons.Outlined.RssFeed,
+        title = "Paste a feed or video podcast",
+        subtitle = "Use RSS for missing podcasts, or a YouTube playlist/channel for this sideload build.",
+        modifier = Modifier.padding(horizontal = 20.dp),
+    )
+}
+
+@Composable
+private fun FeedLoading() {
+    val colors = MaterialTheme.colorScheme
+    VibeSurface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                strokeWidth = 2.dp,
+                color = colors.primary,
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = "Reading feed…",
+                style = MaterialTheme.typography.bodyMedium,
+                color = colors.onSurface,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FeedPreview(state: FeedPreviewState.Loaded, onSubscribe: () -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    val podcast = state.podcast
+    val sourceLabel = if (UrlSource.classify(podcast.feedUrl.orEmpty()) == UrlSource.YOUTUBE) {
+        "YOUTUBE"
+    } else {
+        "RSS FEED"
+    }
+    VibeSurface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                model = podcast.artworkUrl,
+                contentDescription = podcast.title,
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+                placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+                error = painterResource(R.drawable.ic_artwork_placeholder),
+                fallback = painterResource(R.drawable.ic_artwork_placeholder),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = sourceLabel,
+                    fontFamily = JetBrainsMono,
+                    fontSize = 9.5.sp,
+                    letterSpacing = 1.4.sp,
+                    color = colors.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = podcast.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = colors.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (podcast.artist.isNotBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = podcast.artist,
+                        fontSize = 12.sp,
+                        color = colors.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.height(10.dp))
+                VibePrimaryPill(label = "Subscribe", onClick = onSubscribe)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeedSaved(title: String) {
+    VibeEmptyState(
+        icon = Icons.Outlined.RssFeed,
+        title = "Subscribed",
+        subtitle = "$title is now in your library.",
+        modifier = Modifier.padding(horizontal = 20.dp),
+    )
+}
+
+@Composable
+private fun FeedError(message: String) {
+    VibeEmptyState(
+        icon = Icons.Outlined.ErrorOutline,
+        title = "Could not read feed",
+        subtitle = message,
+        modifier = Modifier.padding(horizontal = 20.dp),
+    )
+}

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Movie
 import androidx.compose.material.icons.outlined.Podcasts
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -45,6 +46,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
+import com.podcastplayer.app.data.local.UrlDownloadEntity
+import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
@@ -89,9 +92,12 @@ private fun formatBytes(bytes: Long): String {
 @Composable
 fun DownloadsScreen(
     entries: List<DownloadEntryUi>,
+    failedUrlDownloads: List<UrlDownloadEntity> = emptyList(),
     totalBytes: Long,
     onPlay: (DownloadEntryUi) -> Unit,
     onDelete: (DownloadEntryUi) -> Unit,
+    onRetryUrlDownload: (String) -> Unit = {},
+    onDeleteUrlDownload: (String) -> Unit = {},
     onDeleteAll: () -> Unit,
     @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
@@ -125,7 +131,7 @@ fun DownloadsScreen(
                 },
             )
 
-            if (entries.isEmpty()) {
+            if (entries.isEmpty() && failedUrlDownloads.isEmpty()) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -139,20 +145,6 @@ fun DownloadsScreen(
                     )
                 }
             } else {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    VibeSectionEyebrow(text = "Saved", modifier = Modifier.weight(1f))
-                    Text(
-                        text = "${entries.size}",
-                        fontFamily = JetBrainsMono,
-                        fontSize = 11.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(
@@ -163,7 +155,50 @@ fun DownloadsScreen(
                     ),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    items(entries, key = { it.id }) { entry ->
+                    if (failedUrlDownloads.isNotEmpty()) {
+                        item {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                VibeSectionEyebrow(text = "Needs attention", modifier = Modifier.weight(1f))
+                                Text(
+                                    text = "${failedUrlDownloads.size}",
+                                    fontFamily = JetBrainsMono,
+                                    fontSize = 11.sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        items(failedUrlDownloads, key = { "failed:${it.id}" }) { item ->
+                            FailedUrlDownloadRow(
+                                item = item,
+                                onRetry = { onRetryUrlDownload(item.id) },
+                                onDelete = { onDeleteUrlDownload(item.id) },
+                            )
+                        }
+                    }
+                    if (entries.isNotEmpty()) {
+                        item {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                VibeSectionEyebrow(text = "Saved", modifier = Modifier.weight(1f))
+                                Text(
+                                    text = "${entries.size}",
+                                    fontFamily = JetBrainsMono,
+                                    fontSize = 11.sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                    items(entries, key = { "saved:${it.id}" }) { entry ->
                         DownloadRow(
                             entry = entry,
                             onPlay = { onPlay(entry) },
@@ -194,6 +229,88 @@ fun DownloadsScreen(
                 }
             },
             containerColor = MaterialTheme.colorScheme.surface,
+        )
+    }
+}
+
+@Composable
+private fun FailedUrlDownloadRow(
+    item: UrlDownloadEntity,
+    onRetry: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(14.dp)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(colors.surface)
+            .border(1.dp, colors.outline, shape)
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = item.thumbnailUrl,
+            contentDescription = item.title,
+            modifier = Modifier
+                .size(60.dp)
+                .clip(RoundedCornerShape(10.dp)),
+            placeholder = painterResource(R.drawable.ic_artwork_placeholder),
+            error = painterResource(R.drawable.ic_artwork_placeholder),
+            fallback = painterResource(R.drawable.ic_artwork_placeholder),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                KindBadge(
+                    if (item.mediaType == "video") DownloadEntryUi.Kind.URL_VIDEO else DownloadEntryUi.Kind.URL_AUDIO
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = UrlSource.fromTag(item.source).displayName.uppercase(),
+                    fontFamily = JetBrainsMono,
+                    fontSize = 9.5.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 1.2.sp,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleSmall,
+                color = colors.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = item.errorMessage ?: item.status.lowercase().replaceFirstChar { it.uppercase() },
+                style = MaterialTheme.typography.bodySmall,
+                color = colors.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        VibeCircleIconButton(
+            icon = Icons.Outlined.Delete,
+            description = "Delete failed download",
+            onClick = onDelete,
+            size = 36.dp,
+            iconSize = 18.dp,
+        )
+        Spacer(Modifier.width(6.dp))
+        VibeCircleIconButton(
+            icon = Icons.Outlined.Refresh,
+            description = "Retry download",
+            onClick = onRetry,
+            size = 40.dp,
+            iconSize = 20.dp,
+            tinted = true,
         )
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
@@ -1,5 +1,10 @@
 package com.podcastplayer.app.presentation.ui
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -26,10 +31,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.DownloadDone
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -50,6 +57,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -103,6 +111,7 @@ fun EpisodeListScreen(
         savedPodcasts.firstOrNull { it.id == podcast?.id }?.autoDownload == true
     }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     if (isLandscape) {
         EpisodeListLandscape(
@@ -138,6 +147,26 @@ fun EpisodeListScreen(
                     eyebrow = podcast?.artist,
                     onBack = onBack,
                     actions = {
+                        if (!podcast?.feedUrl.isNullOrBlank()) {
+                            VibeCircleIconButton(
+                                icon = Icons.Outlined.ContentCopy,
+                                description = "Copy feed URL",
+                                onClick = { copyFeedUrl(context, podcast?.feedUrl.orEmpty()) },
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            VibeCircleIconButton(
+                                icon = Icons.Outlined.Share,
+                                description = "Share feed URL",
+                                onClick = {
+                                    shareFeedUrl(
+                                        context = context,
+                                        title = podcast?.title.orEmpty(),
+                                        feedUrl = podcast?.feedUrl.orEmpty(),
+                                    )
+                                },
+                            )
+                            Spacer(Modifier.width(8.dp))
+                        }
                         VibeCircleIconButton(
                             icon = Icons.Outlined.Refresh,
                             description = "Refresh episodes",
@@ -234,8 +263,12 @@ fun EpisodeListScreen(
                                         isCompleted = isCompleted,
                                         playbackProgress = playbackProgress,
                                         onClick = {
-                                            playerViewModel.playEpisode(episode, podcast?.artworkUrl)
-                                            onPlayEpisode()
+                                            if (episode.shouldOpenExternally()) {
+                                                openExternalUrl(context, episode.audioUrl)
+                                            } else {
+                                                playerViewModel.playEpisode(episode, podcast?.artworkUrl)
+                                                onPlayEpisode()
+                                            }
                                         },
                                         onDownload = { podcastViewModel.startDownload(episode) },
                                         onDelete = {
@@ -880,4 +913,32 @@ private fun formatDuration(ms: Long): String {
     val seconds = totalSeconds % 60
     return if (hours > 0) "%d:%02d:%02d".format(hours, minutes, seconds)
     else "%d:%02d".format(minutes, seconds)
+}
+
+private fun copyFeedUrl(context: Context, feedUrl: String) {
+    if (feedUrl.isBlank()) return
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText("Podcast RSS feed", feedUrl))
+}
+
+private fun shareFeedUrl(context: Context, title: String, feedUrl: String) {
+    if (feedUrl.isBlank()) return
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_SUBJECT, title.ifBlank { "Podcast RSS feed" })
+        putExtra(Intent.EXTRA_TEXT, feedUrl)
+    }
+    context.startActivity(Intent.createChooser(intent, "Share RSS feed"))
+}
+
+private fun Episode.shouldOpenExternally(): Boolean {
+    return localPath.isNullOrBlank() &&
+        com.podcastplayer.app.data.repository.UrlSource.classify(audioUrl) ==
+        com.podcastplayer.app.data.repository.UrlSource.YOUTUBE
+}
+
+private fun openExternalUrl(context: Context, url: String) {
+    if (url.isBlank()) return
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+    context.startActivity(intent)
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/HomeScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/HomeScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Movie
 import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.RssFeed
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -65,15 +67,18 @@ fun HomeScreen(
     continueListening: List<ContinueListeningUi>,
     urlDownloads: List<UrlDownloadEntity>,
     urlInFlight: List<UrlDownloadEntity>,
+    urlNeedsAttention: List<UrlDownloadEntity>,
     currentEpisode: Episode?,
     currentArtworkUrl: String?,
     playerState: PlayerState,
     onOpenPodcast: (Podcast) -> Unit,
     onOpenSearch: () -> Unit,
+    onAddFeed: () -> Unit,
     onAddFromUrl: () -> Unit,
     onPlayUrlDownload: (UrlDownloadEntity) -> Unit,
     onDeleteUrlDownload: (String) -> Unit,
     onCancelUrlDownload: (String) -> Unit,
+    onRetryUrlDownload: (String) -> Unit,
     onPlayEpisode: (Episode, String?) -> Unit,
     onPlayPause: () -> Unit,
     onOpenPlayer: () -> Unit,
@@ -92,7 +97,7 @@ fun HomeScreen(
             HomeHeader(now = now)
 
             // Quick-action row: "Add from URL" entry point.
-            QuickActionRow(onAddFromUrl = onAddFromUrl)
+            QuickActionRow(onAddFeed = onAddFeed, onAddFromUrl = onAddFromUrl)
 
             // Currently downloading items, if any.
             if (urlInFlight.isNotEmpty()) {
@@ -100,6 +105,16 @@ fun HomeScreen(
                 InFlightColumn(
                     items = urlInFlight,
                     onCancel = onCancelUrlDownload,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
+            if (urlNeedsAttention.isNotEmpty()) {
+                SectionHeader(label = "Needs attention")
+                FailedUrlColumn(
+                    items = urlNeedsAttention,
+                    onRetry = onRetryUrlDownload,
+                    onDelete = onDeleteUrlDownload,
                 )
                 Spacer(Modifier.height(4.dp))
             }
@@ -128,7 +143,7 @@ fun HomeScreen(
                 Spacer(Modifier.height(4.dp))
             }
 
-            if (subscriptions.isEmpty() && urlDownloads.isEmpty() && urlInFlight.isEmpty()) {
+            if (subscriptions.isEmpty() && urlDownloads.isEmpty() && urlInFlight.isEmpty() && urlNeedsAttention.isEmpty()) {
                 VibeEmptyState(
                     icon = Icons.Outlined.Search,
                     title = "No subscriptions yet",
@@ -198,13 +213,24 @@ private fun HomeHeader(now: LocalDateTime) {
 
 /** Quick-actions strip directly under the greeting. Currently just "Add from URL" (issue #33). */
 @Composable
-private fun QuickActionRow(onAddFromUrl: () -> Unit) {
+private fun QuickActionRow(onAddFeed: () -> Unit, onAddFromUrl: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        VibeChip(
+            label = "Add show",
+            onClick = onAddFeed,
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.RssFeed,
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                )
+            },
+        )
         VibeChip(
             label = "Add from URL",
             onClick = onAddFromUrl,
@@ -469,6 +495,105 @@ private fun UrlDownloadCard(
                 color = colors.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+/** Failed/canceled URL saves remain visible so the user can retry or delete them. */
+@Composable
+private fun FailedUrlColumn(
+    items: List<UrlDownloadEntity>,
+    onRetry: (String) -> Unit,
+    onDelete: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items.forEach { item ->
+            FailedUrlCard(
+                item = item,
+                onRetry = { onRetry(item.id) },
+                onDelete = { onDelete(item.id) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun FailedUrlCard(
+    item: UrlDownloadEntity,
+    onRetry: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(colors.surface)
+            .border(1.dp, colors.outline, RoundedCornerShape(14.dp))
+            .padding(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            AsyncImage(
+                model = item.thumbnailUrl,
+                contentDescription = item.title,
+                modifier = Modifier
+                    .size(50.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(colors.surfaceVariant),
+                placeholder = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                error = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+                fallback = androidx.compose.ui.res.painterResource(R.drawable.ic_artwork_placeholder),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 17.sp,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = item.errorMessage ?: item.status.lowercase().replaceFirstChar { it.uppercase() },
+                    fontSize = 11.sp,
+                    color = colors.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            VibeChip(
+                label = "Retry",
+                onClick = onRetry,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                    )
+                },
+            )
+            VibeChip(
+                label = "Delete",
+                onClick = onDelete,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                    )
+                },
             )
         }
     }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastListScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.PlaylistAdd
+import androidx.compose.material.icons.outlined.RssFeed
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.rounded.Bookmark
 import androidx.compose.material3.AlertDialog
@@ -74,6 +75,7 @@ import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.domain.model.PodcastQueue
 import com.podcastplayer.app.presentation.viewmodel.OpmlResult
 import com.podcastplayer.app.presentation.viewmodel.PodcastUiState
+import com.podcastplayer.app.ui.theme.JetBrainsMono
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -87,6 +89,7 @@ fun PodcastListScreen(
     @Suppress("UNUSED_PARAMETER") onOpenDownloads: () -> Unit,
     onPlayQueue: () -> Unit,
     onAddFromUrl: (String) -> Unit = {},
+    onAddFeed: (String) -> Unit = {},
     onExportOpml: () -> Unit = {},
     onImportOpml: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
@@ -213,6 +216,15 @@ fun PodcastListScreen(
                         onClick = {
                             focusManager.clearFocus()
                             onAddFromUrl(pastedUrl)
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                } else if (pastedUrl != null) {
+                    RssFeedShortcutCard(
+                        url = pastedUrl,
+                        onClick = {
+                            focusManager.clearFocus()
+                            onAddFeed(pastedUrl)
                         },
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     )
@@ -404,6 +416,49 @@ fun PodcastListScreen(
             },
             onDismiss = { queuePickerPodcast = null },
         )
+    }
+}
+
+@Composable
+private fun RssFeedShortcutCard(
+    url: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(androidx.compose.foundation.shape.RoundedCornerShape(14.dp))
+            .background(colors.primaryContainer)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.RssFeed,
+            contentDescription = null,
+            tint = colors.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Subscribe from this RSS feed",
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.onSurface,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = url,
+                fontFamily = JetBrainsMono,
+                fontSize = 10.5.sp,
+                color = colors.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -72,6 +72,13 @@ private object Routes {
 
     fun addUrl(rawUrl: String? = null): String =
         if (rawUrl.isNullOrBlank()) AddUrlBase else "$AddUrlBase?$UrlArg=${Uri.encode(rawUrl)}"
+
+    const val AddFeedBase = "add-feed"
+    const val FeedUrlArg = "feedUrl"
+    const val AddFeedPattern = "$AddFeedBase?$FeedUrlArg={$FeedUrlArg}"
+
+    fun addFeed(rawUrl: String? = null): String =
+        if (rawUrl.isNullOrBlank()) AddFeedBase else "$AddFeedBase?$FeedUrlArg=${Uri.encode(rawUrl)}"
 }
 
 @Composable
@@ -173,7 +180,14 @@ fun PodcastNavHost(
     // we navigate to the AddFromUrl screen and clear the slot so we don't loop.
     LaunchedEffect(sharedUrl) {
         val url = sharedUrl ?: return@LaunchedEffect
-        navController.navigate(Routes.addUrl(url)) {
+        val route = if (com.podcastplayer.app.data.repository.UrlSource.classify(url) ==
+            com.podcastplayer.app.data.repository.UrlSource.OTHER
+        ) {
+            Routes.addFeed(url)
+        } else {
+            Routes.addUrl(url)
+        }
+        navController.navigate(route) {
             launchSingleTop = true
         }
         onSharedUrlConsumed()
@@ -229,6 +243,7 @@ fun PodcastNavHost(
                     val currentArtworkUrl by playerViewModel.currentArtworkUrl.collectAsState()
                     val urlDownloads by urlDownloadViewModel.completedDownloads.collectAsState()
                     val urlInFlight by urlDownloadViewModel.inFlightDownloads.collectAsState()
+                    val urlNeedsAttention by urlDownloadViewModel.needsAttentionDownloads.collectAsState()
 
                     val urlRepository = remember(context) {
                         com.podcastplayer.app.data.repository.UrlDownloadRepository(context)
@@ -239,6 +254,7 @@ fun PodcastNavHost(
                         continueListening = continueListening,
                         urlDownloads = urlDownloads,
                         urlInFlight = urlInFlight,
+                        urlNeedsAttention = urlNeedsAttention,
                         currentEpisode = currentEpisode,
                         currentArtworkUrl = currentArtworkUrl,
                         playerState = playerState,
@@ -247,6 +263,7 @@ fun PodcastNavHost(
                             navController.navigate(Routes.episodes(podcast.id))
                         },
                         onOpenSearch = { navController.navigate(Routes.Search) },
+                        onAddFeed = { navController.navigate(Routes.addFeed()) },
                         onAddFromUrl = { navController.navigate(Routes.addUrl()) },
                         onPlayUrlDownload = { entity ->
                             val episode = urlRepository.toEpisode(entity)
@@ -257,6 +274,7 @@ fun PodcastNavHost(
                         },
                         onDeleteUrlDownload = { id -> urlDownloadViewModel.deleteDownload(id) },
                         onCancelUrlDownload = { id -> urlDownloadViewModel.cancelDownload(id) },
+                        onRetryUrlDownload = { id -> urlDownloadViewModel.retryDownload(id) },
                         onPlayEpisode = { episode, artwork ->
                             playerViewModel.playEpisode(episode, artwork)
                             navController.navigate(Routes.Player)
@@ -300,6 +318,31 @@ fun PodcastNavHost(
                     )
                 }
 
+                composable(
+                    route = Routes.AddFeedPattern,
+                    arguments = listOf(
+                        navArgument(Routes.FeedUrlArg) {
+                            type = NavType.StringType
+                            nullable = true
+                            defaultValue = null
+                        }
+                    )
+                ) { backStackEntry ->
+                    val incomingUrl = backStackEntry.arguments?.getString(Routes.FeedUrlArg).orEmpty()
+                    val feedPreviewState by podcastViewModel.feedPreviewState.collectAsState()
+
+                    AddFeedScreen(
+                        initialUrl = incomingUrl,
+                        state = feedPreviewState,
+                        onLoad = { podcastViewModel.loadFeedPreview(it) },
+                        onSubscribe = { podcastViewModel.confirmFeedPreview() },
+                        onBack = {
+                            podcastViewModel.resetFeedPreview()
+                            navController.popBackStack(route = Routes.Home, inclusive = false)
+                        },
+                    )
+                }
+
                 composable(Routes.Search) {
                     val scope = rememberCoroutineScope()
                     val selectedQueuePodcasts by podcastViewModel.selectedQueuePodcasts.collectAsState()
@@ -331,6 +374,9 @@ fun PodcastNavHost(
                         },
                         onAddFromUrl = { rawUrl ->
                             navController.navigate(Routes.addUrl(rawUrl))
+                        },
+                        onAddFeed = { rawUrl ->
+                            navController.navigate(Routes.addFeed(rawUrl))
                         },
                         onExportOpml = { exportLauncher.launch("vibe-podcasts.opml") },
                         onImportOpml = {
@@ -428,6 +474,7 @@ fun PodcastNavHost(
                     val scope = rememberCoroutineScope()
                     val podcastDownloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
                     val urlDownloads by urlDownloadViewModel.completedDownloads.collectAsState()
+                    val failedUrlDownloads by urlDownloadViewModel.needsAttentionDownloads.collectAsState()
                     // Raw entities give us fileSize, which the UI flows above don't carry.
                     val podcastEntities by produceState<List<com.podcastplayer.app.data.local.DownloadedEpisodeEntity>>(
                         initialValue = emptyList(),
@@ -479,6 +526,7 @@ fun PodcastNavHost(
 
                     DownloadsScreen(
                         entries = entries,
+                        failedUrlDownloads = failedUrlDownloads,
                         totalBytes = totalBytes,
                         onPlay = { entry ->
                             playerViewModel.playEpisode(entry.episode, entry.artworkUrl)
@@ -497,6 +545,8 @@ fun PodcastNavHost(
                                 }
                             }
                         },
+                        onRetryUrlDownload = { id -> urlDownloadViewModel.retryDownload(id) },
+                        onDeleteUrlDownload = { id -> urlDownloadViewModel.deleteDownload(id) },
                         onDeleteAll = {
                             scope.launch {
                                 podcastViewModel.deleteAllDownloads()

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -145,6 +145,9 @@ class PodcastViewModel(
     private val _opmlResult = MutableStateFlow<OpmlResult?>(null)
     val opmlResult: StateFlow<OpmlResult?> = _opmlResult.asStateFlow()
 
+    private val _feedPreviewState = MutableStateFlow<FeedPreviewState>(FeedPreviewState.Idle)
+    val feedPreviewState: StateFlow<FeedPreviewState> = _feedPreviewState.asStateFlow()
+
     private var downloadsJob: Job? = null
     private var savedJob: Job? = null
     private var progressJob: Job? = null
@@ -256,6 +259,30 @@ class PodcastViewModel(
 
     fun startDownload(episode: Episode) {
         if (_downloadProgress.value.containsKey(episode.id)) return
+        if (com.podcastplayer.app.data.repository.UrlSource.classify(episode.audioUrl) ==
+            com.podcastplayer.app.data.repository.UrlSource.YOUTUBE
+        ) {
+            val repository = urlDownloadRepository ?: run {
+                _downloadError.value = "YouTube downloader is not available."
+                return
+            }
+            _downloadProgress.value = _downloadProgress.value + (episode.id to 0f)
+            viewModelScope.launch {
+                repository.enqueue(
+                    rawUrl = episode.audioUrl,
+                    mediaType = episode.mediaType,
+                    prefetchedMetadata = com.podcastplayer.app.data.repository.UrlMetadata(
+                        title = episode.title,
+                        uploader = episode.description,
+                        thumbnailUrl = episode.imageUrl,
+                        durationMs = episode.duration,
+                    ),
+                )
+                repository.startPump()
+                _downloadProgress.value = _downloadProgress.value - episode.id
+            }
+            return
+        }
         _downloadProgress.value = _downloadProgress.value + (episode.id to 0f)
         // Surface the podcast title to DownloadManager so the MediaStore display
         // name reads as "<podcast> - <episode>.mp3" when browsed from VLC / Files.
@@ -327,6 +354,71 @@ class PodcastViewModel(
 
     fun savePodcast(podcast: Podcast) {
         viewModelScope.launch { savedPodcastsStorage.save(podcast) }
+    }
+
+    fun loadFeedPreview(feedUrl: String) {
+        val normalized = feedUrl.trim()
+        if (normalized.isBlank()) {
+            _feedPreviewState.value = FeedPreviewState.Idle
+            return
+        }
+        if (!normalized.startsWith("http://", ignoreCase = true) &&
+            !normalized.startsWith("https://", ignoreCase = true)
+        ) {
+            _feedPreviewState.value = FeedPreviewState.Error("Enter a valid RSS feed URL.")
+            return
+        }
+        viewModelScope.launch {
+            _feedPreviewState.value = FeedPreviewState.Loading(normalized)
+            if (com.podcastplayer.app.data.repository.UrlSource.classify(normalized) ==
+                com.podcastplayer.app.data.repository.UrlSource.YOUTUBE
+            ) {
+                val metadata = urlDownloadRepository?.fetchYoutubeSubscriptionMetadata(normalized)
+                if (metadata == null) {
+                    _feedPreviewState.value = FeedPreviewState.Error(
+                        "Could not read that YouTube playlist or channel.",
+                    )
+                    return@launch
+                }
+                _feedPreviewState.value = FeedPreviewState.Loaded(
+                    Podcast(
+                        id = "youtube:${
+                            com.podcastplayer.app.data.repository.UrlValidator.stableId(
+                                normalized,
+                                "subscription",
+                            )
+                        }",
+                        title = metadata.title,
+                        artist = metadata.uploader.orEmpty(),
+                        artworkUrl = metadata.thumbnailUrl,
+                        feedUrl = normalized,
+                    )
+                )
+                return@launch
+            }
+            repository.getPodcastFromFeed(normalized).fold(
+                onSuccess = { podcast ->
+                    _feedPreviewState.value = FeedPreviewState.Loaded(podcast)
+                },
+                onFailure = { error ->
+                    _feedPreviewState.value = FeedPreviewState.Error(
+                        error.message ?: "Could not read that feed.",
+                    )
+                },
+            )
+        }
+    }
+
+    fun confirmFeedPreview() {
+        val podcast = (_feedPreviewState.value as? FeedPreviewState.Loaded)?.podcast ?: return
+        viewModelScope.launch {
+            savedPodcastsStorage.save(podcast)
+            _feedPreviewState.value = FeedPreviewState.Saved(podcast)
+        }
+    }
+
+    fun resetFeedPreview() {
+        _feedPreviewState.value = FeedPreviewState.Idle
     }
 
     fun removeSavedPodcast(podcastId: String) {
@@ -496,4 +588,12 @@ sealed class OpmlResult {
     data class ExportSuccess(val podcastCount: Int, val queueCount: Int) : OpmlResult()
     data class ImportSuccess(val podcastCount: Int, val queueCount: Int) : OpmlResult()
     data class Error(val message: String) : OpmlResult()
+}
+
+sealed class FeedPreviewState {
+    data object Idle : FeedPreviewState()
+    data class Loading(val url: String) : FeedPreviewState()
+    data class Loaded(val podcast: Podcast) : FeedPreviewState()
+    data class Saved(val podcast: Podcast) : FeedPreviewState()
+    data class Error(val message: String) : FeedPreviewState()
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/UrlDownloadViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/UrlDownloadViewModel.kt
@@ -58,6 +58,14 @@ class UrlDownloadViewModel(application: Application) : AndroidViewModel(applicat
             initialValue = emptyList(),
         )
 
+    /** Failed/canceled URL downloads that should stay visible until retried or deleted. */
+    val needsAttentionDownloads: StateFlow<List<UrlDownloadEntity>> =
+        repository.observeNeedsAttention().stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = emptyList(),
+        )
+
     /**
      * Begin metadata extraction for [rawUrl]. Called when the user opens the
      * AddFromUrl screen with a URL (paste, share, or dedicated input).
@@ -111,6 +119,15 @@ class UrlDownloadViewModel(application: Application) : AndroidViewModel(applicat
 
     fun deleteDownload(id: String) {
         viewModelScope.launch { repository.delete(id) }
+    }
+
+    fun retryDownload(id: String) {
+        val app = getApplication<Application>()
+        viewModelScope.launch {
+            if (repository.retry(id)) {
+                UrlDownloadService.startPump(app)
+            }
+        }
     }
 
     fun cancelDownload(id: String) {

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
@@ -16,6 +16,9 @@ import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
 import com.podcastplayer.app.data.repository.DownloadManager
 import com.podcastplayer.app.data.repository.PodcastRepository
+import com.podcastplayer.app.data.repository.UrlDownloadRepository
+import com.podcastplayer.app.data.repository.UrlMetadata
+import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import java.util.concurrent.TimeUnit
@@ -122,27 +125,48 @@ class AutoDownloadWorker(
 
             val repository = PodcastRepository(iTunesApi.create(), RssParser())
             val downloadManager = DownloadManager(context)
+            val urlDownloadRepository = UrlDownloadRepository(context)
             val downloadedDao = DatabaseProvider.getDatabase(context).downloadedEpisodeDao()
 
             val cutoffMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_AGE_DAYS)
+            var queuedUrlDownloads = false
 
             for (podcast in candidates) {
                 val feedUrl = podcast.feedUrl ?: continue
                 val episodes = repository.getEpisodes(feedUrl, podcast.id).getOrNull()
                     ?: continue
+                val progressByEpisodeId = DatabaseProvider.getDatabase(context)
+                    .playbackProgressDao()
+                    .getByPodcastId(podcast.id)
+                    .associateBy { it.episodeId }
 
                 val freshEpisodes = episodes.filter { ep ->
                     val pubMs = ep.pubDate?.time ?: 0L
-                    pubMs >= cutoffMs
+                    pubMs >= cutoffMs && progressByEpisodeId[ep.id]?.completed != true
                 }
 
                 for (episode in freshEpisodes) {
+                    if (UrlSource.classify(episode.audioUrl) == UrlSource.YOUTUBE) {
+                        urlDownloadRepository.enqueue(
+                            rawUrl = episode.audioUrl,
+                            mediaType = episode.mediaType,
+                            prefetchedMetadata = UrlMetadata(
+                                title = episode.title,
+                                uploader = episode.description,
+                                thumbnailUrl = episode.imageUrl,
+                                durationMs = episode.duration,
+                            ),
+                        )
+                        queuedUrlDownloads = true
+                        continue
+                    }
                     if (downloadedDao.isEpisodeDownloaded(episode.id)) continue
                     val withArtwork = ensureArtwork(episode, podcast)
                     // Result is ignored — periodic work; we'll try again next interval.
                     downloadManager.downloadEpisode(withArtwork, podcastTitle = podcast.title)
                 }
             }
+            if (queuedUrlDownloads) urlDownloadRepository.startPump()
         }
 
         private fun ensureArtwork(episode: Episode, podcast: Podcast): Episode {

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
@@ -46,6 +47,7 @@ class PlayerService : MediaSessionService() {
     private val CHANNEL_ID = "podcast_player_channel"
     private val NOTIFICATION_ID = 1
 
+    @UnstableApi
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
@@ -200,6 +202,7 @@ class PlayerService : MediaSessionService() {
         }
     }
 
+    @UnstableApi
     private fun setupNotification() {
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
@@ -298,6 +301,7 @@ class PlayerService : MediaSessionService() {
         return mediaSession
     }
 
+    @UnstableApi
     override fun onDestroy() {
         stopPersistLoop()
         persistProgress(markCompleted = false)

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -82,6 +82,7 @@ class UrlDownloadService : Service() {
      */
     private suspend fun pumpQueue() {
         pumpMutex.withLock {
+            repository.requeueInterrupted()
             while (!stopRequested) {
                 val nextId = nextQueuedId() ?: break
                 processOne(nextId)


### PR DESCRIPTION
## Summary

This PR improves the app's subscription and offline workflows so users can add shows that are missing from iTunes, recover failed URL saves, and manage video-podcast content in a more predictable way.

Key changes:
- Adds an **Add show** flow for direct RSS feed URLs and personal-build YouTube playlist/channel URLs.
- Adds RSS feed preview, subscription saving, and feed copy/share actions from the episode detail screen.
- Routes shared/pasted URLs to the right flow: YouTube/X links go to offline URL save, other URLs go to feed subscription lookup.
- Surfaces failed or canceled URL downloads in Home and Downloads with retry/delete actions.
- Requeues interrupted URL downloads when the foreground download service restarts.
- Tightens auto-download so completed episodes are skipped.
- Supports personal/sideload YouTube playlist/channel subscriptions by listing videos through yt-dlp and saving selected videos through the existing URL download pipeline.
- Requests Android 13+ notification permission so foreground download/playback notifications can be shown.
- Fixes Media3 unstable API lint opt-ins in `PlayerService`.

## Implementation Notes

- The new feed flow is intentionally built on the existing `SavedPodcastsStorage` model instead of introducing a larger Room migration in this PR.
- YouTube playlist/channel support is for personal/sideload builds only. This should not be treated as Play Store-safe distribution behavior.
- Undownloaded YouTube subscription items open externally. Once saved offline, they play through the existing Media3 video path.
- URL downloads now expose completed, in-flight, failed, and canceled states through the UI instead of hiding terminal failures.

## Verification

- `./gradlew test --no-daemon`
- `./gradlew lint --no-daemon`

## QA Steps

### RSS Feed Subscription

1. Launch the app and open Home.
2. Tap **Add show**.
3. Paste a valid podcast RSS feed URL.
4. Tap **Look up feed**.
5. Confirm the preview shows the show title/artwork when available.
6. Tap **Subscribe**.
7. Return to Home and confirm the show appears under subscriptions.
8. Open the show and confirm episodes load from the feed.

### RSS Paste From Search

1. Open Search.
2. Paste a non-YouTube RSS feed URL into the search field.
3. Confirm the inline **Subscribe from this RSS feed** card appears.
4. Tap the card and confirm it opens the Add show flow with the URL prefilled.

### RSS Copy And Share

1. Open a subscribed RSS show.
2. Tap the copy feed action in the top bar.
3. Paste into another text field/app and confirm the feed URL was copied.
4. Return to the show and tap the share action.
5. Confirm Android's share sheet opens with the feed URL.

### URL Download Failure/Retry

1. Use **Add from URL** with a URL that fails or temporarily disable network during a URL save.
2. Confirm the failed/canceled item stays visible in Home under **Needs attention**.
3. Open Downloads and confirm the same item appears under **Needs attention**.
4. Restore network and tap **Retry**.
5. Confirm the item moves back into in-flight progress and can complete or fail with a visible reason.
6. Tap **Delete** on a failed item and confirm it disappears.

### Interrupted URL Download Recovery

1. Start a large URL download.
2. Force-stop or kill the app while the item is downloading.
3. Reopen the app.
4. Confirm the download service requeues interrupted work instead of leaving it stuck in a downloading/extracting state.

### YouTube Playlist/Channel Subscription

1. Open Home and tap **Add show**.
2. Paste a YouTube playlist or channel URL.
3. Tap **Look up feed**.
4. Confirm a YouTube preview appears.
5. Tap **Subscribe**.
6. Open the subscribed show and confirm recent video items load.
7. Tap an undownloaded video and confirm it opens externally.
8. Tap **Download** on a video item and confirm it is queued through the URL download flow.
9. After completion, play the saved item and confirm video playback uses the in-app player.

### Auto-Download

1. Subscribe to a show with recent episodes.
2. Mark one episode as played.
3. Enable **Auto-download new** for the show.
4. Trigger or wait for auto-download.
5. Confirm completed/played episodes are skipped and fresh unplayed items are eligible.

### Notifications

1. Install on Android 13+.
2. Launch the app and accept the notification permission prompt.
3. Start a URL download.
4. Confirm foreground download progress appears in notifications.

## Risks / Follow-Ups

- The direct feed subscription model still uses SharedPreferences-backed saved podcasts; a Room-backed library model remains a larger follow-up.
- YouTube playlist/channel refresh depends on yt-dlp metadata availability and can fail when YouTube changes behavior.
- Manual QA on a real Android 13+ device is still needed for notification permission, share sheet, and foreground-service behavior.
