### PR TITLE
fix: Play Queue plays each podcast's latest unplayed episode, not oldest

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/remote/RssParser.kt
@@ -254,13 +254,25 @@ class RssParser(
     }
 
     companion object {
-        // RFC 822 (the RSS 2.0 spec's format) plus common non-compliant variants
-        // real feeds emit — some omit the weekday name entirely.
+        // RFC 822 (the RSS 2.0 spec's format) plus common non-compliant variants real
+        // feeds emit — some omit the weekday, the seconds, or the timezone entirely.
+        //
+        // ORDER IS LOAD-BEARING: SimpleDateFormat.parse ignores trailing input, so a
+        // less-specific pattern placed earlier would swallow a fuller timestamp and
+        // silently drop the tail. e.g. the no-timezone "…HH:mm:ss" would "match"
+        // "…08:00:00 +0000" and lose the offset. So: most specific (seconds + zone)
+        // first; no-timezone forms (parsed as device-local) strictly last.
         private val RFC_822_FORMATS = listOf(
             "EEE, dd MMM yyyy HH:mm:ss Z",
             "EEE, dd MMM yyyy HH:mm:ss z",
             "dd MMM yyyy HH:mm:ss Z",
             "dd MMM yyyy HH:mm:ss z",
+            // No seconds, but zoned.
+            "EEE, dd MMM yyyy HH:mm Z",
+            "EEE, dd MMM yyyy HH:mm z",
+            // No timezone at all (naive local time). Must stay last.
+            "EEE, dd MMM yyyy HH:mm:ss",
+            "dd MMM yyyy HH:mm:ss",
         )
 
         // XXX accepts "Z" or "+HH:MM"; XX accepts "Z" or "+HHMM" (no colon).

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -621,10 +621,10 @@ class PodcastViewModel(
 
     /**
      * Build the "Play Queue" playlist per docs/specs/004-podcast-queue-play.md section 4-5:
-     * for each podcast in queue order, include ALL unplayed (non-completed) episodes,
-     * ordered oldest -> newest within that podcast. Queue order across podcasts is preserved
-     * in the flattened result. Per-podcast feed fetches run concurrently (independent network
-     * calls), bounded by [MAX_CONCURRENT_QUEUE_FEED_FETCHES].
+     * for each podcast in queue order, include its single LATEST (newest) unplayed
+     * (non-completed) episode. Queue order across podcasts is preserved in the result.
+     * Per-podcast feed fetches run concurrently (independent network calls), bounded by
+     * [MAX_CONCURRENT_QUEUE_FEED_FETCHES].
      */
     suspend fun buildUnplayedEpisodesForPodcastQueue(podcasts: List<Podcast>): List<Episode> {
         return buildUnplayedEpisodesForQueue(
@@ -705,8 +705,9 @@ private const val MAX_CONCURRENT_QUEUE_FEED_FETCHES = 4
  *
  * Feed fetches for different podcasts are independent network calls, so they run
  * concurrently (bounded by [MAX_CONCURRENT_QUEUE_FEED_FETCHES]) while queue order is
- * preserved in the flattened result: `awaitAll()` on a `List<Deferred<T>>` returns
- * results in the original list order, not completion order.
+ * preserved in the result: `awaitAll()` on a `List<Deferred<T>>` returns results in
+ * the original list order, not completion order. Podcasts whose latest unplayed
+ * episode can't be resolved (no feed, empty feed, all episodes completed) are dropped.
  */
 internal suspend fun buildUnplayedEpisodesForQueue(
     podcasts: List<Podcast>,
@@ -720,40 +721,45 @@ internal suspend fun buildUnplayedEpisodesForQueue(
             .map { podcast ->
                 async {
                     semaphore.withPermit {
-                        unplayedEpisodesForPodcast(podcast, fetchEpisodes, fetchProgress)
+                        latestUnplayedEpisodeForPodcast(podcast, fetchEpisodes, fetchProgress)
                     }
                 }
             }
             .awaitAll()
-            .flatten()
+            .filterNotNull()
     }
 }
 
 /**
- * All non-completed episodes for a single [podcast], oldest -> newest by [Episode.pubDate]
- * (episodes with no pubDate sort last — we don't know how old they are). "Unplayed" means
- * no playback_progress row, or a row with `completed == false`; partially-played episodes
- * are included, per spec section 5.
+ * The single LATEST (newest by [Episode.pubDate]) non-completed episode for a
+ * [podcast], or null if none qualifies. "Unplayed" means no playback_progress row,
+ * or a row with `completed == false`; partially-played episodes are included, per
+ * spec section 5.
+ *
+ * Selection uses [Long.MIN_VALUE] as the sentinel for a missing/unparseable pubDate
+ * so such an episode never wins "newest" over a dated one. When EVERY candidate has
+ * no pubDate, `maxByOrNull` returns the first in feed document order — conventionally
+ * the newest, since feeds list newest-first.
  */
-private suspend fun unplayedEpisodesForPodcast(
+private suspend fun latestUnplayedEpisodeForPodcast(
     podcast: Podcast,
     fetchEpisodes: suspend (feedUrl: String, podcastId: String) -> Result<List<Episode>>,
     fetchProgress: suspend (podcastId: String) -> List<PlaybackProgressEntity>,
-): List<Episode> {
-    val feedUrl = podcast.feedUrl ?: return emptyList()
+): Episode? {
+    val feedUrl = podcast.feedUrl ?: return null
     val episodes = fetchEpisodes(feedUrl, podcast.id).getOrNull().orEmpty()
-    if (episodes.isEmpty()) return emptyList()
+    if (episodes.isEmpty()) return null
 
     val progressByEpisodeId = fetchProgress(podcast.id).associateBy { it.episodeId }
 
-    return episodes
+    val latest = episodes
         .filter { episode -> progressByEpisodeId[episode.id]?.completed != true }
-        .sortedBy { it.pubDate?.time ?: Long.MAX_VALUE }
-        .map { episode ->
-            if (episode.imageUrl == null && podcast.artworkUrl != null) {
-                episode.copy(imageUrl = podcast.artworkUrl)
-            } else {
-                episode
-            }
-        }
+        .maxByOrNull { it.pubDate?.time ?: Long.MIN_VALUE }
+        ?: return null
+
+    return if (latest.imageUrl == null && podcast.artworkUrl != null) {
+        latest.copy(imageUrl = podcast.artworkUrl)
+    } else {
+        latest
+    }
 }

--- a/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/remote/RssParserTest.kt
@@ -70,6 +70,31 @@ class RssParserTest {
     }
 
     @Test
+    fun `parses RFC 822 dates without seconds`() {
+        val episodes = episodesFor(listOf("Tue, 14 Jan 2025 08:00 +0000"))
+        assertNotNull(episodes[0].pubDate)
+        assertEquals(1736841600000L, episodes[0].pubDate!!.time)
+    }
+
+    @Test
+    fun `parses RFC 822 dates without a timezone`() {
+        // Parsed as device-local, so the exact instant is zone-dependent; only assert
+        // it resolves to a non-null date (relative ordering within one feed is what matters).
+        val episodes = episodesFor(listOf("Tue, 14 Jan 2025 08:00:00"))
+        assertNotNull(episodes[0].pubDate)
+    }
+
+    @Test
+    fun `a zoned timestamp keeps its offset and is not swallowed by the no-timezone pattern`() {
+        // Regression guard for pattern ordering: a non-UTC offset must survive. If the
+        // no-timezone "…HH:mm:ss" pattern caught this first it would drop the -0500 and
+        // (on a UTC runner) land 5 hours early.
+        val episodes = episodesFor(listOf("Tue, 14 Jan 2025 08:00:00 -0500"))
+        assertNotNull(episodes[0].pubDate)
+        assertEquals(1736859600000L, episodes[0].pubDate!!.time) // 08:00 -0500 == 13:00 UTC
+    }
+
+    @Test
     fun `parses ISO-8601 dates from Atom-style or non-compliant feeds`() {
         val episodes = episodesFor(
             listOf(

--- a/app/src/test/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModelTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModelTest.kt
@@ -28,17 +28,17 @@ class PodcastViewModelTest {
     @get:Rule val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun buildsPlaylistWithAllUnplayedEpisodesOldestFirstInQueueOrder() = runTest(mainDispatcherRule.dispatcher) {
+    fun picksLatestUnplayedEpisodePerPodcastInQueueOrder() = runTest(mainDispatcherRule.dispatcher) {
         val podcastA = podcast("a", feedUrl = "https://feed.example/a")
         val podcastB = podcast("b", feedUrl = "https://feed.example/b")
 
-        // Podcast A: ep-a2 is completed and must be excluded. ep-a1/ep-a3 are unplayed
-        // and published out of chronological order, to verify oldest -> newest sorting.
+        // Podcast A: ep-a2 is the newest overall (3_000) but completed, so it must be
+        // excluded; the newest UNPLAYED is ep-a3 (2_000), not ep-a1 (1_000).
         val epA1 = episode("ep-a1", podcastA.id, pubDateMs = 1_000L)
         val epA2 = episode("ep-a2", podcastA.id, pubDateMs = 3_000L)
         val epA3 = episode("ep-a3", podcastA.id, pubDateMs = 2_000L)
 
-        // Podcast B: both episodes unplayed (no progress row at all for one of them).
+        // Podcast B: both unplayed; newest is ep-b2 (1_500).
         val epB1 = episode("ep-b1", podcastB.id, pubDateMs = 500L)
         val epB2 = episode("ep-b2", podcastB.id, pubDateMs = 1_500L)
 
@@ -51,50 +51,77 @@ class PodcastViewModelTest {
             podcastB.id to listOf(progress(epB1.id, podcastB.id, completed = false)),
         )
 
-        // Queue order is B then A; the result must follow queue order, not alphabetical
-        // podcast id order or feed-fetch completion order.
+        // Queue order is B then A; result must follow queue order (one episode each),
+        // not alphabetical podcast id order or feed-fetch completion order.
         val result = buildUnplayedEpisodesForQueue(
             podcasts = listOf(podcastB, podcastA),
             fetchEpisodes = { feedUrl, _ -> Result.success(episodesByFeed.getValue(feedUrl)) },
             fetchProgress = { podcastId -> progressByPodcast.getValue(podcastId) },
         )
 
-        assertEquals(listOf(epB1.id, epB2.id, epA1.id, epA3.id), result.map { it.id })
+        assertEquals(listOf(epB2.id, epA3.id), result.map { it.id })
     }
 
     @Test
-    fun skipsPodcastsWithNoFeedUrlAndToleratesFetchFailures() = runTest(mainDispatcherRule.dispatcher) {
+    fun skipsPodcastsWithNoEligibleEpisodeAndToleratesFetchFailures() = runTest(mainDispatcherRule.dispatcher) {
         val noFeed = podcast("no-feed", feedUrl = null)
         val failingFeed = podcast("failing", feedUrl = "https://feed.example/failing")
+        val allCompleted = podcast("all-done", feedUrl = "https://feed.example/done")
         val ok = podcast("ok", feedUrl = "https://feed.example/ok")
+        val epDone = episode("ep-done", allCompleted.id, pubDateMs = 1_000L)
         val epOk = episode("ep-ok", ok.id, pubDateMs = 1_000L)
 
         val result = buildUnplayedEpisodesForQueue(
-            podcasts = listOf(noFeed, failingFeed, ok),
+            podcasts = listOf(noFeed, failingFeed, allCompleted, ok),
             fetchEpisodes = { feedUrl, _ ->
-                if (feedUrl == failingFeed.feedUrl) Result.failure(Exception("boom"))
-                else Result.success(listOf(epOk))
+                when (feedUrl) {
+                    failingFeed.feedUrl -> Result.failure(Exception("boom"))
+                    allCompleted.feedUrl -> Result.success(listOf(epDone))
+                    else -> Result.success(listOf(epOk))
+                }
             },
-            fetchProgress = { emptyList() },
+            fetchProgress = { podcastId ->
+                if (podcastId == allCompleted.id) listOf(progress(epDone.id, podcastId, completed = true))
+                else emptyList()
+            },
         )
 
+        // no-feed skipped, failing skipped, all-completed skipped → only ok remains.
         assertEquals(listOf(epOk.id), result.map { it.id })
     }
 
     @Test
-    fun episodesWithNoPubDateSortLast() = runTest(mainDispatcherRule.dispatcher) {
+    fun picksLatestDatedEpisodeOverUndated() = runTest(mainDispatcherRule.dispatcher) {
         val podcast = podcast("a", feedUrl = "https://feed.example/a")
         val dated = episode("ep-dated", podcast.id, pubDateMs = 1_000L)
         val undated = episode("ep-undated", podcast.id, pubDateMs = null)
 
         val result = buildUnplayedEpisodesForQueue(
             podcasts = listOf(podcast),
-            // Listed undated-first on purpose, to confirm sorting (not input order) decides.
+            // Listed undated-first on purpose: an undated episode must never win "newest"
+            // over a dated one, regardless of input order.
             fetchEpisodes = { _, _ -> Result.success(listOf(undated, dated)) },
             fetchProgress = { emptyList() },
         )
 
-        assertEquals(listOf(dated.id, undated.id), result.map { it.id })
+        assertEquals(listOf(dated.id), result.map { it.id })
+    }
+
+    @Test
+    fun allNullDatesFallsBackToFeedFirst() = runTest(mainDispatcherRule.dispatcher) {
+        val podcast = podcast("a", feedUrl = "https://feed.example/a")
+        // Feeds are conventionally newest-first; with no dates to compare, the first
+        // episode in document order is taken as the newest.
+        val feedNewest = episode("ep-first", podcast.id, pubDateMs = null)
+        val feedOlder = episode("ep-second", podcast.id, pubDateMs = null)
+
+        val result = buildUnplayedEpisodesForQueue(
+            podcasts = listOf(podcast),
+            fetchEpisodes = { _, _ -> Result.success(listOf(feedNewest, feedOlder)) },
+            fetchProgress = { emptyList() },
+        )
+
+        assertEquals(listOf(feedNewest.id), result.map { it.id })
     }
 
     private fun podcast(id: String, feedUrl: String?) = Podcast(

--- a/docs/analysis-2026-07.md
+++ b/docs/analysis-2026-07.md
@@ -124,10 +124,13 @@ Ranked by user-visible impact.
 
 ### Corrections (bugs in shipped features)
 
-- **[FIXED] Play Queue contradicted its own spec.** `docs/specs/004-podcast-queue-play.md` specifies
-  playing **all** unplayed episodes per podcast, oldest→newest; the implementation played only the single
-  newest unplayed episode per podcast (`PodcastViewModel.kt:470-499`, `maxByOrNull { pubDate }`). Also
-  fetched each feed sequentially. → spec behavior implemented, fetches parallelized (bounded).
+- **[RESOLVED] Play Queue: latest-episode-per-podcast is the intended behavior.** An earlier pass read
+  spec 004 literally ("all unplayed episodes, oldest→newest") and rewrote the builder from
+  `maxByOrNull { pubDate }` (single newest unplayed per podcast) to `sortedBy { pubDate }` over all
+  unplayed episodes. That made Play Queue start at the *oldest* episode of the first podcast, which users
+  reported as a bug. Product intent confirmed: each queued podcast contributes only its **single newest
+  unplayed** episode, in queue order. Reverted to `maxByOrNull` selection and **spec 004 §2.3/§4/§7 were
+  rewritten to match** so code and spec no longer disagree. Concurrent bounded feed fetches were kept.
 - **[FIXED] URL-download partial files leaked.** Workdir cleanup ran only on the success path
   (`UrlDownloadService.kt:169-171`); any failure/cancel left `url_downloads/<id>/` with `.part` files
   forever, and a leftover partial could even be picked up as the "produced file" on retry

--- a/docs/specs/004-podcast-queue-play.md
+++ b/docs/specs/004-podcast-queue-play.md
@@ -13,8 +13,13 @@ Last updated: 2026-01-31
 2. **Queue remains podcast-level** (Option A)
    - Queue is a manually ordered list of subscribed podcasts.
 3. **Play Queue behavior**
-   - “Play Queue” should play **all unplayed episodes** for each podcast **in the queue order**.
-   - Within a podcast, episodes are played in a consistent order (default: **oldest → newest** among unplayed episodes).
+   - “Play Queue” should play the **single latest (newest) unplayed episode** of each
+     podcast, **in the queue order** (podcast 1’s newest, then podcast 2’s newest, …).
+   - Rationale: the queue is a *podcast* list, not an episode backlog. Users tapping
+     “Play Queue” want the freshest episode from each show they follow — not to be
+     dropped at the oldest unheard episode of the first show. (An earlier revision
+     played *all* unplayed episodes oldest→newest; that started playback at the oldest
+     episode, which users reported as a bug. See docs/analysis-2026-07.md.)
 
 ## 3) UX changes
 ### 3.1 Home (Search screen)
@@ -28,9 +33,10 @@ Last updated: 2026-01-31
 ## 4) Playback implementation
 - Build a flattened episode list:
   1) Iterate podcasts in queue order
-  2) Fetch RSS episodes per podcast
+  2) Fetch RSS episodes per podcast (fetches run concurrently, bounded)
   3) Filter out completed episodes using `PlaybackProgressDao` (completed=true)
-  4) Append remaining episodes to a single list
+  4) Select the **newest remaining episode** (max by `pubDate`) for that podcast
+  5) Append that one episode to a single list (podcasts with no eligible episode are skipped)
 - Start playback using a Media3 playlist:
   - `MediaController.setMediaItems(mediaItems)`
   - `prepare()` then `play()`
@@ -38,7 +44,11 @@ Last updated: 2026-01-31
 ## 5) Data / filtering rules
 - “Unplayed” = no progress row, or `completed=false`.
 - Exclude episodes marked completed.
-- Partially played episodes are included.
+- Partially played episodes are eligible (a partially-played newest episode is still
+  the one selected).
+- “Newest” = max `Episode.pubDate`. Episodes with an unknown/unparseable pubDate rank
+  as oldest (never win “newest”); if *every* candidate lacks a pubDate, the first in
+  feed document order is used (feeds are conventionally newest-first).
 
 ## 6) Non-goals (for this spec)
 - Episode-level Up Next queue UI.
@@ -48,5 +58,6 @@ Last updated: 2026-01-31
 ## 7) Acceptance criteria
 - Home shows a Play Queue button when subscriptions exist.
 - Queue screen Play Queue starts audio playback.
-- Playback continues across multiple episodes (playlist) until exhausted.
-- Completed episodes are skipped.
+- The first track is the **newest unplayed** episode of the **first** queued podcast.
+- Playback continues across podcasts (one episode each, queue order) until exhausted.
+- Completed episodes are never selected; a podcast whose episodes are all completed is skipped.


### PR DESCRIPTION
## The bug
"Play Queue" starts playback at the **oldest** episode of the first queued podcast. Expected: each podcast in the queue contributes its **single latest (newest) unplayed** episode, in queue order.

## Real root cause (why the previous attempt didn't fix it)
This is the second attempt. PR #53 hardened RSS date parsing on the theory that unparseable dates caused wrong ordering — wrong root cause. The actual cause is a deliberate design inversion in the audit commit `98ff84a`:

- Original shipped behavior: single newest unplayed per podcast (`maxByOrNull { pubDate }`).
- `98ff84a` read `docs/specs/004` §2.3 literally ("all unplayed episodes … oldest → newest") and rewrote the builder to `.sortedBy { pubDate }` over **all** unplayed episodes. Playback starts at index 0 → oldest.
- #53 landed one commit later against a stale mental model (its message still describes the removed `maxByOrNull`).

So three sources disagreed: code + spec said "all, oldest-first"; the `RssParser` doc comment said "picks the latest." This PR realigns all of them to the intended behavior.

## Changes
**Behavior** — `PodcastViewModel`: replace `unplayedEpisodesForPodcast` (all episodes, oldest-first) with `latestUnplayedEpisodeForPodcast(): Episode?` using `maxByOrNull { it.pubDate?.time ?: Long.MIN_VALUE }`; the builder collects with `filterNotNull()`. `MIN_VALUE` sentinel means an undated episode never wins "newest"; when every candidate is undated it falls back to feed-first (feeds are conventionally newest-first). Nothing in the player path reorders (`PlayerViewModel.playEpisodesQueue` → `episodes.first()`; `PlayerController.prepareEpisodes` → `setMediaItems(items, 0, …)`), so this is the only behavioral change.

**Defensive** — `RssParser`: add no-seconds and no-timezone RFC-822 patterns so a parse failure on the genuine newest episode can't silently demote it below older parseable ones. Pattern order is load-bearing (`SimpleDateFormat` ignores trailing input) — zoned patterns first, no-timezone last. Verified on the JVM that a non-UTC offset (`-0500`) survives rather than being swallowed by the no-timezone pattern.

**Docs** — rewrote spec 004 §2.3/§4/§7 to make "latest unplayed per podcast" the definitive spec, and corrected the `analysis-2026-07.md` entry that had cited the `maxByOrNull` version as the bug. This stops the code and spec from disagreeing and prevents a third round-trip.

**Tests** — rewrote `PodcastViewModelTest` queue assertions for single-latest selection (completed-newest excluded; queue order preserved; undated-loses-to-dated; all-undated → feed-first). Added `RssParserTest` cases for the new formats plus an offset-survival regression guard.

## Test plan
- [ ] `./gradlew test --tests "*.PodcastViewModelTest" --tests "*.RssParserTest"` (CI runs `testDebugUnitTest` on push)
- [ ] Device: a queue with 2+ podcasts (ideally one newest-first feed, one oldest-first feed) → Play Queue → first track is each podcast's **newest unplayed** episode, in queue order; completed episodes skipped; a podcast with all-completed episodes is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_