### PR TITLE
fix: queue play picking earliest episode on feeds with unparseable dates

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
@@ -5,6 +5,10 @@ import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import java.io.InputStream
 import java.text.SimpleDateFormat
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 
@@ -177,20 +181,43 @@ class RssParser {
         return episodes
     }
 
+    /**
+     * Parses a `<pubDate>` value.
+     *
+     * The queue-play feature picks the *latest* unplayed episode per podcast by
+     * comparing this value, so a feed whose dates fail to parse silently falls
+     * back to feed order — normally harmless (feeds list newest-first) but wrong
+     * for feeds that don't. RFC 822 (the RSS 2.0 spec'd format) covers most
+     * feeds; the ISO-8601 fallback covers Atom-style feeds and the non-compliant
+     * RSS generators that emit ISO timestamps in `<pubDate>` anyway.
+     */
     private fun parseDate(dateString: String): Date? {
-        return try {
-            val formats = listOf(
-                "EEE, dd MMM yyyy HH:mm:ss Z",
-                "EEE, dd MMM yyyy HH:mm:ss z"
-            )
-            for (format in formats) {
-                try {
-                    val sdf = SimpleDateFormat(format, Locale.ENGLISH)
-                    return sdf.parse(dateString)
-                } catch (e: Exception) {
-                }
+        val trimmed = dateString.trim()
+        if (trimmed.isBlank()) return null
+
+        for (format in RFC_822_FORMATS) {
+            try {
+                return SimpleDateFormat(format, Locale.ENGLISH).parse(trimmed)
+            } catch (e: Exception) {
+                // Try the next format.
             }
-            null
+        }
+
+        return parseIso8601(trimmed)
+    }
+
+    private fun parseIso8601(value: String): Date? {
+        for (formatter in ISO_8601_FORMATTERS) {
+            try {
+                return Date.from(OffsetDateTime.parse(value, formatter).toInstant())
+            } catch (e: Exception) {
+                // Try the next formatter.
+            }
+        }
+        return try {
+            // No offset at all (some feeds emit naive local timestamps) — assume
+            // UTC rather than dropping the date entirely.
+            Date.from(LocalDateTime.parse(value).toInstant(ZoneOffset.UTC))
         } catch (e: Exception) {
             null
         }
@@ -217,6 +244,24 @@ class RssParser {
         } catch (e: Exception) {
             null
         }
+    }
+
+    companion object {
+        // RFC 822 (the RSS 2.0 spec's format) plus common non-compliant variants
+        // real feeds emit — some omit the weekday name entirely.
+        private val RFC_822_FORMATS = listOf(
+            "EEE, dd MMM yyyy HH:mm:ss Z",
+            "EEE, dd MMM yyyy HH:mm:ss z",
+            "dd MMM yyyy HH:mm:ss Z",
+            "dd MMM yyyy HH:mm:ss z",
+        )
+
+        // XXX accepts "Z" or "+HH:MM"; XX accepts "Z" or "+HHMM" (no colon).
+        // Tried in sequence so either offset style resolves.
+        private val ISO_8601_FORMATTERS = listOf(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX", Locale.ENGLISH),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS]XX", Locale.ENGLISH),
+        )
     }
 }
 

--- a/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
@@ -1,0 +1,142 @@
+package com.podcastplayer.app.data.remote
+
+import com.podcastplayer.app.domain.model.Episode
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Coverage for [RssParser.parseEpisodes], focused on `pubDate` parsing.
+ *
+ * A podcast's queue-play feature picks the *latest* unplayed episode per
+ * podcast by comparing `Episode.pubDate` (see
+ * `PodcastViewModel.buildUnplayedEpisodesForPodcastQueue`). A feed whose dates
+ * fail to parse falls back to feed order for that comparison — usually
+ * harmless, but wrong for a feed that doesn't list items newest-first. These
+ * tests pin down the date formats we're expected to handle.
+ */
+class RssParserTest {
+
+    private val parser = RssParser()
+
+    private fun episodesFor(pubDates: List<String>): List<Episode> {
+        val items = pubDates.mapIndexed { index, pubDate ->
+            """
+            <item>
+                <title>Episode $index</title>
+                <guid>ep-$index</guid>
+                <pubDate>$pubDate</pubDate>
+                <enclosure url="https://example.com/ep$index.mp3" />
+            </item>
+            """.trimIndent()
+        }.joinToString("\n")
+
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+                <channel>
+                    <title>Test Feed</title>
+                    $items
+                </channel>
+            </rss>
+        """.trimIndent()
+
+        val stream = ByteArrayInputStream(xml.toByteArray(StandardCharsets.UTF_8))
+        return parser.parseEpisodes(stream, "podcast-1")
+    }
+
+    @Test
+    fun `parses RFC 822 dates with numeric offset`() {
+        val episodes = episodesFor(listOf("Tue, 14 Jan 2025 08:00:00 +0000"))
+        assertNotNull(episodes[0].pubDate)
+        assertEquals(1736841600000L, episodes[0].pubDate!!.time)
+    }
+
+    @Test
+    fun `parses RFC 822 dates with timezone name`() {
+        val episodes = episodesFor(listOf("Tue, 14 Jan 2025 08:00:00 GMT"))
+        assertNotNull(episodes[0].pubDate)
+        assertEquals(1736841600000L, episodes[0].pubDate!!.time)
+    }
+
+    @Test
+    fun `parses RFC 822 dates missing the weekday prefix`() {
+        val episodes = episodesFor(listOf("14 Jan 2025 08:00:00 +0000"))
+        assertNotNull(episodes[0].pubDate)
+        assertEquals(1736841600000L, episodes[0].pubDate!!.time)
+    }
+
+    @Test
+    fun `parses ISO-8601 dates from Atom-style or non-compliant feeds`() {
+        val episodes = episodesFor(
+            listOf(
+                "2025-01-14T08:00:00Z",
+                "2025-01-14T08:00:00+00:00",
+                "2025-01-14T08:00:00.123Z",
+                "2025-01-14T08:00:00+0000",
+            ),
+        )
+        episodes.forEach { assertNotNull("expected a parsed date for ${it.title}", it.pubDate) }
+        // All four represent the same instant (ignoring the .123s millis case).
+        assertEquals(1736841600000L, episodes[0].pubDate!!.time)
+        assertEquals(1736841600000L, episodes[1].pubDate!!.time)
+        assertEquals(1736841600000L, episodes[3].pubDate!!.time)
+    }
+
+    @Test
+    fun `garbage pubDate does not throw and yields null`() {
+        val episodes = episodesFor(listOf("not a date at all", ""))
+        assertNull(episodes[0].pubDate)
+        assertNull(episodes[1].pubDate)
+    }
+
+    @Test
+    fun `mixed RFC 822 and ISO-8601 dates still rank correctly by recency`() {
+        // Reproduces the queue-play bug: a feed mixing date formats must still
+        // let callers pick the true latest episode via max-by-pubDate, not
+        // silently drop to feed-order tie-breaking because one format failed
+        // to parse.
+        val episodes = episodesFor(
+            listOf(
+                "Mon, 01 Jan 2024 08:00:00 +0000", // oldest, RFC 822
+                "2025-06-01T08:00:00Z",             // newest, ISO-8601
+                "Wed, 01 Jan 2025 08:00:00 +0000",  // middle, RFC 822
+            ),
+        )
+        val latest = episodes.maxByOrNull { it.pubDate?.time ?: Long.MIN_VALUE }
+        assertEquals("Episode 1", latest?.title)
+    }
+
+    @Test
+    fun `parseDuration handles hh mm ss and bare seconds`() {
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+                <channel>
+                    <item>
+                        <title>A</title>
+                        <guid>a</guid>
+                        <itunes:duration>01:02:03</itunes:duration>
+                        <enclosure url="https://example.com/a.mp3" />
+                    </item>
+                    <item>
+                        <title>B</title>
+                        <guid>b</guid>
+                        <itunes:duration>90</itunes:duration>
+                        <enclosure url="https://example.com/b.mp3" />
+                    </item>
+                </channel>
+            </rss>
+        """.trimIndent()
+        val episodes = parser.parseEpisodes(
+            ByteArrayInputStream(xml.toByteArray(StandardCharsets.UTF_8)),
+            "podcast-1",
+        )
+        assertEquals((1 * 3600 + 2 * 60 + 3) * 1000L, episodes[0].duration)
+        assertEquals(90 * 1000L, episodes[1].duration)
+        assertEquals(2, episodes.size)
+    }
+}


### PR DESCRIPTION
## Summary

`PodcastViewModel.buildUnplayedEpisodesForPodcastQueue` picks the latest unplayed episode per podcast via:
```kotlin
episodes.filter { ... not completed ... }.maxByOrNull { it.pubDate?.time ?: Long.MIN_VALUE }
```
That selection logic is correct. The bug is upstream: `RssParser.parseDate` only understood RFC 822 (the RSS 2.0 spec's format). Any feed whose `<pubDate>` uses ISO-8601 — Atom-style feeds, or the non-compliant RSS generators that emit ISO timestamps in `<pubDate>` anyway — parsed to `null` for **every** episode.

With every episode tied at `Long.MIN_VALUE`, `maxByOrNull`'s tie-break (first element wins) silently fell back to feed document order. For a feed that lists oldest-first rather than the RSS convention of newest-first, "Play Queue" started from the earliest episode instead of the latest — matching the reported bug exactly.

## Fix
- Extended `RssParser.parseDate` with an ISO-8601 fallback (`java.time`, handling both `+HH:MM` and `+HHMM` offset styles, `Z`, and offset-less timestamps assumed UTC).
- Added two more RFC 822 variants real feeds emit (missing weekday prefix).
- Verified the exact parsing algorithm against ~10 real-world date string variants in a standalone JVM harness before porting to Kotlin (network sandboxing here blocks Gradle/AGP resolution, so I validated the `SimpleDateFormat`/`java.time` logic directly against the JDK rather than through the full Android build).

## Tests
Added `RssParserTest` covering:
- RFC 822 with numeric offset, timezone name, and missing weekday
- ISO-8601 with `Z`, `+00:00`, `+0000`, and fractional seconds
- Garbage/blank input (must not throw, yields `null`)
- **The exact regression scenario**: a feed mixing RFC 822 and ISO-8601 dates across episodes — asserts `maxByOrNull` still resolves to the true latest episode by real date, not by parse-failure tie-break.

## Test plan
- [ ] Subscribe to a podcast whose feed uses ISO-8601 `pubDate` values (Atom or Substack-style)
- [ ] "Play Queue" now starts from that podcast's newest unplayed episode, not the oldest
- [ ] Existing iTunes-sourced RSS feeds (RFC 822 dates) are unaffected — regression check
- [ ] `./gradlew test --tests "*.RssParserTest"` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_