### PR TITLE
feat: reuse existing media files instead of re-downloading after reinstall

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,10 @@ dependencies {
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    // Real XmlPullParser for JVM unit tests (same parser Android ships) — the
+    // mockable android.jar stubs XmlPullParserFactory, so RssParserTest injects
+    // a KXmlParser directly.
+    testImplementation("net.sf.kxml:kxml2:2.3.0")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,16 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Restoring downloads after a reinstall: files in the shared VibePodcast folders
+         survive uninstall, but the new install isn't their owner and needs a read
+         permission to see them. Requested at runtime only from the restore/cleanup
+         flows — never on first launch. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <application
         android:name=".PodcastApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaNaming.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaNaming.kt
@@ -1,0 +1,85 @@
+package com.podcastplayer.app.data.local
+
+/**
+ * Single source of truth for the display names we write into MediaStore and the
+ * match keys used to recognize those files again later (JIT download reuse, the
+ * post-reinstall restore flow, and the duplicate cleaner).
+ *
+ * Pure JVM — no Android dependencies — so the naming/matching rules are unit
+ * testable. If you change how names are BUILT here, files written by older
+ * versions must still MATCH, so only ever loosen [matchKey], never tighten it.
+ */
+object MediaNaming {
+
+    private val ILLEGAL_CHARS = Regex("[\\\\/:*?\"<>|]")
+
+    /**
+     * The " (1)" / " (2)" suffix MediaStore appends to a display name's base when
+     * a file with the same name already exists in the folder.
+     */
+    private val DUPLICATE_SUFFIX = Regex(" \\(\\d+\\)$")
+
+    /** Mirrors the historical MediaStoreSaver sanitization exactly. */
+    fun sanitize(name: String): String =
+        name.replace(ILLEGAL_CHARS, "_").take(120).ifBlank { "vibe-media" }
+
+    /**
+     * Display name for an RSS episode download: "<podcast> - <episode>.<ext>".
+     * Same fallbacks as the historical DownloadManager implementation.
+     */
+    fun episodeDisplayName(podcastTitle: String?, episodeTitle: String, extension: String): String {
+        val rawTitle = episodeTitle.trim()
+        val base = when {
+            podcastTitle.isNullOrBlank() && rawTitle.isBlank() -> "episode"
+            podcastTitle.isNullOrBlank() -> rawTitle
+            rawTitle.isBlank() -> podcastTitle
+            else -> "$podcastTitle - $rawTitle"
+        }
+        return sanitize("$base.${extension.ifBlank { "mp3" }}")
+    }
+
+    /**
+     * Display name for a URL (yt-dlp) download: "<uploader> - <title>.<ext>".
+     * Same fallbacks as the historical UrlDownloadService implementation.
+     */
+    fun urlDisplayName(uploader: String?, title: String, extension: String): String {
+        val rawTitle = title.trim()
+        val rawUploader = uploader?.trim()?.removePrefix("@")?.trim()
+        val base = when {
+            rawUploader.isNullOrBlank() && rawTitle.isBlank() -> "vibe-clip"
+            rawUploader.isNullOrBlank() -> rawTitle
+            rawTitle.isBlank() -> rawUploader
+            else -> "$rawUploader - $rawTitle"
+        }
+        return sanitize("$base.${extension.ifBlank { "mp4" }}")
+    }
+
+    /**
+     * Canonical key for deciding that two display names refer to the same media:
+     * extension-agnostic, case-insensitive, and ignoring the " (n)" suffix
+     * MediaStore appends on name collisions. Extension-agnostic so a re-download
+     * that would produce "episode.m4a" still matches an existing "episode.mp3".
+     */
+    fun matchKey(displayName: String): String {
+        val trimmed = displayName.trim()
+        val dot = trimmed.lastIndexOf('.')
+        val base = if (dot > 0) trimmed.substring(0, dot) else trimmed
+        return base.replace(DUPLICATE_SUFFIX, "").lowercase()
+    }
+
+    /** True when the name carries a MediaStore collision suffix like "title (2).mp3". */
+    fun hasDuplicateSuffix(displayName: String): Boolean {
+        val trimmed = displayName.trim()
+        val dot = trimmed.lastIndexOf('.')
+        val base = if (dot > 0) trimmed.substring(0, dot) else trimmed
+        return DUPLICATE_SUFFIX.containsMatchIn(base)
+    }
+
+    /** Display title recovered from a file name: extension and " (n)" suffix stripped. */
+    fun titleFromDisplayName(displayName: String): String {
+        val trimmed = displayName.trim()
+        val dot = trimmed.lastIndexOf('.')
+        val base = if (dot > 0) trimmed.substring(0, dot) else trimmed
+        return base.replace(DUPLICATE_SUFFIX, "").ifBlank { trimmed }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreSaver.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreSaver.kt
@@ -155,8 +155,9 @@ object MediaStoreSaver {
         }
     }
 
-    private fun sanitize(name: String): String =
-        name.replace(Regex("[\\\\/:*?\"<>|]"), "_").take(120).ifBlank { "vibe-media" }
+    // Delegated so writers (this) and readers (MediaStoreScanner matching) can
+    // never drift apart on what a stored name looks like.
+    private fun sanitize(name: String): String = MediaNaming.sanitize(name)
 
     /**
      * Decide whether a [localPath] string points at a MediaStore entry (content://)

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreScanner.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreScanner.kt
@@ -1,0 +1,128 @@
+package com.podcastplayer.app.data.local
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.ContentUris
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.core.content.ContextCompat
+
+/**
+ * Reads back the media this app (or a previous install of it) wrote into the
+ * shared `Podcasts/VibePodcast` and `Movies/VibePodcast` folders.
+ *
+ * Ownership matters here: after an uninstall/reinstall the app is a *different
+ * owner* of those files. Without [requiredReadPermissions] granted, MediaStore
+ * queries silently return only rows the current install contributed — which
+ * makes every method below degrade gracefully: same-install dedupe keeps
+ * working permission-free, and cross-install restore lights up once the user
+ * grants access.
+ */
+class MediaStoreScanner(private val context: Context) {
+
+    /**
+     * A media row found in one of the Vibe folders. [uriString] (not [Uri]) so
+     * downstream matching/grouping logic stays JVM-unit-testable.
+     */
+    data class FoundMedia(
+        val uriString: String,
+        val displayName: String,
+        val sizeBytes: Long,
+        val dateAddedSec: Long,
+        val isVideo: Boolean,
+    )
+
+    fun hasReadPermission(): Boolean = requiredReadPermissions().all { permission ->
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /** Everything in both Vibe folders, audio and video. */
+    fun scanAll(): List<FoundMedia> = scanCollection(isVideo = false) + scanCollection(isVideo = true)
+
+    /**
+     * Best existing file matching [expectedDisplayName] (per [MediaNaming.matchKey]),
+     * or null. Prefers an exact name match, then un-suffixed names, then the oldest
+     * copy — so a reused link points at the original, not a "(2)" duplicate.
+     */
+    fun findExisting(isVideo: Boolean, expectedDisplayName: String): FoundMedia? {
+        val key = MediaNaming.matchKey(expectedDisplayName)
+        return scanCollection(isVideo)
+            .filter { it.sizeBytes > 0L && MediaNaming.matchKey(it.displayName) == key }
+            .minWithOrNull(
+                compareBy(
+                    { it.displayName != expectedDisplayName },
+                    { MediaNaming.hasDuplicateSuffix(it.displayName) },
+                    { it.dateAddedSec },
+                ),
+            )
+    }
+
+    /**
+     * System consent dialog for batch-deleting [uris] (which this install may not
+     * own). API 30+ only — returns null below that, where non-owned deletes would
+     * need a per-file consent loop that isn't worth supporting.
+     */
+    fun createDeleteRequest(uris: List<Uri>): PendingIntent? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || uris.isEmpty()) return null
+        return MediaStore.createDeleteRequest(context.contentResolver, uris)
+    }
+
+    private fun scanCollection(isVideo: Boolean): List<FoundMedia> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return emptyList()
+
+        val collection = if (isVideo) {
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+        } else {
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+        }
+        val folder = if (isVideo) MediaStoreSaver.VIDEO_SUBDIR else MediaStoreSaver.AUDIO_SUBDIR
+
+        val projection = arrayOf(
+            MediaStore.MediaColumns._ID,
+            MediaStore.MediaColumns.DISPLAY_NAME,
+            MediaStore.MediaColumns.SIZE,
+            MediaStore.MediaColumns.DATE_ADDED,
+        )
+
+        val results = mutableListOf<FoundMedia>()
+        try {
+            context.contentResolver.query(
+                collection,
+                projection,
+                "${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?",
+                arrayOf("$folder%"),
+                null,
+            )?.use { cursor ->
+                val idCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+                val nameCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+                val sizeCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
+                val dateCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_ADDED)
+                while (cursor.moveToNext()) {
+                    val id = cursor.getLong(idCol)
+                    results += FoundMedia(
+                        uriString = ContentUris.withAppendedId(collection, id).toString(),
+                        displayName = cursor.getString(nameCol) ?: continue,
+                        sizeBytes = cursor.getLong(sizeCol),
+                        dateAddedSec = cursor.getLong(dateCol),
+                        isVideo = isVideo,
+                    )
+                }
+            }
+        } catch (_: Throwable) {
+            // Query failure (odd OEM providers) — behave as "nothing found".
+        }
+        return results
+    }
+
+    companion object {
+        fun requiredReadPermissions(): Array<String> =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                arrayOf(Manifest.permission.READ_MEDIA_AUDIO, Manifest.permission.READ_MEDIA_VIDEO)
+            } else {
+                arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+            }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
@@ -12,11 +12,19 @@ import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 
-class RssParser {
+class RssParser(
+    /**
+     * How to obtain a pull parser. The default goes through the platform
+     * factory (KXmlParser on device); JVM unit tests inject a real kxml2
+     * parser directly because the mockable android.jar stubs the factory.
+     */
+    private val newPullParser: () -> XmlPullParser = {
+        XmlPullParserFactory.newInstance().newPullParser()
+    },
+) {
 
     fun parsePodcast(inputStream: InputStream, feedUrl: String): PodcastFeedMetadata {
-        val factory = XmlPullParserFactory.newInstance()
-        val parser = factory.newPullParser()
+        val parser = newPullParser()
         parser.setInput(inputStream, null)
 
         var inChannel = false
@@ -81,8 +89,7 @@ class RssParser {
     }
 
     fun parseEpisodes(inputStream: InputStream, podcastId: String): List<Episode> {
-        val factory = XmlPullParserFactory.newInstance()
-        val parser = factory.newPullParser()
+        val parser = newPullParser()
         parser.setInput(inputStream, null)
 
         val episodes = mutableListOf<Episode>()

--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -6,7 +6,9 @@ import android.os.Environment
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.DownloadedEpisodeDao
 import com.podcastplayer.app.data.local.DownloadedEpisodeEntity
+import com.podcastplayer.app.data.local.MediaNaming
 import com.podcastplayer.app.data.local.MediaStoreSaver
+import com.podcastplayer.app.data.local.MediaStoreScanner
 import com.podcastplayer.app.domain.model.Episode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -52,6 +54,24 @@ class DownloadManager(private val context: Context) {
             }
 
             if (MediaStoreSaver.isSupported()) {
+                // Reuse an already-on-disk copy instead of re-downloading — covers
+                // both "downloaded earlier this install" edge cases and files left
+                // behind by a previous install (visible once the user grants the
+                // media read permission; without it this quietly finds nothing).
+                val reusable = MediaStoreScanner(context).findExisting(
+                    isVideo = false,
+                    expectedDisplayName = displayName,
+                )
+                if (reusable != null) {
+                    onProgress(1f)
+                    val entity = episode.toEntity(
+                        localPath = reusable.uriString,
+                        fileSize = reusable.sizeBytes,
+                    )
+                    dao.insertEpisode(entity)
+                    return@withContext Result.success(reusable.uriString)
+                }
+
                 val saved = downloadIntoMediaStore(episode, displayName, onProgress)
                     ?: return@withContext Result.failure(
                         java.io.IOException("Could not save audio to MediaStore"),
@@ -238,19 +258,24 @@ class DownloadManager(private val context: Context) {
     /**
      * Human-readable display name for the MediaStore row, so users see e.g.
      * "Lex Fridman - Joe Rogan Interview.mp3" instead of a hex hash when they
-     * browse the Podcasts folder from another app. Sanitization (illegal chars,
-     * length cap) happens in [MediaStoreSaver].
+     * browse the Podcasts folder from another app. Building and sanitizing live
+     * in [MediaNaming] so the restore/reuse matching computes identical names.
      */
     private fun buildDisplayName(episode: Episode, podcastTitle: String?): String {
         val extension = guessExtension(episode.audioUrl) ?: "mp3"
-        val rawTitle = episode.title.trim()
-        val base = when {
-            podcastTitle.isNullOrBlank() && rawTitle.isBlank() -> "episode"
-            podcastTitle.isNullOrBlank() -> rawTitle
-            rawTitle.isBlank() -> podcastTitle
-            else -> "$podcastTitle - $rawTitle"
-        }
-        return "$base.$extension"
+        return MediaNaming.episodeDisplayName(podcastTitle, episode.title, extension)
+    }
+
+    /**
+     * Record an episode as downloaded WITHOUT downloading — the media already
+     * exists on disk (found by the restore flow via [MediaStoreScanner]).
+     */
+    suspend fun registerExistingDownload(
+        episode: Episode,
+        localPath: String,
+        fileSize: Long,
+    ): Unit = withContext(Dispatchers.IO) {
+        dao.insertEpisode(episode.toEntity(localPath = localPath, fileSize = fileSize))
     }
 
     private fun guessExtension(url: String): String? {

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -3,6 +3,7 @@ package com.podcastplayer.app.data.repository
 import android.content.Context
 import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.MediaNaming
 import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.data.local.UrlDownloadDao
 import com.podcastplayer.app.data.local.UrlDownloadEntity
@@ -190,6 +191,63 @@ class UrlDownloadRepository(private val context: Context) {
             fileSize = fileSize,
             completedAtMs = System.currentTimeMillis(),
         )
+    }
+
+    /**
+     * Import a media file left behind by a previous install as a playable row.
+     * Used by the restore flow for files that couldn't be matched back to a
+     * subscribed podcast's episode (e.g. yt-dlp clips, or episodes of shows the
+     * user hasn't re-subscribed to yet). The source URL is unknowable at this
+     * point, so retry is impossible — but play/delete both work.
+     *
+     * Returns false when this file was already imported (id is deterministic
+     * from the content URI, so repeat restores are no-ops).
+     */
+    suspend fun importRestored(
+        displayName: String,
+        uriString: String,
+        sizeBytes: Long,
+        isVideo: Boolean,
+    ): Boolean = withContext(Dispatchers.IO) {
+        val id = restoredIdFor(uriString)
+        if (dao.getById(id) != null) return@withContext false
+        val now = System.currentTimeMillis()
+        dao.upsert(
+            UrlDownloadEntity(
+                id = id,
+                sourceUrl = "",
+                source = UrlSource.OTHER.tag,
+                title = MediaNaming.titleFromDisplayName(displayName),
+                uploader = null,
+                thumbnailUrl = null,
+                mediaType = if (isVideo) MediaType.VIDEO.tag else MediaType.AUDIO.tag,
+                localPath = uriString,
+                durationMs = null,
+                fileSize = sizeBytes,
+                status = UrlDownloadStatus.COMPLETED.name,
+                progressPercent = 100f,
+                errorMessage = null,
+                createdAtMs = now,
+                completedAtMs = now,
+            )
+        )
+        true
+    }
+
+    /**
+     * Drop the restored-orphan row for [uriString], if one exists. Called when a
+     * later restore pass matches that same file back to a real RSS episode, so
+     * the item isn't listed twice (once as episode, once as orphan clip).
+     */
+    suspend fun removeRestoredFor(uriString: String) = withContext(Dispatchers.IO) {
+        dao.deleteById(restoredIdFor(uriString))
+    }
+
+    private fun restoredIdFor(uriString: String): String {
+        val hash = java.security.MessageDigest.getInstance("MD5")
+            .digest(uriString.toByteArray())
+            .joinToString("") { "%02x".format(it) }
+        return "restored-$hash"
     }
 
     /** Delete the row + the underlying file (if any). */

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -23,10 +23,16 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.Audiotrack
 import androidx.compose.material.icons.outlined.CloudDownload
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.DeleteSweep
+import androidx.compose.material.icons.outlined.MoreHoriz
 import androidx.compose.material.icons.outlined.Movie
 import androidx.compose.material.icons.outlined.Podcasts
 import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -49,6 +55,7 @@ import com.podcastplayer.app.R
 import com.podcastplayer.app.data.local.UrlDownloadEntity
 import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.domain.model.Episode
+import com.podcastplayer.app.presentation.viewmodel.RestoreDownloadsState
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
 /**
@@ -94,19 +101,30 @@ fun DownloadsScreen(
     entries: List<DownloadEntryUi>,
     failedUrlDownloads: List<UrlDownloadEntity> = emptyList(),
     totalBytes: Long,
+    restoreState: RestoreDownloadsState = RestoreDownloadsState.Idle,
+    maintenanceMessage: String? = null,
     onPlay: (DownloadEntryUi) -> Unit,
     onDelete: (DownloadEntryUi) -> Unit,
     onRetryUrlDownload: (String) -> Unit = {},
     onDeleteUrlDownload: (String) -> Unit = {},
     onDeleteAll: () -> Unit,
+    onRestoreDownloads: () -> Unit = {},
+    onCleanupDuplicates: () -> Unit = {},
+    onDismissRestoreResult: () -> Unit = {},
+    onDismissMaintenanceMessage: () -> Unit = {},
     @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
 ) {
     var showDeleteAllDialog by remember { mutableStateOf(false) }
+    var maintenanceMenuOpen by remember { mutableStateOf(false) }
     val eyebrow = if (entries.isEmpty()) {
         "Offline"
     } else {
         "Offline · ${entries.size} item${if (entries.size == 1) "" else "s"} · ${formatBytes(totalBytes)}"
     }
+    // Offer restore prominently when the library looks freshly wiped (typical
+    // post-reinstall state); it stays reachable from the ⋯ menu otherwise.
+    val showRestoreCard = restoreState !is RestoreDownloadsState.Idle ||
+        (entries.isEmpty() && failedUrlDownloads.isEmpty())
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -127,11 +145,46 @@ fun DownloadsScreen(
                                 )
                             },
                         )
+                        Spacer(Modifier.width(8.dp))
+                    }
+                    Box {
+                        VibeCircleIconButton(
+                            icon = Icons.Outlined.MoreHoriz,
+                            description = "Download maintenance",
+                            onClick = { maintenanceMenuOpen = true },
+                        )
+                        DropdownMenu(
+                            expanded = maintenanceMenuOpen,
+                            onDismissRequest = { maintenanceMenuOpen = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Restore previous downloads") },
+                                leadingIcon = { Icon(Icons.Outlined.Restore, contentDescription = null) },
+                                onClick = { maintenanceMenuOpen = false; onRestoreDownloads() },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Clean up duplicate files") },
+                                leadingIcon = { Icon(Icons.Outlined.DeleteSweep, contentDescription = null) },
+                                onClick = { maintenanceMenuOpen = false; onCleanupDuplicates() },
+                            )
+                        }
                     }
                 },
             )
 
+            if (maintenanceMessage != null) {
+                MaintenanceNotice(message = maintenanceMessage, onDismiss = onDismissMaintenanceMessage)
+            }
+
             if (entries.isEmpty() && failedUrlDownloads.isEmpty()) {
+                if (showRestoreCard) {
+                    RestoreDownloadsCard(
+                        state = restoreState,
+                        onRestore = onRestoreDownloads,
+                        onDismiss = onDismissRestoreResult,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -155,6 +208,15 @@ fun DownloadsScreen(
                     ),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
+                    if (restoreState !is RestoreDownloadsState.Idle) {
+                        item(key = "restore-card") {
+                            RestoreDownloadsCard(
+                                state = restoreState,
+                                onRestore = onRestoreDownloads,
+                                onDismiss = onDismissRestoreResult,
+                            )
+                        }
+                    }
                     if (failedUrlDownloads.isNotEmpty()) {
                         item {
                             Row(
@@ -386,6 +448,126 @@ private fun DownloadRow(
             size = 40.dp,
             iconSize = 22.dp,
             tinted = true,
+        )
+    }
+}
+
+/**
+ * Offer/status card for relinking media left on the device by a previous
+ * install. The [state] machine keeps this one card serving as the button,
+ * the progress row, and the result summary.
+ */
+@Composable
+private fun RestoreDownloadsCard(
+    state: RestoreDownloadsState,
+    onRestore: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(14.dp)
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(colors.primaryContainer)
+            .padding(14.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (state is RestoreDownloadsState.Running) {
+                CircularProgressIndicator(
+                    color = colors.primary,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(18.dp),
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Outlined.Restore,
+                    contentDescription = null,
+                    tint = colors.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                val (title, subtitle) = when (state) {
+                    is RestoreDownloadsState.Idle ->
+                        "Reinstalled the app?" to
+                            "Relink downloads already on this device instead of re-downloading them."
+                    is RestoreDownloadsState.Running ->
+                        "Restoring downloads…" to
+                            "Scanning your media folders and matching episodes."
+                    is RestoreDownloadsState.Done ->
+                        if (state.restoredEpisodes == 0 && state.importedClips == 0) {
+                            "Nothing to restore" to "No previously downloaded files were found."
+                        } else {
+                            "Restore complete" to buildString {
+                                append("Relinked ${state.restoredEpisodes} episode")
+                                if (state.restoredEpisodes != 1) append("s")
+                                if (state.importedClips > 0) {
+                                    append(" · imported ${state.importedClips} clip")
+                                    if (state.importedClips != 1) append("s")
+                                }
+                                append(" without re-downloading.")
+                            }
+                        }
+                    is RestoreDownloadsState.Failed ->
+                        "Restore failed" to state.message
+                }
+                Text(
+                    text = title,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.onPrimaryContainer,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = subtitle,
+                    fontSize = 11.sp,
+                    color = colors.onPrimaryContainer,
+                    lineHeight = 15.sp,
+                )
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            when (state) {
+                is RestoreDownloadsState.Idle -> VibeChip(label = "Restore", onClick = onRestore)
+                is RestoreDownloadsState.Running -> Unit
+                is RestoreDownloadsState.Done,
+                is RestoreDownloadsState.Failed -> VibeChip(label = "Dismiss", onClick = onDismiss)
+            }
+        }
+    }
+}
+
+/** One-line dismissible status strip for cleanup results ("Removed 4 files" etc.). */
+@Composable
+private fun MaintenanceNotice(message: String, onDismiss: () -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(colors.surfaceVariant)
+            .clickable(onClick = onDismiss)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = message,
+            fontSize = 12.sp,
+            color = colors.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = "DISMISS",
+            fontFamily = JetBrainsMono,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 1.2.sp,
+            color = colors.primary,
         )
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -13,8 +13,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -96,6 +98,7 @@ fun PodcastNavHost(
     val urlDownloadRepositoryShared = remember {
         com.podcastplayer.app.data.repository.UrlDownloadRepository(context)
     }
+    val mediaScanner = remember { com.podcastplayer.app.data.local.MediaStoreScanner(context) }
     val podcastViewModel: PodcastViewModel = viewModel(
         factory = PodcastViewModelFactory(
             PodcastRepository(iTunesApi.create(), RssParser()),
@@ -104,6 +107,7 @@ fun PodcastNavHost(
             queueStorage,
             db.playbackProgressDao(),
             urlDownloadRepositoryShared,
+            mediaScanner,
         )
     )
     val playerViewModel: PlayerViewModel = viewModel(
@@ -475,6 +479,65 @@ fun PodcastNavHost(
                     val podcastDownloads by podcastViewModel.downloadedEpisodesUi.collectAsState()
                     val urlDownloads by urlDownloadViewModel.completedDownloads.collectAsState()
                     val failedUrlDownloads by urlDownloadViewModel.needsAttentionDownloads.collectAsState()
+                    val restoreState by podcastViewModel.restoreState.collectAsState()
+                    var maintenanceMessage by remember { mutableStateOf<String?>(null) }
+                    var pendingDeleteCount by remember { mutableStateOf(0) }
+
+                    // Receives the outcome of the system batch-delete consent dialog.
+                    val deleteLauncher = rememberLauncherForActivityResult(
+                        ActivityResultContracts.StartIntentSenderForResult()
+                    ) { result ->
+                        maintenanceMessage = if (result.resultCode == android.app.Activity.RESULT_OK) {
+                            "Removed $pendingDeleteCount duplicate file" +
+                                (if (pendingDeleteCount == 1) "." else "s.")
+                        } else {
+                            "Cleanup canceled."
+                        }
+                    }
+
+                    fun startCleanup() {
+                        scope.launch {
+                            val uris = podcastViewModel.planDuplicateCleanup()
+                            if (uris.isEmpty()) {
+                                maintenanceMessage = "No duplicate files found."
+                                return@launch
+                            }
+                            val request = mediaScanner.createDeleteRequest(uris.map(Uri::parse))
+                            if (request == null) {
+                                maintenanceMessage = "Duplicate cleanup needs Android 11 or newer."
+                                return@launch
+                            }
+                            pendingDeleteCount = uris.size
+                            deleteLauncher.launch(
+                                androidx.activity.result.IntentSenderRequest.Builder(request.intentSender).build()
+                            )
+                        }
+                    }
+
+                    // Restore/cleanup both need the media read permission to see files a
+                    // previous install owned; route the intended action through the grant.
+                    var pendingMediaAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+                    val permissionLauncher = rememberLauncherForActivityResult(
+                        ActivityResultContracts.RequestMultiplePermissions()
+                    ) { grants ->
+                        val action = pendingMediaAction
+                        pendingMediaAction = null
+                        if (grants.values.any { it }) {
+                            action?.invoke()
+                        } else {
+                            maintenanceMessage =
+                                "Media access is needed to find files from a previous install."
+                        }
+                    }
+
+                    fun withMediaPermission(action: () -> Unit) {
+                        if (podcastViewModel.hasMediaReadPermission()) {
+                            action()
+                        } else {
+                            pendingMediaAction = action
+                            permissionLauncher.launch(podcastViewModel.mediaReadPermissions())
+                        }
+                    }
                     // Raw entities give us fileSize, which the UI flows above don't carry.
                     val podcastEntities by produceState<List<com.podcastplayer.app.data.local.DownloadedEpisodeEntity>>(
                         initialValue = emptyList(),
@@ -553,6 +616,14 @@ fun PodcastNavHost(
                                 urlDownloads.forEach { urlDownloadViewModel.deleteDownload(it.id) }
                             }
                         },
+                        restoreState = restoreState,
+                        maintenanceMessage = maintenanceMessage,
+                        onRestoreDownloads = {
+                            withMediaPermission { podcastViewModel.restorePreviousDownloads() }
+                        },
+                        onCleanupDuplicates = { withMediaPermission { startCleanup() } },
+                        onDismissRestoreResult = { podcastViewModel.dismissRestoreResult() },
+                        onDismissMaintenanceMessage = { maintenanceMessage = null },
                         onBack = { navController.popBackStack(route = Routes.Home, inclusive = false) }
                     )
                 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastViewModelFactory.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastViewModelFactory.kt
@@ -2,6 +2,7 @@ package com.podcastplayer.app.presentation.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.podcastplayer.app.data.local.MediaStoreScanner
 import com.podcastplayer.app.data.local.PlaybackProgressDao
 import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
@@ -15,6 +16,7 @@ class PodcastViewModelFactory(
     private val queueStorage: QueueStorage,
     private val playbackProgressDao: PlaybackProgressDao,
     private val urlDownloadRepository: UrlDownloadRepository? = null,
+    private val mediaScanner: MediaStoreScanner? = null,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -26,6 +28,7 @@ class PodcastViewModelFactory(
                 queueStorage,
                 playbackProgressDao,
                 urlDownloadRepository,
+                mediaScanner,
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -2,6 +2,8 @@ package com.podcastplayer.app.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.podcastplayer.app.data.local.MediaNaming
+import com.podcastplayer.app.data.local.MediaStoreScanner
 import com.podcastplayer.app.data.local.OpmlExportSummary
 import com.podcastplayer.app.data.local.OpmlImportData
 import com.podcastplayer.app.data.local.OpmlManager
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +44,7 @@ class PodcastViewModel(
     private val queueStorage: QueueStorage,
     private val playbackProgressDao: PlaybackProgressDao,
     private val urlDownloadRepository: UrlDownloadRepository? = null,
+    private val mediaScanner: MediaStoreScanner? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<PodcastUiState>(PodcastUiState.Initial)
@@ -294,6 +298,152 @@ class PodcastViewModel(
         return result
     }
 
+    private val _restoreState = MutableStateFlow<RestoreDownloadsState>(RestoreDownloadsState.Idle)
+    val restoreState: StateFlow<RestoreDownloadsState> = _restoreState.asStateFlow()
+
+    fun dismissRestoreResult() {
+        if (_restoreState.value !is RestoreDownloadsState.Running) {
+            _restoreState.value = RestoreDownloadsState.Idle
+        }
+    }
+
+    /** Read permissions the restore/cleanup flows need. Exposed for the UI to request. */
+    fun mediaReadPermissions(): Array<String> = MediaStoreScanner.requiredReadPermissions()
+
+    fun hasMediaReadPermission(): Boolean = mediaScanner?.hasReadPermission() == true
+
+    /**
+     * Relink media files already on disk (typically left behind by a previous
+     * install) instead of forcing the user to re-download everything.
+     *
+     * Pass 1 — for each subscribed podcast, fetch its feed and match episodes
+     * against the scanned files by [MediaNaming.matchKey]; hits are registered
+     * as downloads pointing at the existing file. Pass 2 — files that matched
+     * nothing (yt-dlp clips, episodes of not-yet-resubscribed shows) are
+     * imported as playable orphan entries, one per name key so "(1)"-style
+     * duplicate copies aren't imported alongside their original.
+     */
+    fun restorePreviousDownloads() {
+        val scanner = mediaScanner ?: return
+        if (_restoreState.value is RestoreDownloadsState.Running) return
+        _restoreState.value = RestoreDownloadsState.Running
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val found = scanner.scanAll().filter { it.sizeBytes > 0L }
+                if (found.isEmpty()) {
+                    _restoreState.value = RestoreDownloadsState.Done(0, 0)
+                    return@launch
+                }
+
+                // Files already referenced by either downloads table are not
+                // candidates — and neither is any same-named duplicate of them.
+                val referencedUris = buildSet {
+                    downloadManager.getAllDownloadedEntitiesFlow().first().forEach { add(it.localPath) }
+                    urlDownloadRepository?.observeAll()?.first()?.forEach { it.localPath?.let(::add) }
+                }
+                val claimedUris = referencedUris.toMutableSet()
+                val claimedKeys = found
+                    .filter { it.uriString in referencedUris }
+                    .map { MediaNaming.matchKey(it.displayName) }
+                    .toMutableSet()
+
+                val audioByKey = found.filter { !it.isVideo }
+                    .groupBy { MediaNaming.matchKey(it.displayName) }
+
+                var restoredEpisodes = 0
+                for (podcast in savedPodcastsStorage.savedPodcasts.value) {
+                    val feedUrl = podcast.feedUrl ?: continue
+                    val episodes = repository.getEpisodes(feedUrl, podcast.id).getOrNull() ?: continue
+                    for (episode in episodes) {
+                        if (downloadManager.isEpisodeDownloaded(episode.id)) continue
+                        val key = MediaNaming.matchKey(
+                            MediaNaming.episodeDisplayName(podcast.title, episode.title, "mp3"),
+                        )
+                        val pick = audioByKey[key]
+                            ?.filter { it.uriString !in claimedUris }
+                            ?.minWithOrNull(
+                                compareBy(
+                                    { MediaNaming.hasDuplicateSuffix(it.displayName) },
+                                    { it.dateAddedSec },
+                                ),
+                            ) ?: continue
+                        claimedUris += pick.uriString
+                        claimedKeys += key
+                        downloadManager.registerExistingDownload(
+                            episode = episode,
+                            localPath = pick.uriString,
+                            fileSize = pick.sizeBytes,
+                        )
+                        // If an earlier restore imported this file as an orphan clip,
+                        // drop that row now that it has a proper episode identity.
+                        urlDownloadRepository?.removeRestoredFor(pick.uriString)
+                        restoredEpisodes++
+                    }
+                }
+
+                // Orphans: at most one import per name key, skipping keys already
+                // represented in the library (their extra copies are duplicates
+                // for the cleaner, not new content).
+                var importedClips = 0
+                val orphanGroups = found
+                    .filter { it.uriString !in claimedUris }
+                    .groupBy { it.isVideo to MediaNaming.matchKey(it.displayName) }
+                for ((groupKey, candidates) in orphanGroups) {
+                    if (groupKey.second in claimedKeys) continue
+                    val pick = candidates.minWithOrNull(
+                        compareBy(
+                            { MediaNaming.hasDuplicateSuffix(it.displayName) },
+                            { it.dateAddedSec },
+                        ),
+                    ) ?: continue
+                    val imported = urlDownloadRepository?.importRestored(
+                        displayName = pick.displayName,
+                        uriString = pick.uriString,
+                        sizeBytes = pick.sizeBytes,
+                        isVideo = pick.isVideo,
+                    ) == true
+                    if (imported) importedClips++
+                }
+
+                refreshEpisodesWithDownloads()
+                _restoreState.value = RestoreDownloadsState.Done(restoredEpisodes, importedClips)
+            } catch (t: Throwable) {
+                _restoreState.value = RestoreDownloadsState.Failed(t.message ?: "Restore failed")
+            }
+        }
+    }
+
+    /**
+     * Content URIs of redundant duplicate copies ("Episode (1).mp3" etc.) that
+     * are safe to delete: never a file some DB row still points at, and always
+     * keeping one copy per name key. The UI feeds these into the system's
+     * batch-delete consent dialog.
+     */
+    suspend fun planDuplicateCleanup(): List<String> = withContext(Dispatchers.IO) {
+        val scanner = mediaScanner ?: return@withContext emptyList()
+        val found = scanner.scanAll()
+        val referencedUris = buildSet {
+            downloadManager.getAllDownloadedEntitiesFlow().first().forEach { add(it.localPath) }
+            urlDownloadRepository?.observeAll()?.first()?.forEach { it.localPath?.let(::add) }
+        }
+        found
+            .groupBy { it.isVideo to MediaNaming.matchKey(it.displayName) }
+            .values
+            .filter { it.size > 1 }
+            .flatMap { group ->
+                val keep = group.firstOrNull { it.uriString in referencedUris }
+                    ?: group.minWithOrNull(
+                        compareBy(
+                            { MediaNaming.hasDuplicateSuffix(it.displayName) },
+                            { it.dateAddedSec },
+                        ),
+                    )
+                group.filter { it !== keep && it.uriString !in referencedUris }
+                    .map { it.uriString }
+            }
+    }
+
     /**
      * Mark an episode as played without actually playing it. Stamps the
      * playback_progress row so it appears in the "completed" filter and
@@ -532,6 +682,15 @@ sealed class FeedPreviewState {
     data class Loaded(val podcast: Podcast) : FeedPreviewState()
     data class Saved(val podcast: Podcast) : FeedPreviewState()
     data class Error(val message: String) : FeedPreviewState()
+}
+
+sealed class RestoreDownloadsState {
+    data object Idle : RestoreDownloadsState()
+    data object Running : RestoreDownloadsState()
+
+    /** [restoredEpisodes] relinked to subscriptions; [importedClips] kept as orphan entries. */
+    data class Done(val restoredEpisodes: Int, val importedClips: Int) : RestoreDownloadsState()
+    data class Failed(val message: String) : RestoreDownloadsState()
 }
 
 /** Bound on simultaneous RSS feed fetches when building a queue playlist. */

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -14,7 +14,9 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.podcastplayer.app.MainActivity
 import com.podcastplayer.app.PodcastApplication
+import com.podcastplayer.app.data.local.MediaNaming
 import com.podcastplayer.app.data.local.MediaStoreSaver
+import com.podcastplayer.app.data.local.MediaStoreScanner
 import com.podcastplayer.app.data.repository.UrlDownloadRepository
 import com.podcastplayer.app.data.repository.UrlDownloadStatus
 import com.podcastplayer.app.domain.model.MediaType
@@ -163,6 +165,22 @@ class UrlDownloadService : Service() {
             repository.markExtracting(id)
             updateNotification(buildProgressNotification(entity.title, 0f, "Preparing…"))
 
+            // Reuse an already-on-disk copy (same install, or a previous install once
+            // the media read permission is granted) instead of re-running yt-dlp.
+            val requestedType = MediaType.fromTag(entity.mediaType)
+            val expectedName = MediaNaming.urlDisplayName(
+                uploader = entity.uploader,
+                title = entity.title,
+                extension = if (requestedType == MediaType.VIDEO) "mp4" else "mp3",
+            )
+            val reusable = MediaStoreScanner(applicationContext)
+                .findExisting(isVideo = requestedType == MediaType.VIDEO, expectedDisplayName = expectedName)
+            if (reusable != null) {
+                repository.markCompleted(id, reusable.uriString, reusable.sizeBytes)
+                updateNotification(buildCompletedNotification(entity.title))
+                return
+            }
+
             if (!PodcastApplication.youtubeDlReady) {
                 repository.markFailed(id, "Downloader not ready. Reopen the app and try again.")
                 return
@@ -204,9 +222,8 @@ class UrlDownloadService : Service() {
             // Try to publish to MediaStore (Android 10+) so VLC, Files, and the
             // Gallery can discover the file. Falls back to app-private storage on
             // older devices.
-            val mediaType = MediaType.fromTag(entity.mediaType)
             val displayName = buildDisplayName(entity.title, entity.uploader, produced.extension)
-            val saved = publishToMediaStore(produced, mediaType, displayName)
+            val saved = publishToMediaStore(produced, requestedType, displayName)
 
             if (saved != null) {
                 repository.markCompleted(id, saved.uri.toString(), saved.sizeBytes)
@@ -289,19 +306,10 @@ class UrlDownloadService : Service() {
      * Display name written to MediaStore. Prefixes the uploader (channel / poster)
      * when available so files browsed from VLC / Gallery read e.g.
      * "Lex Fridman - Joe Rogan #1.mp4" rather than just the bare video title.
-     * Sanitization (illegal chars, length cap) happens inside [MediaStoreSaver].
+     * Building/sanitizing live in [MediaNaming] so reuse matching stays in sync.
      */
-    private fun buildDisplayName(title: String, uploader: String?, extension: String): String {
-        val rawTitle = title.trim()
-        val rawUploader = uploader?.trim()?.removePrefix("@")?.trim()
-        val base = when {
-            rawUploader.isNullOrBlank() && rawTitle.isBlank() -> "vibe-clip"
-            rawUploader.isNullOrBlank() -> rawTitle
-            rawTitle.isBlank() -> rawUploader
-            else -> "$rawUploader - $rawTitle"
-        }
-        return "$base.${extension.ifBlank { "mp4" }}"
-    }
+    private fun buildDisplayName(title: String, uploader: String?, extension: String): String =
+        MediaNaming.urlDisplayName(uploader, title, extension)
 
     private fun pickProducedFile(dir: File): File? {
         val files = dir.listFiles()?.toList().orEmpty()

--- a/app/src/test/java/com/podcastplayer/app/data/local/MediaNamingTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/local/MediaNamingTest.kt
@@ -1,0 +1,105 @@
+package com.podcastplayer.app.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The naming + matching rules that let the app recognize its own files again:
+ * just-in-time download reuse, the post-reinstall restore flow, and the
+ * duplicate cleaner all depend on [MediaNaming.matchKey] agreeing with what
+ * [MediaNaming.episodeDisplayName] / [MediaNaming.urlDisplayName] produce.
+ */
+class MediaNamingTest {
+
+    @Test
+    fun `episode display name combines podcast and episode titles`() {
+        assertEquals(
+            "The Daily - Monday Briefing.mp3",
+            MediaNaming.episodeDisplayName("The Daily", "Monday Briefing", "mp3"),
+        )
+    }
+
+    @Test
+    fun `episode display name falls back when parts are missing`() {
+        assertEquals("episode.mp3", MediaNaming.episodeDisplayName(null, "  ", "mp3"))
+        assertEquals("Solo Title.mp3", MediaNaming.episodeDisplayName(null, "Solo Title", "mp3"))
+        assertEquals("The Daily.mp3", MediaNaming.episodeDisplayName("The Daily", "", "mp3"))
+    }
+
+    @Test
+    fun `url display name strips at-prefix from uploader`() {
+        assertEquals(
+            "elonmusk - Rocket landing.mp4",
+            MediaNaming.urlDisplayName("@elonmusk", "Rocket landing", "mp4"),
+        )
+        assertEquals("vibe-clip.mp4", MediaNaming.urlDisplayName(null, "", ""))
+    }
+
+    @Test
+    fun `illegal filesystem characters are replaced`() {
+        val name = MediaNaming.episodeDisplayName("A/B", "What? \"Quotes\": <Test>", "mp3")
+        assertFalse(name.any { it in "\\/:*?\"<>|" })
+    }
+
+    @Test
+    fun `match key ignores extension case and duplicate suffix`() {
+        val original = "The Daily - Monday Briefing.mp3"
+        assertEquals(MediaNaming.matchKey(original), MediaNaming.matchKey("The Daily - Monday Briefing (1).mp3"))
+        assertEquals(MediaNaming.matchKey(original), MediaNaming.matchKey("The Daily - Monday Briefing (12).mp3"))
+        assertEquals(MediaNaming.matchKey(original), MediaNaming.matchKey("the daily - monday briefing.MP3"))
+        assertEquals(MediaNaming.matchKey(original), MediaNaming.matchKey("The Daily - Monday Briefing.m4a"))
+    }
+
+    @Test
+    fun `match key keeps parenthesized words that are part of the title`() {
+        // "(Live)" is content, not a MediaStore collision suffix — only a
+        // trailing " (digits)" group is stripped.
+        val live = MediaNaming.matchKey("Show - Episode (Live).mp3")
+        assertTrue(live.endsWith("(live)"))
+        assertNotEquals(live, MediaNaming.matchKey("Show - Episode.mp3"))
+    }
+
+    @Test
+    fun `different episodes produce different match keys`() {
+        assertNotEquals(
+            MediaNaming.matchKey(MediaNaming.episodeDisplayName("Show", "Episode 1", "mp3")),
+            MediaNaming.matchKey(MediaNaming.episodeDisplayName("Show", "Episode 2", "mp3")),
+        )
+    }
+
+    @Test
+    fun `display name and match key round-trip through sanitization`() {
+        // What the writer stores must be recognized by the reader computing the
+        // expected name from raw metadata — the exact reinstall-restore scenario.
+        val stored = MediaNaming.episodeDisplayName("My Show", "Ep: 42 — The \"Answer\"?", "mp3")
+        val expectedAtRestoreTime =
+            MediaNaming.episodeDisplayName("My Show", "Ep: 42 — The \"Answer\"?", "mp3")
+        assertEquals(MediaNaming.matchKey(stored), MediaNaming.matchKey(expectedAtRestoreTime))
+        // ...and survives the platform appending a collision suffix.
+        val collided = stored.removeSuffix(".mp3") + " (1).mp3"
+        assertEquals(MediaNaming.matchKey(stored), MediaNaming.matchKey(collided))
+    }
+
+    @Test
+    fun `hasDuplicateSuffix flags only collision-suffixed names`() {
+        assertTrue(MediaNaming.hasDuplicateSuffix("Episode (1).mp3"))
+        assertTrue(MediaNaming.hasDuplicateSuffix("Episode (23).mp3"))
+        assertFalse(MediaNaming.hasDuplicateSuffix("Episode.mp3"))
+        assertFalse(MediaNaming.hasDuplicateSuffix("Episode (Live).mp3"))
+    }
+
+    @Test
+    fun `titleFromDisplayName strips extension and collision suffix`() {
+        assertEquals("Lex - Interview", MediaNaming.titleFromDisplayName("Lex - Interview (2).mp4"))
+        assertEquals("Lex - Interview", MediaNaming.titleFromDisplayName("Lex - Interview.mp4"))
+    }
+
+    @Test
+    fun `sanitize caps length and never returns blank`() {
+        assertEquals(120, MediaNaming.sanitize("x".repeat(300)).length)
+        assertEquals("vibe-media", MediaNaming.sanitize(""))
+    }
+}

--- a/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
@@ -25,26 +25,24 @@ class RssParserTest {
     private val parser = RssParser(newPullParser = { org.kxml2.io.KXmlParser() })
 
     private fun episodesFor(pubDates: List<String>): List<Episode> {
-        val items = pubDates.mapIndexed { index, pubDate ->
-            """
-            <item>
-                <title>Episode $index</title>
-                <guid>ep-$index</guid>
-                <pubDate>$pubDate</pubDate>
-                <enclosure url="https://example.com/ep$index.mp3" />
-            </item>
-            """.trimIndent()
-        }.joinToString("\n")
-
-        val xml = """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <rss version="2.0">
-                <channel>
-                    <title>Test Feed</title>
-                    $items
-                </channel>
-            </rss>
-        """.trimIndent()
+        // Assembled with buildString rather than a trimIndent'd template:
+        // trimIndent runs AFTER interpolation, so interpolated zero-indent
+        // lines would stop the surrounding indentation from being stripped —
+        // leaving whitespace before <?xml?>, a fatal prolog error for a
+        // strict pull parser.
+        val xml = buildString {
+            append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            append("<rss version=\"2.0\"><channel><title>Test Feed</title>\n")
+            pubDates.forEachIndexed { index, pubDate ->
+                append("<item>")
+                append("<title>Episode $index</title>")
+                append("<guid>ep-$index</guid>")
+                append("<pubDate>$pubDate</pubDate>")
+                append("<enclosure url=\"https://example.com/ep$index.mp3\" />")
+                append("</item>\n")
+            }
+            append("</channel></rss>")
+        }
 
         val stream = ByteArrayInputStream(xml.toByteArray(StandardCharsets.UTF_8))
         return parser.parseEpisodes(stream, "podcast-1")

--- a/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
@@ -20,7 +20,9 @@ import org.junit.Test
  */
 class RssParserTest {
 
-    private val parser = RssParser()
+    // Inject a real kxml2 parser: on the JVM the default XmlPullParserFactory
+    // path resolves to the mockable android.jar, whose methods throw "Stub!".
+    private val parser = RssParser(newPullParser = { org.kxml2.io.KXmlParser() })
 
     private fun episodesFor(pubDates: List<String>): List<Episode> {
         val items = pubDates.mapIndexed { index, pubDate ->


### PR DESCRIPTION
## Problem
Downloads live in shared MediaStore folders (`Podcasts/VibePodcast`, `Movies/VibePodcast`) and deliberately survive uninstall — but the Room DB tracking them is app-private and gets wiped. After a reinstall the app has amnesia: every download re-fetches the bytes and MediaStore appends " (1)", " (2)" to the new copies. Wasted time, data, and battery.

**The Android constraint that shapes the design**: a reinstalled app is a *different owner* of those files. Seeing them requires a media read permission (`READ_MEDIA_AUDIO`/`READ_MEDIA_VIDEO` on 13+, `READ_EXTERNAL_STORAGE` on 10–12), and deleting them requires the system batch-consent dialog (API 30+). Both are requested lazily, only from the restore/cleanup flows — never on first launch.

## What's new

**`MediaNaming`** (pure, unit-tested) — single source of truth for display names and the match key (extension-agnostic, case-insensitive, ignores MediaStore's " (n)" collision suffix). `MediaStoreSaver`, `DownloadManager`, and `UrlDownloadService` all build names through it now, so writers and readers can't drift.

**`MediaStoreScanner`** — queries the two Vibe folders, finds an existing file for an expected name, builds `createDeleteRequest` batches. Without the read permission, MediaStore queries silently return only own files — so every caller degrades gracefully rather than erroring.

**Just-in-time reuse** — `DownloadManager` and `UrlDownloadService` check for an existing on-disk copy *before* downloading / running yt-dlp, and relink instead. Works permission-free within an install; spans reinstalls once permission is granted.

**Restore flow** — "Reinstalled the app?" card on the empty Downloads screen (plus always available in the new ⋯ menu). Requests permission → re-fetches each subscription's feed → matches episodes to scanned files by name key → re-inserts download rows pointing at the existing files. Unmatched files import as playable orphan entries (one per name key, so "(1)" copies aren't imported as content). Re-runs are idempotent.

**Duplicate cleaner** — ⋯ menu → groups same-key copies, keeps the DB-referenced (or oldest) one, feeds the rest to Android's one-shot batch-delete consent dialog. Never deletes a file a DB row still points at. API 30+; graceful message below.

## Known limitations (by design)
- The "Found N downloads" count can only appear *after* the first permission grant — Android hides other-owner files until then, so the empty-library card is the heuristic prompt.
- Restore matches RSS episodes by display name (`"Podcast - Episode"`), so an episode retitled upstream, or names truncated past 120 chars, may import as an orphan clip instead of relinking. Clean filenames were chosen over embedded ID tags per product decision.
- If the user later revokes the permission, previously relinked (non-owned) files stop being readable; playback errors surface through the existing resilient-player path.

## Tests
`MediaNamingTest` — name building, sanitization round-trip, collision-suffix rules, and the writer/reader match-key agreement the whole feature depends on.

## Test plan
- [ ] Download episodes + a YouTube clip → uninstall → reinstall → re-subscribe → Downloads → Restore → grant permission → items return without network traffic, no "(1)" files created
- [ ] Tap download on an episode whose file already exists → relinks instantly instead of re-downloading
- [ ] Device with existing "(1)"/"(2)" duplicates → Clean up duplicate files → system dialog → extras gone, playable copy kept
- [ ] Deny permission → clear message, no crash; downloads still work normally
- [ ] `./gradlew test --tests "*.MediaNamingTest"` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_