### PR TITLE
Fix unreliable playback controls

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/SavedPodcastsStorage.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.podcastplayer.app.data.remote.upgradeITunesArtwork
 import com.podcastplayer.app.domain.model.Podcast
+import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,8 +87,12 @@ class SavedPodcastsStorage(context: Context) {
         } catch (_: Exception) {
             return emptyList()
         }
-        val migrated = parsed.map { it.copy(artworkUrl = upgradeITunesArtwork(it.artworkUrl)) }
+        val migrated = parsed
+            .filterNot(::isLegacyYouTubeSubscription)
+            .map { it.copy(artworkUrl = upgradeITunesArtwork(it.artworkUrl)) }
         if (migrated != parsed) {
+            // Artwork and removed-provider migration share one durable write so a
+            // legacy subscription cannot reappear on the next process start.
             prefs.edit().putString(KEY_PODCASTS, gson.toJson(migrated)).apply()
         }
         return migrated
@@ -96,5 +101,20 @@ class SavedPodcastsStorage(context: Context) {
     companion object {
         private const val PREFS_NAME = "saved_podcasts"
         private const val KEY_PODCASTS = "podcasts"
+
+        internal fun isLegacyYouTubeSubscription(podcast: Podcast): Boolean {
+            if (podcast.id.startsWith("youtube:", ignoreCase = true)) return true
+            val uri = podcast.feedUrl?.trim()?.let { runCatching { URI(it) }.getOrNull() } ?: return false
+            val host = uri.host?.lowercase()?.removePrefix("www.") ?: return false
+            if (host != "youtube.com" && !host.endsWith(".youtube.com")) return false
+            val path = uri.path.orEmpty().lowercase()
+            val query = uri.rawQuery.orEmpty().lowercase()
+            return path.startsWith("/channel/") ||
+                path.startsWith("/playlist") ||
+                path.startsWith("/feeds/videos.xml") ||
+                path.startsWith("/@") ||
+                "list=" in query ||
+                "channel_id=" in query
+        }
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/domain/model/PlayerState.kt
+++ b/app/src/main/java/com/podcastplayer/app/domain/model/PlayerState.kt
@@ -13,5 +13,8 @@ data class PlayerState(
     val currentEpisode: Episode? = null,
     val currentPosition: Long = 0L,
     val duration: Long = 0L,
-    val playbackSpeed: Float = 1.0f
+    val playbackSpeed: Float = 1.0f,
+    val playRequested: Boolean = false,
+    val isBuffering: Boolean = false,
+    val playbackError: String? = null,
 )

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/LandscapeLayouts.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/LandscapeLayouts.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.rounded.FastRewind
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.Icon
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,7 +39,6 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
-import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.domain.model.PlayerState
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
@@ -142,7 +142,9 @@ fun MiniPlayerBarLandscape(
     val duration = playerState.duration.coerceAtLeast(1L)
     val position = playerState.currentPosition.coerceIn(0L, duration)
     val progress = position.toFloat() / duration.toFloat()
-    val isPlaying = playerState.state == PlaybackState.PLAYING
+    val showsPause = playerState.playRequested
+    val controlColor = if (playerState.playbackError != null) colors.error else colors.primary
+    val controlContentColor = if (playerState.playbackError != null) colors.onError else colors.onPrimary
 
     Box(
         modifier = modifier
@@ -210,14 +212,27 @@ fun MiniPlayerBarLandscape(
                 modifier = Modifier
                     .size(42.dp)
                     .clip(CircleShape)
-                    .background(colors.primary)
+                    .background(controlColor)
                     .clickable { onPlayPause() },
                 contentAlignment = Alignment.Center,
             ) {
+                if (playerState.isBuffering) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(34.dp),
+                        color = controlContentColor,
+                        strokeWidth = 2.dp,
+                    )
+                }
                 Icon(
-                    imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
-                    tint = colors.onPrimary,
+                    imageVector = if (showsPause) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                    contentDescription = if (playerState.playbackError != null) {
+                        "Retry playback"
+                    } else if (showsPause) {
+                        "Pause"
+                    } else {
+                        "Play"
+                    },
+                    tint = controlContentColor,
                     modifier = Modifier.size(18.dp),
                 )
             }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/MiniPlayerBar.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/MiniPlayerBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.Icon
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,7 +30,6 @@ import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.PlayerState
-import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
 /**
@@ -51,7 +51,9 @@ fun MiniPlayerBar(
     val duration = playerState.duration.coerceAtLeast(1L)
     val position = playerState.currentPosition.coerceIn(0L, duration)
     val progress = position.toFloat() / duration.toFloat()
-    val isPlaying = playerState.state == PlaybackState.PLAYING
+    val showsPause = playerState.playRequested
+    val controlColor = if (playerState.playbackError != null) colors.error else colors.primary
+    val controlContentColor = if (playerState.playbackError != null) colors.onError else colors.onPrimary
 
     Surface(
         modifier = modifier
@@ -126,14 +128,25 @@ fun MiniPlayerBar(
                     modifier = Modifier
                         .size(46.dp)
                         .clip(CircleShape)
-                        .background(colors.primary)
+                        .background(controlColor)
                         .clickable { onPlayPause() },
                     contentAlignment = Alignment.Center,
                 ) {
+                    if (playerState.isBuffering) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(38.dp),
+                            color = controlContentColor,
+                            strokeWidth = 2.dp,
+                        )
+                    }
                     Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
-                        tint = colors.onPrimary,
+                        imageVector = if (showsPause) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = when {
+                            playerState.playbackError != null -> "Retry playback"
+                            showsPause -> "Pause"
+                            else -> "Play"
+                        },
+                        tint = controlContentColor,
                         modifier = Modifier.size(20.dp),
                     )
                 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PlayerScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material3.Icon
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -63,7 +64,6 @@ import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.MediaType
-import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.domain.model.PlayerState
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
@@ -87,7 +87,7 @@ fun PlayerScreen(
 ) {
     val colors = MaterialTheme.colorScheme
     val description = remember(episode.description) { episode.description.stripHtml() }
-    val isPlaying = playerState.state == PlaybackState.PLAYING
+    val showsPause = playerState.playRequested
     val duration = playerState.duration.coerceAtLeast(1L)
     val position = playerState.currentPosition.coerceIn(0L, duration)
 
@@ -147,7 +147,9 @@ fun PlayerScreen(
     if (isVideoFullscreen) {
         PlayerVideoFullscreen(
             episode = episode,
-            isPlaying = isPlaying,
+            showsPause = showsPause,
+            isBuffering = playerState.isBuffering,
+            hasPlaybackError = playerState.playbackError != null,
             position = position,
             duration = duration,
             hasPrevious = hasPrevious,
@@ -165,7 +167,9 @@ fun PlayerScreen(
         PlayerLandscape(
             episode = episode,
             artworkUrl = artworkUrl,
-            isPlaying = isPlaying,
+            showsPause = showsPause,
+            isBuffering = playerState.isBuffering,
+            hasPlaybackError = playerState.playbackError != null,
             position = position,
             duration = duration,
             playbackSpeed = playerState.playbackSpeed,
@@ -285,6 +289,16 @@ fun PlayerScreen(
             overflow = TextOverflow.Ellipsis,
             textAlign = TextAlign.Center,
         )
+        playerState.playbackError?.let { error ->
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = "$error — tap Play to retry",
+                style = MaterialTheme.typography.labelSmall,
+                color = colors.error,
+                maxLines = 2,
+                textAlign = TextAlign.Center,
+            )
+        }
 
         Spacer(Modifier.height(24.dp))
 
@@ -381,14 +395,31 @@ fun PlayerScreen(
                 modifier = Modifier
                     .size(80.dp)
                     .clip(CircleShape)
-                    .background(colors.primary)
+                    .background(
+                        if (playerState.playbackError != null) colors.error else colors.primary,
+                    )
                     .clickable(onClick = onPlayPause),
                 contentAlignment = Alignment.Center,
             ) {
+                if (playerState.isBuffering) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(68.dp),
+                        color = if (playerState.playbackError != null) {
+                            colors.onError
+                        } else {
+                            colors.onPrimary
+                        },
+                        strokeWidth = 3.dp,
+                    )
+                }
                 Icon(
-                    imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
-                    tint = colors.onPrimary,
+                    imageVector = if (showsPause) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                    contentDescription = when {
+                        playerState.playbackError != null -> "Retry playback"
+                        showsPause -> "Pause"
+                        else -> "Play"
+                    },
+                    tint = if (playerState.playbackError != null) colors.onError else colors.onPrimary,
                     modifier = Modifier.size(40.dp),
                 )
             }
@@ -553,7 +584,9 @@ private fun SleepOption(minutes: Long, onClick: () -> Unit) {
 private fun PlayerLandscape(
     episode: Episode,
     artworkUrl: String?,
-    isPlaying: Boolean,
+    showsPause: Boolean,
+    isBuffering: Boolean,
+    hasPlaybackError: Boolean,
     position: Long,
     duration: Long,
     playbackSpeed: Float,
@@ -570,7 +603,6 @@ private fun PlayerLandscape(
     onDismiss: () -> Unit,
 ) {
     val colors = MaterialTheme.colorScheme
-    val progress = position.toFloat() / duration.toFloat()
     var sleepSheetOpen by remember { mutableStateOf(false) }
 
     Row(
@@ -711,14 +743,25 @@ private fun PlayerLandscape(
                     modifier = Modifier
                         .size(60.dp)
                         .clip(CircleShape)
-                        .background(colors.primary)
+                        .background(if (hasPlaybackError) colors.error else colors.primary)
                         .clickable(onClick = onPlayPause),
                     contentAlignment = Alignment.Center,
                 ) {
+                    if (isBuffering) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(50.dp),
+                            color = if (hasPlaybackError) colors.onError else colors.onPrimary,
+                            strokeWidth = 2.dp,
+                        )
+                    }
                     Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
-                        tint = colors.onPrimary,
+                        imageVector = if (showsPause) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = when {
+                            hasPlaybackError -> "Retry playback"
+                            showsPause -> "Pause"
+                            else -> "Play"
+                        },
+                        tint = if (hasPlaybackError) colors.onError else colors.onPrimary,
                         modifier = Modifier.size(28.dp),
                     )
                 }
@@ -797,7 +840,9 @@ private fun PlayerLandscape(
 @Composable
 private fun PlayerVideoFullscreen(
     episode: Episode,
-    isPlaying: Boolean,
+    showsPause: Boolean,
+    isBuffering: Boolean,
+    hasPlaybackError: Boolean,
     position: Long,
     duration: Long,
     hasPrevious: Boolean,
@@ -916,14 +961,25 @@ private fun PlayerVideoFullscreen(
                     modifier = Modifier
                         .size(68.dp)
                         .clip(CircleShape)
-                        .background(Color.White)
+                        .background(if (hasPlaybackError) Color.Red else Color.White)
                         .clickable(onClick = onPlayPause),
                     contentAlignment = Alignment.Center,
                 ) {
+                    if (isBuffering) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(56.dp),
+                            color = Color.Black,
+                            strokeWidth = 3.dp,
+                        )
+                    }
                     Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
-                        tint = Color.Black,
+                        imageVector = if (showsPause) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = when {
+                            hasPlaybackError -> "Retry playback"
+                            showsPause -> "Pause"
+                            else -> "Play"
+                        },
+                        tint = if (hasPlaybackError) Color.White else Color.Black,
                         modifier = Modifier.size(36.dp),
                     )
                 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModel.kt
@@ -2,14 +2,16 @@ package com.podcastplayer.app.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.PlaybackState
 import com.podcastplayer.app.domain.model.PlayerState
+import com.podcastplayer.app.service.ControllerSnapshot
+import com.podcastplayer.app.service.PlaybackController
+import com.podcastplayer.app.service.PlaybackControllerListener
 import com.podcastplayer.app.service.PlaybackSessionStorage
-import com.podcastplayer.app.service.PlayerController
+import com.podcastplayer.app.util.Logger
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,178 +20,188 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class PlayerViewModel(
-    private val playerController: PlayerController,
-    private val playbackSessionStorage: PlaybackSessionStorage,
+    private val playerController: PlaybackController,
+    private val playbackSessionStorage: PlaybackSessionStorage?,
     private val appSettings: AppSettings? = null,
 ) : ViewModel() {
 
     private val _playerState = MutableStateFlow(PlayerState())
     val playerState: StateFlow<PlayerState> = _playerState.asStateFlow()
-
     private val _currentEpisode = MutableStateFlow<Episode?>(null)
     val currentEpisode: StateFlow<Episode?> = _currentEpisode.asStateFlow()
-
     private val _currentArtworkUrl = MutableStateFlow<String?>(null)
     val currentArtworkUrl: StateFlow<String?> = _currentArtworkUrl.asStateFlow()
-
     private val _sleepTimerRemaining = MutableStateFlow<Long?>(null)
     val sleepTimerRemaining: StateFlow<Long?> = _sleepTimerRemaining.asStateFlow()
-
     private val _hasPrevious = MutableStateFlow(false)
     val hasPrevious: StateFlow<Boolean> = _hasPrevious.asStateFlow()
-
     private val _hasNext = MutableStateFlow(false)
     val hasNext: StateFlow<Boolean> = _hasNext.asStateFlow()
-
-    /**
-     * Fires once after each manual playback start that resumed at a saved position.
-     * The UI consumes the value to show a "Resumed at MM:SS" snackbar/toast, then
-     * sets it back to null. Auto-advance through a queue does not raise this.
-     */
     private val _resumedFromMs = MutableStateFlow<Long?>(null)
     val resumedFromMs: StateFlow<Long?> = _resumedFromMs.asStateFlow()
 
     private var sleepTimerJob: Job? = null
-
+    private var positionTickerJob: Job? = null
+    private var requestGeneration = 0L
+    private var pendingRequestId: Long? = null
     private var queueEpisodes: Map<String, Episode> = emptyMap()
     private var queueDefaultArtworkUrl: String? = null
 
-    init {
-        playerController.addListener(object : Player.Listener {
-            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                val episodeId = mediaItem?.mediaId?.takeIf { it.isNotBlank() } ?: return
-                val episode = queueEpisodes[episodeId] ?: return
-                updateCurrentEpisode(episode, queueDefaultArtworkUrl)
-            }
-        })
+    private val controllerListener = PlaybackControllerListener(::applySnapshot)
 
+    init {
         viewModelScope.launch {
-            playerController.restoreLastSessionIfNeeded()
-            refreshFromController()
-            startPositionUpdates()
+            try {
+                playerController.addListener(controllerListener)
+                playerController.restoreLastSessionIfNeeded()
+                applySnapshot(playerController.snapshot())
+            } catch (error: Exception) {
+                Logger.e("Unable to connect playback controller", error)
+                _playerState.value = _playerState.value.copy(
+                    state = PlaybackState.ERROR,
+                    playRequested = false,
+                    isBuffering = false,
+                    playbackError = error.message ?: "Unable to connect to player",
+                )
+            }
         }
     }
 
     fun playEpisode(episode: Episode, artworkUrl: String?) {
-        viewModelScope.launch {
-            queueEpisodes = emptyMap()
-            queueDefaultArtworkUrl = null
-            updateCurrentEpisode(episode, artworkUrl)
-            _playerState.value = _playerState.value.copy(
-                state = PlaybackState.LOADING,
-                currentEpisode = episode
-            )
-            try {
-                val startMs = playerController.playEpisode(episode, artworkUrl)
-                applyDefaultSpeedIfNeeded()
-                _playerState.value = _playerState.value.copy(
-                    state = PlaybackState.PLAYING
-                )
-                if (startMs > 0L) _resumedFromMs.value = startMs
-                refreshFromController()
-            } catch (e: Exception) {
-                _playerState.value = _playerState.value.copy(
-                    state = PlaybackState.ERROR
-                )
-            }
+        queueEpisodes = emptyMap()
+        queueDefaultArtworkUrl = null
+        startEpisodeRequest(episode, artworkUrl) { requestId ->
+            playerController.prepareEpisode(episode, artworkUrl, requestId)
         }
-    }
-
-    /**
-     * Apply the user's preferred default playback speed, if a setting was wired in.
-     * Called after each manual play start; auto-advance through a queue keeps the
-     * currently-set speed.
-     */
-    private suspend fun applyDefaultSpeedIfNeeded() {
-        val speed = appSettings?.defaultPlaybackSpeed?.value ?: return
-        if (kotlin.math.abs(speed - 1.0f) < 0.01f) return
-        playerController.setPlaybackSpeed(speed)
-        _playerState.value = _playerState.value.copy(playbackSpeed = speed)
     }
 
     fun playEpisodesQueue(episodes: List<Episode>, defaultArtworkUrl: String?) {
         if (episodes.isEmpty()) return
+        queueEpisodes = episodes.associateBy(Episode::id)
+        queueDefaultArtworkUrl = defaultArtworkUrl
+        val first = episodes.first()
+        startEpisodeRequest(first, defaultArtworkUrl) { requestId ->
+            playerController.prepareEpisodes(episodes, defaultArtworkUrl, requestId)
+        }
+    }
 
+    private fun startEpisodeRequest(
+        episode: Episode,
+        artworkUrl: String?,
+        prepare: suspend (Long) -> Long?,
+    ) {
+        val requestId = ++requestGeneration
+        pendingRequestId = requestId
+        playerController.beginPlaybackRequest(requestId)
+        updateCurrentEpisode(episode, artworkUrl)
+        _playerState.value = _playerState.value.copy(
+            state = PlaybackState.LOADING,
+            currentEpisode = episode,
+            playRequested = true,
+            isBuffering = true,
+            playbackError = null,
+        )
         viewModelScope.launch {
-            queueEpisodes = episodes.associateBy { it.id }
-            queueDefaultArtworkUrl = defaultArtworkUrl
-
-            val first = episodes.first()
-            updateCurrentEpisode(first, defaultArtworkUrl)
-            _playerState.value = _playerState.value.copy(
-                state = PlaybackState.LOADING,
-                currentEpisode = first
-            )
-
             try {
-                val startMs = playerController.playEpisodes(episodes, defaultArtworkUrl)
+                val startMs = prepare(requestId) ?: return@launch
+                if (requestId != requestGeneration) return@launch
                 applyDefaultSpeedIfNeeded()
-                _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
+                if (requestId != requestGeneration) return@launch
+                playerController.play(requestId)
+                pendingRequestId = null
                 if (startMs > 0L) _resumedFromMs.value = startMs
-                refreshFromController()
-            } catch (e: Exception) {
-                _playerState.value = _playerState.value.copy(state = PlaybackState.ERROR)
+                applySnapshot(playerController.snapshot())
+            } catch (error: Exception) {
+                if (requestId != requestGeneration) return@launch
+                pendingRequestId = null
+                Logger.e("Playback request failed", error)
+                _playerState.value = _playerState.value.copy(
+                    state = PlaybackState.ERROR,
+                    playRequested = false,
+                    isBuffering = false,
+                    playbackError = error.message ?: "Playback failed",
+                )
             }
         }
     }
 
-    fun consumeResumeNotice() {
-        _resumedFromMs.value = null
+    private suspend fun applyDefaultSpeedIfNeeded() {
+        val speed = appSettings?.defaultPlaybackSpeed?.value ?: return
+        if (kotlin.math.abs(speed - 1f) < 0.01f) return
+        playerController.setPlaybackSpeed(speed)
     }
+
+    fun consumeResumeNotice() { _resumedFromMs.value = null }
 
     fun togglePlayPause() {
-        viewModelScope.launch {
-            when (_playerState.value.state) {
-                PlaybackState.PLAYING -> {
-                    playerController.pause()
-                    _playerState.value = _playerState.value.copy(state = PlaybackState.PAUSED)
-                }
-                PlaybackState.PAUSED, PlaybackState.IDLE -> {
-                    playerController.play()
-                    _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
-                }
-                else -> Unit
+        if (_playerState.value.playRequested) {
+            val cancellationId = ++requestGeneration
+            pendingRequestId = null
+            playerController.beginPlaybackRequest(cancellationId)
+            _playerState.value = _playerState.value.copy(
+                state = if (_currentEpisode.value == null) PlaybackState.IDLE else PlaybackState.PAUSED,
+                playRequested = false,
+                isBuffering = false,
+                playbackError = null,
+            )
+            viewModelScope.launch {
+                runCatching { playerController.pause() }
+                    .onFailure { Logger.e("Pause failed", it) }
             }
-            refreshFromController()
+            return
+        }
+
+        val requestId = ++requestGeneration
+        playerController.beginPlaybackRequest(requestId)
+        _playerState.value = _playerState.value.copy(
+            state = PlaybackState.LOADING,
+            playRequested = true,
+            isBuffering = true,
+            playbackError = null,
+        )
+        viewModelScope.launch {
+            try {
+                playerController.play(requestId)
+                applySnapshot(playerController.snapshot())
+            } catch (error: Exception) {
+                Logger.e("Play failed", error)
+                _playerState.value = _playerState.value.copy(
+                    state = PlaybackState.ERROR,
+                    playRequested = false,
+                    isBuffering = false,
+                    playbackError = error.message ?: "Playback failed",
+                )
+            }
         }
     }
 
-    fun playNext() {
-        viewModelScope.launch {
-            if (!_hasNext.value) return@launch
-            playerController.skipToNext()
-            playerController.play()
-            _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
-            refreshFromController()
-        }
-    }
+    fun playNext() = navigateQueue(next = true)
+    fun playPrevious() = navigateQueue(next = false)
 
-    fun playPrevious() {
+    private fun navigateQueue(next: Boolean) {
+        if (next && !_hasNext.value || !next && !_hasPrevious.value) return
+        val requestId = ++requestGeneration
+        playerController.beginPlaybackRequest(requestId)
+        _playerState.value = _playerState.value.copy(
+            state = PlaybackState.LOADING,
+            playRequested = true,
+            isBuffering = true,
+            playbackError = null,
+        )
         viewModelScope.launch {
-            if (!_hasPrevious.value) return@launch
-            playerController.skipToPrevious()
-            playerController.play()
-            _playerState.value = _playerState.value.copy(state = PlaybackState.PLAYING)
-            refreshFromController()
+            if (next) playerController.skipToNext() else playerController.skipToPrevious()
+            playerController.play(requestId)
         }
     }
 
     fun seekTo(position: Long) {
-        viewModelScope.launch {
-            playerController.seekTo(position)
-            _playerState.value = _playerState.value.copy(
-                currentPosition = position.coerceAtLeast(0)
-            )
-        }
+        _playerState.value = _playerState.value.copy(currentPosition = position.coerceAtLeast(0L))
+        viewModelScope.launch { playerController.seekTo(position) }
     }
 
     fun setPlaybackSpeed(speed: Float) {
-        viewModelScope.launch {
-            playerController.setPlaybackSpeed(speed)
-            _playerState.value = _playerState.value.copy(
-                playbackSpeed = speed
-            )
-        }
+        _playerState.value = _playerState.value.copy(playbackSpeed = speed)
+        viewModelScope.launch { playerController.setPlaybackSpeed(speed) }
     }
 
     fun setSleepTimer(durationMs: Long) {
@@ -198,12 +210,11 @@ class PlayerViewModel(
         sleepTimerJob = viewModelScope.launch {
             var remaining = durationMs
             while (remaining > 0) {
-                delay(1000)
-                remaining -= 1000
+                delay(1_000)
+                remaining -= 1_000
                 _sleepTimerRemaining.value = remaining.coerceAtLeast(0)
             }
             playerController.pause()
-            _playerState.value = _playerState.value.copy(state = PlaybackState.PAUSED)
             _sleepTimerRemaining.value = null
         }
     }
@@ -214,46 +225,55 @@ class PlayerViewModel(
         _sleepTimerRemaining.value = null
     }
 
-    private suspend fun refreshFromController() {
-        val rebuilt = playerController.getCurrentEpisode()
-        // The controller reconstructs Episode from MediaItem URI, where mediaType
-        // has to be inferred. If we already had the same episode tracked here
-        // (set by playEpisode / queue listener), preserve its mediaType so the
-        // periodic refresh can't downgrade a known-video back to audio.
-        val prev = _currentEpisode.value
+    private fun applySnapshot(snapshot: ControllerSnapshot) {
+        if (pendingRequestId != null) return
+        val previous = _currentEpisode.value
+        val rebuilt = snapshot.currentEpisode
         val episode = when {
             rebuilt == null -> null
-            prev != null && rebuilt.id == prev.id -> rebuilt.copy(mediaType = prev.mediaType)
+            queueEpisodes[rebuilt.id] != null -> queueEpisodes.getValue(rebuilt.id)
+            previous?.id == rebuilt.id -> rebuilt.copy(mediaType = previous.mediaType)
             else -> rebuilt
         }
         _currentEpisode.value = episode
-        _currentArtworkUrl.value = playerController.getCurrentArtworkUrl() ?: episode?.imageUrl
-        _hasPrevious.value = playerController.hasPrevious()
-        _hasNext.value = playerController.hasNext()
+        _currentArtworkUrl.value = episode?.imageUrl ?: snapshot.artworkUrl ?: queueDefaultArtworkUrl
+        _hasPrevious.value = snapshot.hasPrevious
+        _hasNext.value = snapshot.hasNext
 
-        val playbackState = when {
-            playerController.isPlaying() -> PlaybackState.PLAYING
-            episode != null -> PlaybackState.PAUSED
-            else -> PlaybackState.IDLE
+        val buffering = snapshot.playWhenReady && snapshot.playbackState == Player.STATE_BUFFERING
+        val state = when {
+            snapshot.playbackError != null -> PlaybackState.ERROR
+            episode == null -> PlaybackState.IDLE
+            buffering -> PlaybackState.LOADING
+            snapshot.playWhenReady && snapshot.playbackState != Player.STATE_ENDED -> PlaybackState.PLAYING
+            else -> PlaybackState.PAUSED
         }
-
-        _playerState.value = _playerState.value.copy(
-            state = playbackState,
+        _playerState.value = PlayerState(
+            state = state,
             currentEpisode = episode,
-            currentPosition = playerController.getCurrentPosition().coerceAtLeast(0L),
-            duration = playerController.getDuration().coerceAtLeast(0L)
+            currentPosition = snapshot.currentPosition,
+            duration = snapshot.duration,
+            playbackSpeed = snapshot.playbackSpeed,
+            playRequested = snapshot.playWhenReady && snapshot.playbackState != Player.STATE_ENDED,
+            isBuffering = buffering,
+            playbackError = snapshot.playbackError,
         )
+        updatePositionTicker(snapshot.playWhenReady && snapshot.playbackState != Player.STATE_ENDED)
     }
 
-    private fun startPositionUpdates() {
-        viewModelScope.launch {
+    private fun updatePositionTicker(active: Boolean) {
+        if (!active) {
+            positionTickerJob?.cancel()
+            positionTickerJob = null
+            return
+        }
+        if (positionTickerJob?.isActive == true) return
+        positionTickerJob = viewModelScope.launch {
             while (true) {
-                try {
-                    refreshFromController()
-                    kotlinx.coroutines.delay(1000)
-                } catch (e: Exception) {
-                    kotlinx.coroutines.delay(2000)
-                }
+                delay(1_000)
+                runCatching { playerController.snapshot() }
+                    .onSuccess(::applySnapshot)
+                    .onFailure { Logger.w("Position refresh failed", it) }
             }
         }
     }
@@ -261,24 +281,29 @@ class PlayerViewModel(
     private fun updateCurrentEpisode(episode: Episode, artworkUrl: String?) {
         _currentEpisode.value = episode
         _currentArtworkUrl.value = episode.imageUrl ?: artworkUrl
-        _playerState.value = _playerState.value.copy(currentEpisode = episode)
     }
 
     fun clearPlayer() {
+        val requestId = ++requestGeneration
+        pendingRequestId = null
+        playerController.beginPlaybackRequest(requestId)
+        positionTickerJob?.cancel()
         viewModelScope.launch {
             playerController.stop()
-            playbackSessionStorage.clear()
-            _currentEpisode.value = null
-            _currentArtworkUrl.value = null
-            queueEpisodes = emptyMap()
-            _playerState.value = PlayerState(PlaybackState.IDLE, null, 0L, 0L, 1f)
-            _hasPrevious.value = false
-            _hasNext.value = false
+            playbackSessionStorage?.clear()
         }
+        _currentEpisode.value = null
+        _currentArtworkUrl.value = null
+        queueEpisodes = emptyMap()
+        _playerState.value = PlayerState()
+        _hasPrevious.value = false
+        _hasNext.value = false
     }
 
     override fun onCleared() {
         sleepTimerJob?.cancel()
+        positionTickerJob?.cancel()
+        playerController.removeListener(controllerListener)
         super.onCleared()
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/service/PlaybackController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlaybackController.kt
@@ -1,0 +1,39 @@
+package com.podcastplayer.app.service
+
+import com.podcastplayer.app.domain.model.Episode
+
+data class ControllerSnapshot(
+    val currentEpisode: Episode? = null,
+    val artworkUrl: String? = null,
+    val playbackState: Int,
+    val playWhenReady: Boolean,
+    val isPlaying: Boolean,
+    val playbackError: String? = null,
+    val currentPosition: Long = 0L,
+    val duration: Long = 0L,
+    val hasPrevious: Boolean = false,
+    val hasNext: Boolean = false,
+    val playbackSpeed: Float = 1f,
+)
+
+fun interface PlaybackControllerListener {
+    fun onSnapshotChanged(snapshot: ControllerSnapshot)
+}
+
+/** Testable boundary around the app's Media3 controller. */
+interface PlaybackController {
+    fun beginPlaybackRequest(requestId: Long)
+    suspend fun prepareEpisode(episode: Episode, artworkUrl: String?, requestId: Long): Long?
+    suspend fun prepareEpisodes(episodes: List<Episode>, defaultArtworkUrl: String?, requestId: Long): Long?
+    suspend fun play(requestId: Long? = null)
+    suspend fun pause()
+    suspend fun seekTo(position: Long)
+    suspend fun skipToPrevious()
+    suspend fun skipToNext()
+    suspend fun setPlaybackSpeed(speed: Float)
+    suspend fun stop()
+    suspend fun restoreLastSessionIfNeeded(): Episode?
+    suspend fun snapshot(): ControllerSnapshot
+    suspend fun addListener(listener: PlaybackControllerListener)
+    fun removeListener(listener: PlaybackControllerListener)
+}

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerController.kt
@@ -3,176 +3,167 @@ package com.podcastplayer.app.service
 import android.content.ComponentName
 import android.content.Context
 import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import androidx.core.content.ContextCompat
 import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.MediaType
 import java.io.File
-import java.util.concurrent.Executors
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.withContext
 
-class PlayerController private constructor(private val context: Context) {
+class PlayerController private constructor(private val context: Context) : PlaybackController {
 
-    private val sessionToken = SessionToken(
-        context,
-        ComponentName(context, PlayerService::class.java)
-    )
-
-    private val controllerFuture = MediaController.Builder(context, sessionToken)
-        .buildAsync()
-
-    private val executor = Executors.newSingleThreadExecutor()
+    private val sessionToken = SessionToken(context, ComponentName(context, PlayerService::class.java))
+    private val controllerFuture = MediaController.Builder(context, sessionToken).buildAsync()
     private val playbackSessionStorage = PlaybackSessionStorage(context)
-    private val playbackProgressDao by lazy {
-        DatabaseProvider.getDatabase(context).playbackProgressDao()
+    private val playbackProgressDao by lazy { DatabaseProvider.getDatabase(context).playbackProgressDao() }
+    private val listeners = ConcurrentHashMap<PlaybackControllerListener, Player.Listener>()
+
+    @Volatile
+    private var latestPlaybackRequest = 0L
+
+    override fun beginPlaybackRequest(requestId: Long) {
+        latestPlaybackRequest = requestId
     }
 
-    private fun episodeToMediaItem(
-        episode: com.podcastplayer.app.domain.model.Episode,
-        artworkUrl: String?
-    ): androidx.media3.common.MediaItem {
-        val metadata = androidx.media3.common.MediaMetadata.Builder()
+    private fun episodeToMediaItem(episode: Episode, artworkUrl: String?): MediaItem {
+        val metadata = MediaMetadata.Builder()
             .setTitle(episode.title)
             .setArtist(episode.podcastId)
             .setDescription(episode.description)
-            .setArtworkUri(artworkUrl?.let { android.net.Uri.parse(it) })
+            .setArtworkUri(artworkUrl?.let(Uri::parse))
             .build()
-
-        val mediaUri = episode.localPath?.takeIf { episode.isDownloaded }?.let { resolveLocalUri(it) }
+        val mediaUri = episode.localPath?.takeIf { episode.isDownloaded }?.let(::resolveLocalUri)
             ?: Uri.parse(episode.audioUrl)
-
-        return androidx.media3.common.MediaItem.Builder()
+        return MediaItem.Builder()
             .setMediaId(episode.id)
             .setUri(mediaUri)
             .setMediaMetadata(metadata)
             .build()
     }
 
-    /**
-     * Saved listen-position for [episodeId], or null if the user hasn't started it
-     * or already finished it. Looked up before `prepare()` so resume is baked into
-     * the MediaItem rather than racing the player's STATE_READY callback.
-     */
     private suspend fun resumePositionFor(episodeId: String): Long? = withContext(Dispatchers.IO) {
-        val saved = playbackProgressDao.getByEpisodeId(episodeId) ?: return@withContext null
-        if (saved.completed || saved.positionMs <= 0L) null else saved.positionMs
+        playbackProgressDao.getByEpisodeId(episodeId)
+            ?.takeIf { !it.completed && it.positionMs > 0L }
+            ?.positionMs
     }
 
-    suspend fun playEpisode(episode: com.podcastplayer.app.domain.model.Episode, artworkUrl: String?): Long {
-        val controller = controllerFuture.await()
+    override suspend fun prepareEpisode(episode: Episode, artworkUrl: String?, requestId: Long): Long? {
         val startMs = resumePositionFor(episode.id) ?: 0L
+        if (requestId != latestPlaybackRequest) return null
+        val controller = controllerFuture.await()
+        if (requestId != latestPlaybackRequest) return null
         controller.setMediaItem(episodeToMediaItem(episode, artworkUrl), startMs)
         controller.prepare()
-        controller.play()
         return startMs
     }
 
-    suspend fun playEpisodes(
-        episodes: List<com.podcastplayer.app.domain.model.Episode>,
-        defaultArtworkUrl: String?
-    ): Long {
-        if (episodes.isEmpty()) return 0L
-
-        val controller = controllerFuture.await()
+    override suspend fun prepareEpisodes(
+        episodes: List<Episode>,
+        defaultArtworkUrl: String?,
+        requestId: Long,
+    ): Long? {
+        if (episodes.isEmpty()) return null
+        val startMs = resumePositionFor(episodes.first().id) ?: 0L
+        if (requestId != latestPlaybackRequest) return null
         val items = episodes.map { episode ->
-            episodeToMediaItem(
-                episode = episode,
-                artworkUrl = episode.imageUrl ?: defaultArtworkUrl
-            )
+            episodeToMediaItem(episode, episode.imageUrl ?: defaultArtworkUrl)
         }
-
-        val firstEpisodeId = episodes.first().id
-        val startMs = resumePositionFor(firstEpisodeId) ?: 0L
-
-        controller.setMediaItems(items, /* startIndex= */ 0, /* startPositionMs= */ startMs)
+        val controller = controllerFuture.await()
+        if (requestId != latestPlaybackRequest) return null
+        controller.setMediaItems(items, 0, startMs)
         controller.prepare()
-        controller.play()
         return startMs
     }
 
-    suspend fun play() {
+    override suspend fun play(requestId: Long?) {
+        if (requestId != null && requestId != latestPlaybackRequest) return
         controllerFuture.await().play()
     }
 
-    suspend fun pause() {
-        val controller = controllerFuture.await()
-        controller.pause()
-    }
+    override suspend fun pause() = controllerFuture.await().pause()
+    override suspend fun seekTo(position: Long) = controllerFuture.await().seekTo(position)
+    override suspend fun skipToPrevious() = controllerFuture.await().seekToPreviousMediaItem()
+    override suspend fun skipToNext() = controllerFuture.await().seekToNextMediaItem()
 
-    suspend fun seekTo(position: Long) {
-        val controller = controllerFuture.await()
-        controller.seekTo(position)
-    }
-
-    suspend fun skipToPrevious() {
-        val controller = controllerFuture.await()
-        controller.seekToPreviousMediaItem()
-    }
-
-    suspend fun skipToNext() {
-        val controller = controllerFuture.await()
-        controller.seekToNextMediaItem()
-    }
-
-    suspend fun hasPrevious(): Boolean {
-        val controller = controllerFuture.await()
-        return controller.hasPreviousMediaItem()
-    }
-
-    suspend fun hasNext(): Boolean {
-        val controller = controllerFuture.await()
-        return controller.hasNextMediaItem()
-    }
-
-    suspend fun setPlaybackSpeed(speed: Float) {
+    override suspend fun setPlaybackSpeed(speed: Float) {
         val controller = controllerFuture.await()
         controller.playbackParameters = controller.playbackParameters.withSpeed(speed)
     }
 
-    suspend fun getCurrentPosition(): Long {
-        val controller = controllerFuture.await()
-        return controller.currentPosition
+    override suspend fun stop() {
+        controllerFuture.await().run {
+            stop()
+            clearMediaItems()
+        }
     }
 
-    suspend fun getDuration(): Long {
-        val controller = controllerFuture.await()
-        return controller.duration
-    }
+    override suspend fun snapshot(): ControllerSnapshot = snapshotOf(controllerFuture.await())
 
-    suspend fun getPlaybackState(): Int {
-        val controller = controllerFuture.await()
-        return controller.playbackState
-    }
-
-    fun addListener(listener: Player.Listener) {
-        controllerFuture.addListener(
-            {
-                try {
-                    controllerFuture.get().addListener(listener)
-                } catch (_: Exception) {
-                }
-            },
-            executor
+    private fun snapshotOf(controller: MediaController): ControllerSnapshot {
+        val item = controller.currentMediaItem
+        val episode = item?.let(::mediaItemToEpisode)
+        return ControllerSnapshot(
+            currentEpisode = episode,
+            artworkUrl = item?.mediaMetadata?.artworkUri?.toString(),
+            playbackState = controller.playbackState,
+            playWhenReady = controller.playWhenReady,
+            isPlaying = controller.isPlaying,
+            playbackError = controller.playerError?.message,
+            currentPosition = controller.currentPosition.coerceAtLeast(0L),
+            duration = controller.duration.coerceAtLeast(0L),
+            hasPrevious = controller.hasPreviousMediaItem(),
+            hasNext = controller.hasNextMediaItem(),
+            playbackSpeed = controller.playbackParameters.speed,
         )
     }
 
-    suspend fun stop() {
+    override suspend fun addListener(listener: PlaybackControllerListener) {
         val controller = controllerFuture.await()
-        controller.stop()
-        controller.clearMediaItems()
+        withContext(Dispatchers.Main.immediate) {
+            val media3Listener = object : Player.Listener {
+                override fun onEvents(player: Player, events: Player.Events) {
+                    listener.onSnapshotChanged(snapshotOf(controller))
+                }
+            }
+            listeners.put(listener, media3Listener)?.let(controller::removeListener)
+            controller.addListener(media3Listener)
+            listener.onSnapshotChanged(snapshotOf(controller))
+        }
     }
 
-    suspend fun isPlaying(): Boolean {
-        return controllerFuture.await().isPlaying
+    override fun removeListener(listener: PlaybackControllerListener) {
+        val media3Listener = listeners.remove(listener) ?: return
+        controllerFuture.addListener(
+            { controllerFuture.get().removeListener(media3Listener) },
+            ContextCompat.getMainExecutor(context),
+        )
     }
 
-    suspend fun getCurrentEpisode(): com.podcastplayer.app.domain.model.Episode? {
-        val item = controllerFuture.await().currentMediaItem ?: return null
+    override suspend fun restoreLastSessionIfNeeded(): Episode? {
+        val controller = controllerFuture.await()
+        if (controller.mediaItemCount == 0) {
+            val session = playbackSessionStorage.load() ?: return null
+            if (session.items.isEmpty()) return null
+            controller.setMediaItems(session.items, session.currentIndex, session.currentPositionMs)
+            controller.prepare()
+            controller.playbackParameters = controller.playbackParameters.withSpeed(session.playbackSpeed)
+            if (session.wasPlaying && !session.isCompleted) controller.play() else controller.pause()
+        }
+        return controller.currentMediaItem?.let(::mediaItemToEpisode)
+    }
+
+    private fun mediaItemToEpisode(item: MediaItem): Episode {
         val uri = item.localConfiguration?.uri?.toString().orEmpty()
         val isLocal = uri.startsWith("file://") || uri.startsWith("content://")
-        return com.podcastplayer.app.domain.model.Episode(
+        return Episode(
             id = item.mediaId,
             podcastId = item.mediaMetadata.artist?.toString().orEmpty(),
             title = item.mediaMetadata.title?.toString().orEmpty(),
@@ -189,88 +180,31 @@ class PlayerController private constructor(private val context: Context) {
         )
     }
 
-    /** Build a media URI from a stored path — handles file paths AND content:// URIs. */
     private fun resolveLocalUri(localPath: String): Uri =
         if (localPath.startsWith("content://")) Uri.parse(localPath) else Uri.fromFile(File(localPath))
 
-    /**
-     * Best-effort inference of [com.podcastplayer.app.domain.model.MediaType] from a
-     * media URI, used when restoring a session or reconstructing an Episode from the
-     * MediaController. We check the extension for `file://` URIs and ask the
-     * ContentResolver for `content://` URIs (e.g. MediaStore-published downloads,
-     * which don't carry a visible extension). Defaults to AUDIO.
-     */
-    private fun inferMediaType(uri: String): com.podcastplayer.app.domain.model.MediaType {
+    private fun inferMediaType(uri: String): MediaType {
         if (uri.startsWith("content://")) {
-            val mime = try {
-                context.contentResolver.getType(Uri.parse(uri))
-            } catch (_: Throwable) {
-                null
-            }
-            if (mime?.startsWith("video/") == true) {
-                return com.podcastplayer.app.domain.model.MediaType.VIDEO
-            }
-            if (mime?.startsWith("audio/") == true) {
-                return com.podcastplayer.app.domain.model.MediaType.AUDIO
-            }
-            // Fall through to extension sniffing if MIME isn't available.
+            val mime = runCatching { context.contentResolver.getType(Uri.parse(uri)) }.getOrNull()
+            if (mime?.startsWith("video/") == true) return MediaType.VIDEO
+            if (mime?.startsWith("audio/") == true) return MediaType.AUDIO
         }
-        val ext = uri.substringAfterLast('.', "").substringBefore('?').lowercase()
-        val videoExts = setOf("mp4", "webm", "mkv", "mov", "avi", "m4v")
-        return if (ext in videoExts) {
-            com.podcastplayer.app.domain.model.MediaType.VIDEO
+        val extension = uri.substringAfterLast('.', "").substringBefore('?').lowercase()
+        return if (extension in setOf("mp4", "webm", "mkv", "mov", "avi", "m4v")) {
+            MediaType.VIDEO
         } else {
-            com.podcastplayer.app.domain.model.MediaType.AUDIO
+            MediaType.AUDIO
         }
     }
 
-    suspend fun restoreLastSessionIfNeeded(): com.podcastplayer.app.domain.model.Episode? {
-        val controller = controllerFuture.await()
-        if (controller.mediaItemCount > 0) {
-            return getCurrentEpisode()
-        }
-
-        val session = playbackSessionStorage.load() ?: return null
-        if (session.items.isEmpty()) return null
-
-        controller.setMediaItems(session.items, session.currentIndex, session.currentPositionMs)
-        controller.prepare()
-        controller.playbackParameters = controller.playbackParameters.withSpeed(session.playbackSpeed)
-
-        if (session.wasPlaying && !session.isCompleted) {
-            controller.play()
-        } else {
-            controller.pause()
-        }
-
-        return getCurrentEpisode()
-    }
-
-    suspend fun getCurrentArtworkUrl(): String? {
-        return controllerFuture.await().currentMediaItem?.mediaMetadata?.artworkUri?.toString()
-    }
-
-    fun release() {
-        MediaController.releaseFuture(controllerFuture)
-        executor.shutdown()
-    }
-
-    /**
-     * Suspends until the underlying [MediaController] is available, then returns it.
-     *
-     * Used by the video player surface (issue #33) to bind an Android `PlayerView`
-     * to the same Player instance that drives audio playback.
-     */
+    fun release() = MediaController.releaseFuture(controllerFuture)
     suspend fun awaitController(): MediaController = controllerFuture.await()
 
     companion object {
-        @Volatile
-        private var instance: PlayerController? = null
+        @Volatile private var instance: PlayerController? = null
 
-        fun getInstance(context: Context): PlayerController {
-            return instance ?: synchronized(this) {
-                instance ?: PlayerController(context.applicationContext).also { instance = it }
-            }
+        fun getInstance(context: Context): PlayerController = instance ?: synchronized(this) {
+            instance ?: PlayerController(context.applicationContext).also { instance = it }
         }
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/PlayerService.kt
@@ -1,6 +1,5 @@
 package com.podcastplayer.app.service
 
-import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -16,7 +15,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
-import androidx.media3.ui.PlayerNotificationManager
+import androidx.media3.session.DefaultMediaNotificationProvider
 import com.podcastplayer.app.MainActivity
 import com.podcastplayer.app.R
 import com.podcastplayer.app.data.local.DatabaseProvider
@@ -35,7 +34,6 @@ class PlayerService : MediaSessionService() {
 
     private var player: ExoPlayer? = null
     private var mediaSession: MediaSession? = null
-    private var notificationManager: PlayerNotificationManager? = null
 
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(serviceJob + Dispatchers.Main)
@@ -52,9 +50,10 @@ class PlayerService : MediaSessionService() {
         super.onCreate()
         createNotificationChannel()
         initializePlayer()
-        setupNotification()
+        setupMediaNotification()
     }
 
+    @UnstableApi
     private fun initializePlayer() {
         val audioAttributes = AudioAttributes.Builder()
             .setUsage(C.USAGE_MEDIA)
@@ -122,7 +121,15 @@ class PlayerService : MediaSessionService() {
             }
         )
 
-        mediaSession = MediaSession.Builder(this, player!!).build()
+        val sessionActivity = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply { flags = Intent.FLAG_ACTIVITY_SINGLE_TOP },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        mediaSession = MediaSession.Builder(this, ResilientForwardingPlayer(player!!))
+            .setSessionActivity(sessionActivity)
+            .build()
     }
 
     private fun startPersistLoop() {
@@ -203,62 +210,14 @@ class PlayerService : MediaSessionService() {
     }
 
     @UnstableApi
-    private fun setupNotification() {
-        val intent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            intent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        val descriptionAdapter = object : PlayerNotificationManager.MediaDescriptionAdapter {
-            override fun getCurrentContentTitle(player: Player): CharSequence {
-                return player.mediaMetadata.title ?: "Now playing"
-            }
-
-            override fun createCurrentContentIntent(player: Player): PendingIntent? {
-                return pendingIntent
-            }
-
-            override fun getCurrentContentText(player: Player): CharSequence? {
-                return player.mediaMetadata.artist
-            }
-
-            override fun getCurrentLargeIcon(
-                player: Player,
-                callback: PlayerNotificationManager.BitmapCallback
-            ) = null
-        }
-
-        val listener = object : PlayerNotificationManager.NotificationListener {
-            override fun onNotificationPosted(
-                notificationId: Int,
-                notification: Notification,
-                ongoing: Boolean
-            ) {
-                if (ongoing) {
-                    startForeground(notificationId, notification)
-                }
-            }
-
-            override fun onNotificationCancelled(notificationId: Int, dismissedByUser: Boolean) {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelf()
-            }
-        }
-
-        notificationManager = PlayerNotificationManager.Builder(this, NOTIFICATION_ID, CHANNEL_ID)
-            .setMediaDescriptionAdapter(descriptionAdapter)
-            .setNotificationListener(listener)
-            .setChannelImportance(NotificationManager.IMPORTANCE_LOW)
-            .setSmallIconResourceId(R.drawable.ic_launcher_foreground)
-            .build().apply {
-                setMediaSessionToken(mediaSession?.sessionCompatToken!!)
-                setPlayer(player)
-            }
+    private fun setupMediaNotification() {
+        val provider = DefaultMediaNotificationProvider.Builder(this)
+            .setNotificationId(NOTIFICATION_ID)
+            .setChannelId(CHANNEL_ID)
+            .setChannelName(R.string.app_name)
+            .build()
+        provider.setSmallIcon(R.drawable.ic_launcher_foreground)
+        setMediaNotificationProvider(provider)
     }
 
     fun playEpisode(episode: Episode, artworkUrl: String?) {
@@ -301,14 +260,11 @@ class PlayerService : MediaSessionService() {
         return mediaSession
     }
 
-    @UnstableApi
     override fun onDestroy() {
         stopPersistLoop()
         persistProgress(markCompleted = false)
         persistPlaybackSession(isCompleted = false)
         serviceJob.cancel()
-        notificationManager?.setPlayer(null)
-        notificationManager = null
         mediaSession?.release()
         mediaSession = null
         player?.release()

--- a/app/src/main/java/com/podcastplayer/app/service/ResilientForwardingPlayer.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/ResilientForwardingPlayer.kt
@@ -1,0 +1,17 @@
+package com.podcastplayer.app.service
+
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+
+/** Applies the same restart/retry behavior to app, notification, and lock-screen controls. */
+@UnstableApi
+class ResilientForwardingPlayer(player: Player) : ForwardingPlayer(player) {
+    override fun play() {
+        when {
+            playbackState == Player.STATE_ENDED -> seekToDefaultPosition()
+            playbackState == Player.STATE_IDLE && mediaItemCount > 0 -> prepare()
+        }
+        super.play()
+    }
+}

--- a/app/src/test/java/com/podcastplayer/app/data/local/SavedPodcastsMigrationTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/local/SavedPodcastsMigrationTest.kt
@@ -1,0 +1,23 @@
+package com.podcastplayer.app.data.local
+
+import com.podcastplayer.app.domain.model.Podcast
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SavedPodcastsMigrationTest {
+    @Test
+    fun removesLegacyYoutubeNamespacesAndSubscriptionFeedsOnly() {
+        assertTrue(isLegacy(podcast("youtube:UC123", "https://example.com/rss")))
+        assertTrue(isLegacy(podcast("channel", "https://www.youtube.com/feeds/videos.xml?channel_id=UC123")))
+        assertTrue(isLegacy(podcast("playlist", "https://youtube.com/playlist?list=PL123")))
+        assertTrue(isLegacy(podcast("handle", "https://youtube.com/@creator")))
+
+        assertFalse(isLegacy(podcast("rss", "https://feeds.example.com/show.xml")))
+        assertFalse(isLegacy(podcast("video", "https://youtube.com/watch?v=abc")))
+        assertFalse(isLegacy(podcast("url:42", null)))
+    }
+
+    private fun isLegacy(podcast: Podcast) = SavedPodcastsStorage.isLegacyYouTubeSubscription(podcast)
+    private fun podcast(id: String, feed: String?) = Podcast(id, "Title", "Artist", null, feed)
+}

--- a/app/src/test/java/com/podcastplayer/app/presentation/viewmodel/MainDispatcherRule.kt
+++ b/app/src/test/java/com/podcastplayer/app/presentation/viewmodel/MainDispatcherRule.kt
@@ -1,0 +1,18 @@
+package com.podcastplayer.app.presentation.viewmodel
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) = Dispatchers.setMain(dispatcher)
+    override fun finished(description: Description) = Dispatchers.resetMain()
+}

--- a/app/src/test/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/presentation/viewmodel/PlayerViewModelTest.kt
@@ -1,0 +1,181 @@
+package com.podcastplayer.app.presentation.viewmodel
+
+import androidx.lifecycle.ViewModelStore
+import androidx.media3.common.Player
+import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.domain.model.PlaybackState
+import com.podcastplayer.app.service.ControllerSnapshot
+import com.podcastplayer.app.service.PlaybackController
+import com.podcastplayer.app.service.PlaybackControllerListener
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlayerViewModelTest {
+    @get:Rule val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun secondTapDuringPreparationCancelsAutoplayImmediately() = runTest(mainDispatcherRule.dispatcher) {
+        val controller = FakePlaybackController()
+        val viewModel = PlayerViewModel(controller, null)
+        runCurrent()
+
+        viewModel.playEpisode(episode("one"), null)
+        runCurrent()
+        assertTrue(viewModel.playerState.value.playRequested)
+        assertEquals(PlaybackState.LOADING, viewModel.playerState.value.state)
+
+        viewModel.togglePlayPause()
+        assertFalse(viewModel.playerState.value.playRequested)
+        assertEquals(PlaybackState.PAUSED, viewModel.playerState.value.state)
+        controller.prepares.getValue("one").complete(0L)
+        advanceUntilIdle()
+
+        assertEquals(0, controller.playRequests.size)
+        assertEquals(1, controller.pauseCount)
+    }
+
+    @Test
+    fun staleEpisodePreparationCannotStartAfterNewSelection() = runTest(mainDispatcherRule.dispatcher) {
+        val controller = FakePlaybackController()
+        val viewModel = PlayerViewModel(controller, null)
+        runCurrent()
+
+        viewModel.playEpisode(episode("old"), null)
+        runCurrent()
+        viewModel.playEpisode(episode("new"), null)
+        runCurrent()
+        controller.prepares.getValue("new").complete(0L)
+        runCurrent()
+        controller.prepares.getValue("old").complete(0L)
+        runCurrent()
+
+        assertEquals(listOf(2L), controller.playRequests)
+        assertEquals("new", viewModel.currentEpisode.value?.id)
+        controller.emit(snapshot(episode("new"), Player.STATE_READY))
+    }
+
+    @Test
+    fun mediaEventsDriveBufferingReadyFocusAndErrorState() = runTest(mainDispatcherRule.dispatcher) {
+        val controller = FakePlaybackController()
+        val viewModel = PlayerViewModel(controller, null)
+        runCurrent()
+        val episode = episode("one")
+
+        controller.emit(snapshot(episode, Player.STATE_BUFFERING, playWhenReady = true))
+        assertEquals(PlaybackState.LOADING, viewModel.playerState.value.state)
+        assertTrue(viewModel.playerState.value.isBuffering)
+
+        // isPlaying=false models transient audio-focus suppression; play intent remains visible.
+        controller.emit(snapshot(episode, Player.STATE_READY, playWhenReady = true, isPlaying = false))
+        assertEquals(PlaybackState.PLAYING, viewModel.playerState.value.state)
+        assertTrue(viewModel.playerState.value.playRequested)
+
+        controller.emit(snapshot(episode, Player.STATE_IDLE, playbackError = "network"))
+        assertEquals(PlaybackState.ERROR, viewModel.playerState.value.state)
+        assertEquals("network", viewModel.playerState.value.playbackError)
+    }
+
+    @Test
+    fun listenerIsRegisteredAndRemovedWithViewModel() = runTest(mainDispatcherRule.dispatcher) {
+        val controller = FakePlaybackController()
+        val store = ViewModelStore()
+        val viewModel = PlayerViewModel(controller, null)
+        store.put("player", viewModel)
+        runCurrent()
+        assertEquals(1, controller.addCount)
+
+        store.clear()
+        assertEquals(1, controller.removeCount)
+    }
+
+    private fun episode(id: String) = Episode(
+        id = id,
+        podcastId = "podcast",
+        title = id,
+        description = null,
+        pubDate = null,
+        audioUrl = "https://example.com/$id.mp3",
+        duration = null,
+    )
+
+    private fun snapshot(
+        episode: Episode,
+        state: Int,
+        playWhenReady: Boolean = false,
+        isPlaying: Boolean = false,
+        playbackError: String? = null,
+    ) = ControllerSnapshot(
+        currentEpisode = episode,
+        playbackState = state,
+        playWhenReady = playWhenReady,
+        isPlaying = isPlaying,
+        playbackError = playbackError,
+    )
+
+    private class FakePlaybackController : PlaybackController {
+        var latestRequest = 0L
+        var listener: PlaybackControllerListener? = null
+        var current = ControllerSnapshot(
+            playbackState = Player.STATE_IDLE,
+            playWhenReady = false,
+            isPlaying = false,
+        )
+        val prepares = mutableMapOf<String, CompletableDeferred<Long>>()
+        val playRequests = mutableListOf<Long>()
+        var pauseCount = 0
+        var addCount = 0
+        var removeCount = 0
+
+        override fun beginPlaybackRequest(requestId: Long) { latestRequest = requestId }
+        override suspend fun prepareEpisode(episode: Episode, artworkUrl: String?, requestId: Long): Long? {
+            val result = prepares.getOrPut(episode.id) { CompletableDeferred() }.await()
+            if (requestId != latestRequest) return null
+            current = snapshotFor(episode, Player.STATE_BUFFERING, true)
+            return result
+        }
+        override suspend fun prepareEpisodes(
+            episodes: List<Episode>, defaultArtworkUrl: String?, requestId: Long,
+        ): Long? = prepareEpisode(episodes.first(), defaultArtworkUrl, requestId)
+        override suspend fun play(requestId: Long?) {
+            if (requestId != null && requestId != latestRequest) return
+            requestId?.let(playRequests::add)
+            current = current.copy(playbackState = Player.STATE_READY, playWhenReady = true, isPlaying = true)
+            listener?.onSnapshotChanged(current)
+        }
+        override suspend fun pause() { pauseCount++ }
+        override suspend fun seekTo(position: Long) = Unit
+        override suspend fun skipToPrevious() = Unit
+        override suspend fun skipToNext() = Unit
+        override suspend fun setPlaybackSpeed(speed: Float) { current = current.copy(playbackSpeed = speed) }
+        override suspend fun stop() = Unit
+        override suspend fun restoreLastSessionIfNeeded(): Episode? = null
+        override suspend fun snapshot(): ControllerSnapshot = current
+        override suspend fun addListener(listener: PlaybackControllerListener) {
+            addCount++
+            this.listener = listener
+        }
+        override fun removeListener(listener: PlaybackControllerListener) {
+            removeCount++
+            if (this.listener === listener) this.listener = null
+        }
+        fun emit(snapshot: ControllerSnapshot) {
+            current = snapshot
+            listener?.onSnapshotChanged(snapshot)
+        }
+        private fun snapshotFor(episode: Episode, state: Int, requested: Boolean) = ControllerSnapshot(
+            currentEpisode = episode,
+            playbackState = state,
+            playWhenReady = requested,
+            isPlaying = false,
+        )
+    }
+}

--- a/app/src/test/java/com/podcastplayer/app/service/ResilientForwardingPlayerTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/service/ResilientForwardingPlayerTest.kt
@@ -1,0 +1,66 @@
+package com.podcastplayer.app.service
+
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@UnstableApi
+class ResilientForwardingPlayerTest {
+    @Test
+    fun playAfterCompletionSeeksToBeginning() {
+        val calls = mutableListOf<String>()
+        val player = ResilientForwardingPlayer(fakePlayer(Player.STATE_ENDED, 1, calls))
+
+        player.play()
+
+        assertEquals(listOf("seekToDefaultPosition", "play"), calls)
+    }
+
+    @Test
+    fun playFromIdleWithItemPreparesBeforeRetry() {
+        val calls = mutableListOf<String>()
+        val player = ResilientForwardingPlayer(fakePlayer(Player.STATE_IDLE, 1, calls))
+
+        player.play()
+
+        assertEquals(listOf("prepare", "play"), calls)
+    }
+
+    @Test
+    fun normalPausedPlaybackDoesNotChangePosition() {
+        val calls = mutableListOf<String>()
+        val player = ResilientForwardingPlayer(fakePlayer(Player.STATE_READY, 1, calls))
+
+        player.play()
+
+        assertEquals(listOf("play"), calls)
+    }
+
+    private fun fakePlayer(state: Int, itemCount: Int, calls: MutableList<String>): Player {
+        return Proxy.newProxyInstance(
+            Player::class.java.classLoader,
+            arrayOf(Player::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "getPlaybackState" -> state
+                "getMediaItemCount" -> itemCount
+                "seekToDefaultPosition", "prepare", "play" -> {
+                    calls += method.name
+                    null
+                }
+                else -> defaultValue(method.returnType)
+            }
+        } as Player
+    }
+
+    private fun defaultValue(type: Class<*>): Any? = when (type) {
+        Boolean::class.javaPrimitiveType -> false
+        Int::class.javaPrimitiveType -> 0
+        Long::class.javaPrimitiveType -> 0L
+        Float::class.javaPrimitiveType -> 0f
+        Double::class.javaPrimitiveType -> 0.0
+        else -> null
+    }
+}


### PR DESCRIPTION
Summary:
- Drive playback UI from Media3 events and a single controller snapshot.
- Cancel pending autoplay and prevent stale episode requests from winning.
- Unify app and system controls through MediaSessionService restart/retry policy.
- Add buffering, immediate intent, and retry feedback across player layouts.
- Remove legacy YouTube subscriptions while preserving RSS and URL downloads.
- Add focused playback and migration tests.

Verification:
- ./gradlew testDebugUnitTest
- ./gradlew lint
- ./gradlew compileDebugKotlin
- git diff --check

Manual device/emulator testing was not run because no connected target was available.