### PR TITLE
feat: remove YouTube channel subscribe (unreliable)

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/PodcastRepository.kt
@@ -1,22 +1,13 @@
 package com.podcastplayer.app.data.repository
 
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
-import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
 import com.podcastplayer.app.data.remote.upgradeITunesArtwork
-import com.podcastplayer.app.domain.model.MediaType
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import com.podcastplayer.app.domain.model.PodcastDto
-import com.yausername.youtubedl_android.YoutubeDL
-import com.yausername.youtubedl_android.YoutubeDLRequest
 import java.net.URL
 import java.security.MessageDigest
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -41,9 +32,6 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
     suspend fun getEpisodes(feedUrl: String, podcastId: String): Result<List<Episode>> {
         return withContext(Dispatchers.IO) {
             try {
-                if (UrlSource.classify(feedUrl) == UrlSource.YOUTUBE) {
-                    return@withContext getYoutubeEpisodes(feedUrl, podcastId)
-                }
                 val url = URL(feedUrl)
                 url.openStream().use { inputStream ->
                     val episodes = rssParser.parseEpisodes(inputStream, podcastId)
@@ -52,45 +40,6 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
             } catch (e: Exception) {
                 Result.failure(e)
             }
-        }
-    }
-
-    private fun getYoutubeEpisodes(url: String, podcastId: String): Result<List<Episode>> {
-        if (!PodcastApplication.youtubeDlReady) {
-            return Result.failure(Exception("YouTube subscription reader is still starting. Try again shortly."))
-        }
-        return try {
-            val request = YoutubeDLRequest(url).apply {
-                addOption("--flat-playlist")
-                addOption("--dump-single-json")
-                addOption("--playlist-end", "25")
-                addOption("--socket-timeout", "30")
-            }
-            val response = YoutubeDL.getInstance().execute(request)
-            val root = JsonParser().parse(response.out).asJsonObject
-            val entries = root.getAsJsonArray("entries") ?: return Result.success(emptyList())
-            val uploader = root.stringOrNull("uploader") ?: root.stringOrNull("channel")
-            val episodes = entries.mapNotNull { element ->
-                val item = element.asJsonObject
-                val id = item.stringOrNull("id") ?: item.stringOrNull("url") ?: return@mapNotNull null
-                val webpageUrl = item.stringOrNull("webpage_url")
-                    ?: item.stringOrNull("url")?.takeIf { it.startsWith("http", ignoreCase = true) }
-                    ?: "https://www.youtube.com/watch?v=$id"
-                Episode(
-                    id = "youtube:${stableHash(webpageUrl)}",
-                    podcastId = podcastId,
-                    title = item.stringOrNull("title") ?: webpageUrl,
-                    description = uploader,
-                    pubDate = item.dateOrNull(),
-                    audioUrl = webpageUrl,
-                    duration = item.longOrNull("duration")?.let { it * 1000L },
-                    imageUrl = item.stringOrNull("thumbnail"),
-                    mediaType = MediaType.VIDEO,
-                )
-            }
-            Result.success(episodes)
-        } catch (e: Exception) {
-            Result.failure(e)
         }
     }
 
@@ -131,26 +80,5 @@ class PodcastRepository(private val iTunesApi: iTunesApi, private val rssParser:
         return MessageDigest.getInstance("SHA-1")
             .digest(value.trim().lowercase().toByteArray())
             .joinToString("") { "%02x".format(it) }
-    }
-
-    private fun JsonObject.stringOrNull(name: String): String? {
-        val value = get(name) ?: return null
-        if (value.isJsonNull) return null
-        return runCatching { value.asString }.getOrNull()?.takeIf { it.isNotBlank() }
-    }
-
-    private fun JsonObject.longOrNull(name: String): Long? {
-        val value = get(name) ?: return null
-        if (value.isJsonNull) return null
-        return runCatching { value.asLong }.getOrNull()
-    }
-
-    private fun JsonObject.dateOrNull(): Date? {
-        longOrNull("timestamp")?.let { return Date(it * 1000L) }
-        longOrNull("release_timestamp")?.let { return Date(it * 1000L) }
-        val uploadDate = stringOrNull("upload_date") ?: return null
-        return runCatching {
-            SimpleDateFormat("yyyyMMdd", Locale.US).parse(uploadDate)
-        }.getOrNull()
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -1,8 +1,6 @@
 package com.podcastplayer.app.data.repository
 
 import android.content.Context
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.MediaStoreSaver
@@ -93,29 +91,6 @@ class UrlDownloadRepository(private val context: Context) {
             null
         } catch (e: Throwable) {
             null
-        }
-    }
-
-    suspend fun fetchYoutubeSubscriptionMetadata(rawUrl: String): UrlMetadata? = withContext(Dispatchers.IO) {
-        if (!PodcastApplication.youtubeDlReady) return@withContext null
-        if (UrlSource.classify(rawUrl) != UrlSource.YOUTUBE) return@withContext null
-        try {
-            val request = YoutubeDLRequest(rawUrl).apply {
-                addOption("--flat-playlist")
-                addOption("--dump-single-json")
-                addOption("--playlist-end", "1")
-                addOption("--socket-timeout", "30")
-            }
-            val response = YoutubeDL.getInstance().execute(request)
-            val root = JsonParser().parse(response.out).asJsonObject
-            UrlMetadata(
-                title = root.stringOrNull("title") ?: rawUrl,
-                uploader = root.stringOrNull("uploader") ?: root.stringOrNull("channel"),
-                thumbnailUrl = root.stringOrNull("thumbnail"),
-                durationMs = null,
-            )
-        } catch (e: Throwable) {
-            fetchMetadata(rawUrl)
         }
     }
 
@@ -303,12 +278,6 @@ class UrlDownloadRepository(private val context: Context) {
             UrlDownloadStatus.FAILED.name,
             UrlDownloadStatus.CANCELED.name,
         )
-    }
-
-    private fun JsonObject.stringOrNull(name: String): String? {
-        val value = get(name) ?: return null
-        if (value.isJsonNull) return null
-        return runCatching { value.asString }.getOrNull()?.takeIf { it.isNotBlank() }
     }
 }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/AddFeedScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/AddFeedScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
-import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.presentation.viewmodel.FeedPreviewState
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
@@ -73,7 +72,7 @@ fun AddFeedScreen(
     ) {
         VibeTopBar(
             title = "Add show",
-            eyebrow = "RSS or YouTube",
+            eyebrow = "RSS",
             onBack = onBack,
         )
 
@@ -107,7 +106,7 @@ fun AddFeedScreen(
                     decorationBox = { inner ->
                         if (url.isBlank()) {
                             Text(
-                                text = "RSS feed or YouTube playlist/channel URL",
+                                text = "RSS feed URL",
                                 color = colors.onSurfaceVariant,
                                 fontSize = 13.sp,
                                 fontFamily = JetBrainsMono,
@@ -156,7 +155,7 @@ private fun FeedHint() {
     VibeEmptyState(
         icon = Icons.Outlined.RssFeed,
         title = "Paste a feed or video podcast",
-        subtitle = "Use RSS for missing podcasts, or a YouTube playlist/channel for this sideload build.",
+        subtitle = "Use an RSS feed to add a podcast that search didn't find.",
         modifier = Modifier.padding(horizontal = 20.dp),
     )
 }
@@ -192,11 +191,7 @@ private fun FeedLoading() {
 private fun FeedPreview(state: FeedPreviewState.Loaded, onSubscribe: () -> Unit) {
     val colors = MaterialTheme.colorScheme
     val podcast = state.podcast
-    val sourceLabel = if (UrlSource.classify(podcast.feedUrl.orEmpty()) == UrlSource.YOUTUBE) {
-        "YOUTUBE"
-    } else {
-        "RSS FEED"
-    }
+    val sourceLabel = "RSS FEED"
     VibeSurface(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/EpisodeListScreen.kt
@@ -4,7 +4,6 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -263,12 +262,8 @@ fun EpisodeListScreen(
                                         isCompleted = isCompleted,
                                         playbackProgress = playbackProgress,
                                         onClick = {
-                                            if (episode.shouldOpenExternally()) {
-                                                openExternalUrl(context, episode.audioUrl)
-                                            } else {
-                                                playerViewModel.playEpisode(episode, podcast?.artworkUrl)
-                                                onPlayEpisode()
-                                            }
+                                            playerViewModel.playEpisode(episode, podcast?.artworkUrl)
+                                            onPlayEpisode()
                                         },
                                         onDownload = { podcastViewModel.startDownload(episode) },
                                         onDelete = {
@@ -929,16 +924,4 @@ private fun shareFeedUrl(context: Context, title: String, feedUrl: String) {
         putExtra(Intent.EXTRA_TEXT, feedUrl)
     }
     context.startActivity(Intent.createChooser(intent, "Share RSS feed"))
-}
-
-private fun Episode.shouldOpenExternally(): Boolean {
-    return localPath.isNullOrBlank() &&
-        com.podcastplayer.app.data.repository.UrlSource.classify(audioUrl) ==
-        com.podcastplayer.app.data.repository.UrlSource.YOUTUBE
-}
-
-private fun openExternalUrl(context: Context, url: String) {
-    if (url.isBlank()) return
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-    context.startActivity(intent)
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -259,30 +259,6 @@ class PodcastViewModel(
 
     fun startDownload(episode: Episode) {
         if (_downloadProgress.value.containsKey(episode.id)) return
-        if (com.podcastplayer.app.data.repository.UrlSource.classify(episode.audioUrl) ==
-            com.podcastplayer.app.data.repository.UrlSource.YOUTUBE
-        ) {
-            val repository = urlDownloadRepository ?: run {
-                _downloadError.value = "YouTube downloader is not available."
-                return
-            }
-            _downloadProgress.value = _downloadProgress.value + (episode.id to 0f)
-            viewModelScope.launch {
-                repository.enqueue(
-                    rawUrl = episode.audioUrl,
-                    mediaType = episode.mediaType,
-                    prefetchedMetadata = com.podcastplayer.app.data.repository.UrlMetadata(
-                        title = episode.title,
-                        uploader = episode.description,
-                        thumbnailUrl = episode.imageUrl,
-                        durationMs = episode.duration,
-                    ),
-                )
-                repository.startPump()
-                _downloadProgress.value = _downloadProgress.value - episode.id
-            }
-            return
-        }
         _downloadProgress.value = _downloadProgress.value + (episode.id to 0f)
         // Surface the podcast title to DownloadManager so the MediaStore display
         // name reads as "<podcast> - <episode>.mp3" when browsed from VLC / Files.
@@ -370,32 +346,6 @@ class PodcastViewModel(
         }
         viewModelScope.launch {
             _feedPreviewState.value = FeedPreviewState.Loading(normalized)
-            if (com.podcastplayer.app.data.repository.UrlSource.classify(normalized) ==
-                com.podcastplayer.app.data.repository.UrlSource.YOUTUBE
-            ) {
-                val metadata = urlDownloadRepository?.fetchYoutubeSubscriptionMetadata(normalized)
-                if (metadata == null) {
-                    _feedPreviewState.value = FeedPreviewState.Error(
-                        "Could not read that YouTube playlist or channel.",
-                    )
-                    return@launch
-                }
-                _feedPreviewState.value = FeedPreviewState.Loaded(
-                    Podcast(
-                        id = "youtube:${
-                            com.podcastplayer.app.data.repository.UrlValidator.stableId(
-                                normalized,
-                                "subscription",
-                            )
-                        }",
-                        title = metadata.title,
-                        artist = metadata.uploader.orEmpty(),
-                        artworkUrl = metadata.thumbnailUrl,
-                        feedUrl = normalized,
-                    )
-                )
-                return@launch
-            }
             repository.getPodcastFromFeed(normalized).fold(
                 onSuccess = { podcast ->
                     _feedPreviewState.value = FeedPreviewState.Loaded(podcast)

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
@@ -16,9 +16,6 @@ import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
 import com.podcastplayer.app.data.repository.DownloadManager
 import com.podcastplayer.app.data.repository.PodcastRepository
-import com.podcastplayer.app.data.repository.UrlDownloadRepository
-import com.podcastplayer.app.data.repository.UrlMetadata
-import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.Podcast
 import java.util.concurrent.TimeUnit
@@ -125,11 +122,9 @@ class AutoDownloadWorker(
 
             val repository = PodcastRepository(iTunesApi.create(), RssParser())
             val downloadManager = DownloadManager(context)
-            val urlDownloadRepository = UrlDownloadRepository(context)
             val downloadedDao = DatabaseProvider.getDatabase(context).downloadedEpisodeDao()
 
             val cutoffMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_AGE_DAYS)
-            var queuedUrlDownloads = false
 
             for (podcast in candidates) {
                 val feedUrl = podcast.feedUrl ?: continue
@@ -146,27 +141,12 @@ class AutoDownloadWorker(
                 }
 
                 for (episode in freshEpisodes) {
-                    if (UrlSource.classify(episode.audioUrl) == UrlSource.YOUTUBE) {
-                        urlDownloadRepository.enqueue(
-                            rawUrl = episode.audioUrl,
-                            mediaType = episode.mediaType,
-                            prefetchedMetadata = UrlMetadata(
-                                title = episode.title,
-                                uploader = episode.description,
-                                thumbnailUrl = episode.imageUrl,
-                                durationMs = episode.duration,
-                            ),
-                        )
-                        queuedUrlDownloads = true
-                        continue
-                    }
                     if (downloadedDao.isEpisodeDownloaded(episode.id)) continue
                     val withArtwork = ensureArtwork(episode, podcast)
                     // Result is ignored — periodic work; we'll try again next interval.
                     downloadManager.downloadEpisode(withArtwork, podcastTitle = podcast.title)
                 }
             }
-            if (queuedUrlDownloads) urlDownloadRepository.startPump()
         }
 
         private fun ensureArtwork(episode: Episode, podcast: Podcast): Episode {


### PR DESCRIPTION
Remove the YouTube channel/playlist subscribe path while preserving RSS subscribe, single-video YouTube/X downloads, and offline UX improvements.

**Removed (-201 lines across 6 files):**
- `PodcastRepository.kt`: `getYoutubeEpisodes()`, YouTube short-circuit in `getEpisodes()`, dead JsonObject extensions
- `PodcastViewModel.kt`: YouTube branches in `startDownload()` and `loadFeedPreview()`
- `UrlDownloadRepository.kt`: `fetchYoutubeSubscriptionMetadata()`, dead `stringOrNull` extension
- `EpisodeListScreen.kt`: `shouldOpenExternally()`, `openExternalUrl()`, YouTube click-to-open branch
- `AutoDownloadWorker.kt`: YouTube branch in download loop, `queuedUrlDownloads`, `startPump()`
- `AddFeedScreen.kt`: YouTube from strings, `UrlSource` import, dynamic `sourceLabel` → hardcoded "RSS FEED"

**Preserved:**
- RSS feed subscribe (AddFeedScreen, RssParser, PodcastRepository)
- Single-video YouTube/X downloads (AddFromUrlScreen, UrlDownloadService)
- Offline UX improvements (retry, needs-attention, playback-progress filter)
- `UrlSource.YOUTUBE` enum (still used by single-video path)

Builds a debug APK for testing.