### PR TITLE
fix: deleting downloads actually removes the media files from storage

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreScanner.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreScanner.kt
@@ -70,6 +70,14 @@ class MediaStoreScanner(private val context: Context) {
         return MediaStore.createDeleteRequest(context.contentResolver, uris)
     }
 
+    /**
+     * Best-effort direct delete of a single MediaStore entry by content URI. Returns
+     * true if the file was removed (the current install owns it), false if it needs
+     * user consent (non-owned) or the delete failed. Callers batch the `false` URIs
+     * into a single [createDeleteRequest] consent dialog.
+     */
+    fun deleteDirect(uriString: String): Boolean = MediaStoreSaver.deleteByUri(context, uriString)
+
     private fun scanCollection(isVideo: Boolean): List<FoundMedia> {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return emptyList()
 

--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -211,35 +211,49 @@ class DownloadManager(private val context: Context) {
      *  the domain [Episode] doesn't carry. */
     fun getAllDownloadedEntitiesFlow(): Flow<List<DownloadedEpisodeEntity>> = dao.getAllEpisodes()
 
-    suspend fun deleteEpisode(episodeId: String): Result<Unit> = withContext(Dispatchers.IO) {
+    /**
+     * Delete one downloaded episode (row + file). Returns the content URI that
+     * couldn't be deleted directly (a MediaStore entry owned by a previous install)
+     * and needs the system consent dialog — empty if fully handled.
+     */
+    suspend fun deleteEpisode(episodeId: String): List<String> = withContext(Dispatchers.IO) {
         try {
-            val episode = dao.getEpisodeById(episodeId)
-            if (episode != null) {
-                deleteLocalPayload(episode.localPath)
-                dao.deleteEpisodeById(episodeId)
-            }
-            Result.success(Unit)
+            val episode = dao.getEpisodeById(episodeId) ?: return@withContext emptyList()
+            val consent = deleteLocalPayload(episode.localPath)
+            dao.deleteEpisodeById(episodeId)
+            listOfNotNull(consent)
         } catch (e: Exception) {
-            Result.failure(e)
+            emptyList()
         }
     }
 
-    suspend fun deleteAllDownloads(): Result<Unit> = withContext(Dispatchers.IO) {
+    /** Same as [deleteEpisode] but for every RSS download; returns all consent-needed URIs. */
+    suspend fun deleteAllDownloads(): List<String> = withContext(Dispatchers.IO) {
         try {
             val episodes = dao.getAllEpisodes().first()
-            episodes.forEach { episode -> deleteLocalPayload(episode.localPath) }
+            val consent = episodes.mapNotNull { deleteLocalPayload(it.localPath) }
             dao.deleteAll()
-            Result.success(Unit)
+            consent
         } catch (e: Exception) {
-            Result.failure(e)
+            emptyList()
         }
     }
 
-    /** Delete either a MediaStore content row or a local file, depending on the path scheme. */
-    private fun deleteLocalPayload(localPath: String) {
-        if (MediaStoreSaver.deleteByUri(context, localPath)) return
+    /**
+     * Delete the on-disk payload for [localPath]. For a `content://` MediaStore entry
+     * we try a direct delete; if that fails (the file is owned by a previous install),
+     * the URI is RETURNED so the caller can route it through the system consent dialog
+     * — we must NOT fall back to `File(contentUri).delete()`, which silently no-ops on
+     * a content URI and was why deletes left files on disk. Returns null when the file
+     * was removed (or was a plain file path handled here).
+     */
+    private fun deleteLocalPayload(localPath: String): String? {
+        if (localPath.startsWith("content://")) {
+            return if (MediaStoreSaver.deleteByUri(context, localPath)) null else localPath
+        }
         val file = File(localPath)
         if (file.exists()) file.delete()
+        return null
     }
 
     suspend fun getDownloadedEpisode(episodeId: String): DownloadedEpisodeEntity? {

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -16,6 +16,7 @@ import com.yausername.youtubedl_android.YoutubeDLRequest
 import com.yausername.youtubedl_android.mapper.VideoInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -251,20 +252,46 @@ class UrlDownloadRepository(private val context: Context) {
     }
 
     /** Delete the row + the underlying file (if any). */
-    suspend fun delete(id: String): Result<Unit> = withContext(Dispatchers.IO) {
+    /**
+     * Delete one URL download (row + file). Returns the content URI that couldn't be
+     * deleted directly (a MediaStore entry owned by a previous install) and needs the
+     * system consent dialog — empty if fully handled.
+     */
+    suspend fun delete(id: String): List<String> = withContext(Dispatchers.IO) {
         try {
             val entity = dao.getById(id)
-            entity?.localPath?.let { path ->
-                if (!MediaStoreSaver.deleteByUri(context, path)) {
-                    val file = File(path)
-                    if (file.exists()) file.delete()
-                }
-            }
+            val consent = entity?.localPath?.let { deleteLocalPayload(it) }
             dao.deleteById(id)
-            Result.success(Unit)
+            listOfNotNull(consent)
         } catch (e: Throwable) {
-            Result.failure(e)
+            emptyList()
         }
+    }
+
+    /** Delete every URL download (rows + files); returns all consent-needed URIs. */
+    suspend fun deleteAllReturningConsent(): List<String> = withContext(Dispatchers.IO) {
+        try {
+            val all = dao.observeAll().first()
+            val consent = all.mapNotNull { it.localPath?.let(::deleteLocalPayload) }
+            dao.deleteAll()
+            consent
+        } catch (e: Throwable) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Delete the on-disk payload for [path]. Returns the content URI (needs consent)
+     * when a non-owned MediaStore entry can't be deleted directly; null otherwise.
+     * See [DownloadManager.deleteLocalPayload] for why we don't `File.delete` a URI.
+     */
+    private fun deleteLocalPayload(path: String): String? {
+        if (path.startsWith("content://")) {
+            return if (MediaStoreSaver.deleteByUri(context, path)) null else path
+        }
+        val file = File(path)
+        if (file.exists()) file.delete()
+        return null
     }
 
     /**

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -483,16 +483,33 @@ fun PodcastNavHost(
                     var maintenanceMessage by remember { mutableStateOf<String?>(null) }
                     var pendingDeleteCount by remember { mutableStateOf(0) }
 
-                    // Receives the outcome of the system batch-delete consent dialog.
+                    // Receives the outcome of the system batch-delete consent dialog
+                    // (used by single delete, remove-all, and duplicate cleanup).
                     val deleteLauncher = rememberLauncherForActivityResult(
                         ActivityResultContracts.StartIntentSenderForResult()
                     ) { result ->
                         maintenanceMessage = if (result.resultCode == android.app.Activity.RESULT_OK) {
-                            "Removed $pendingDeleteCount duplicate file" +
-                                (if (pendingDeleteCount == 1) "." else "s.")
+                            "Removed $pendingDeleteCount file" + (if (pendingDeleteCount == 1) "." else "s.")
                         } else {
-                            "Cleanup canceled."
+                            "Canceled — those files were kept."
                         }
+                    }
+
+                    // Route content URIs that couldn't be deleted directly (owned by a
+                    // previous install) through the system consent dialog. Returns whether
+                    // a dialog was shown.
+                    fun requestConsentDelete(uris: List<String>): Boolean {
+                        if (uris.isEmpty()) return false
+                        val request = mediaScanner.createDeleteRequest(uris.map(Uri::parse))
+                        if (request == null) {
+                            maintenanceMessage = "Deleting files from a previous install needs Android 11 or newer."
+                            return false
+                        }
+                        pendingDeleteCount = uris.size
+                        deleteLauncher.launch(
+                            androidx.activity.result.IntentSenderRequest.Builder(request.intentSender).build()
+                        )
+                        return true
                     }
 
                     fun startCleanup() {
@@ -502,31 +519,49 @@ fun PodcastNavHost(
                                 maintenanceMessage = "No duplicate files found."
                                 return@launch
                             }
-                            val request = mediaScanner.createDeleteRequest(uris.map(Uri::parse))
-                            if (request == null) {
-                                maintenanceMessage = "Duplicate cleanup needs Android 11 or newer."
-                                return@launch
-                            }
-                            pendingDeleteCount = uris.size
-                            deleteLauncher.launch(
-                                androidx.activity.result.IntentSenderRequest.Builder(request.intentSender).build()
-                            )
+                            requestConsentDelete(uris)
                         }
                     }
 
                     // Restore/cleanup both need the media read permission to see files a
                     // previous install owned; route the intended action through the grant.
+                    // Remove-all sets [proceedOnDeny] so it still clears owned + tracked
+                    // downloads even if access is declined (only the dupe/orphan sweep needs it).
                     var pendingMediaAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+                    var pendingMediaActionProceedsOnDeny by remember { mutableStateOf(false) }
                     val permissionLauncher = rememberLauncherForActivityResult(
                         ActivityResultContracts.RequestMultiplePermissions()
                     ) { grants ->
                         val action = pendingMediaAction
+                        val proceedAnyway = pendingMediaActionProceedsOnDeny
                         pendingMediaAction = null
-                        if (grants.values.any { it }) {
+                        pendingMediaActionProceedsOnDeny = false
+                        if (grants.values.any { it } || proceedAnyway) {
                             action?.invoke()
                         } else {
                             maintenanceMessage =
                                 "Media access is needed to find files from a previous install."
+                        }
+                    }
+
+                    fun removeAllDownloads() {
+                        val run: () -> Unit = {
+                            scope.launch {
+                                val consent = podcastViewModel.deleteAllDownloads()
+                                if (!requestConsentDelete(consent)) {
+                                    maintenanceMessage = "All downloads removed."
+                                }
+                            }
+                            Unit
+                        }
+                        // Owned + tracked files are removed regardless; access just lets the
+                        // sweep also catch prior-install duplicates/orphans, so proceed on deny.
+                        if (podcastViewModel.hasMediaReadPermission()) {
+                            run()
+                        } else {
+                            pendingMediaAction = run
+                            pendingMediaActionProceedsOnDeny = true
+                            permissionLauncher.launch(podcastViewModel.mediaReadPermissions())
                         }
                     }
 
@@ -597,25 +632,22 @@ fun PodcastNavHost(
                         },
                         onDelete = { entry ->
                             scope.launch {
-                                when (entry.kind) {
+                                // Row + owned file are removed immediately; a file owned by a
+                                // previous install comes back as a consent URI → system dialog.
+                                val consent = when (entry.kind) {
                                     DownloadEntryUi.Kind.PODCAST ->
                                         podcastViewModel.deleteDownload(entry.episode.id)
                                     DownloadEntryUi.Kind.URL_AUDIO,
-                                    DownloadEntryUi.Kind.URL_VIDEO -> {
+                                    DownloadEntryUi.Kind.URL_VIDEO ->
                                         // entry.id format: "url:<entity-id>"
-                                        urlDownloadViewModel.deleteDownload(entry.id.removePrefix("url:"))
-                                    }
+                                        podcastViewModel.deleteUrlDownload(entry.id.removePrefix("url:"))
                                 }
+                                requestConsentDelete(consent)
                             }
                         },
                         onRetryUrlDownload = { id -> urlDownloadViewModel.retryDownload(id) },
                         onDeleteUrlDownload = { id -> urlDownloadViewModel.deleteDownload(id) },
-                        onDeleteAll = {
-                            scope.launch {
-                                podcastViewModel.deleteAllDownloads()
-                                urlDownloads.forEach { urlDownloadViewModel.deleteDownload(it.id) }
-                            }
-                        },
+                        onDeleteAll = { removeAllDownloads() },
                         restoreState = restoreState,
                         maintenanceMessage = maintenanceMessage,
                         onRestoreDownloads = {

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -292,11 +292,20 @@ class PodcastViewModel(
         _downloadError.value = null
     }
 
-    suspend fun deleteDownload(episodeId: String): Result<Unit> {
-        val result = downloadManager.deleteEpisode(episodeId)
+    /**
+     * Delete one RSS podcast download. Returns content URIs whose files couldn't be
+     * removed directly (owned by a previous install) and need the system consent
+     * dialog — the UI batches them into [MediaStoreScanner.createDeleteRequest].
+     */
+    suspend fun deleteDownload(episodeId: String): List<String> {
+        val consent = downloadManager.deleteEpisode(episodeId)
         refreshEpisodesWithDownloads()
-        return result
+        return consent
     }
+
+    /** Delete one URL (YouTube/X) download; returns consent-needed URIs (see [deleteDownload]). */
+    suspend fun deleteUrlDownload(urlId: String): List<String> =
+        urlDownloadRepository?.delete(urlId).orEmpty()
 
     private val _restoreState = MutableStateFlow<RestoreDownloadsState>(RestoreDownloadsState.Idle)
     val restoreState: StateFlow<RestoreDownloadsState> = _restoreState.asStateFlow()
@@ -587,8 +596,30 @@ class PodcastViewModel(
         return queueStorage.getQueuesForPodcast(podcastId)
     }
 
-    suspend fun deleteAllDownloads(): Result<Unit> {
-        return downloadManager.deleteAllDownloads()
+    /**
+     * Remove ALL downloads and their files from the device — RSS + URL rows, and every
+     * file in the Vibe MediaStore folders, INCLUDING orphans and the duplicate "(1)"
+     * copies left by re-downloads across reinstalls. Owned files are deleted directly;
+     * the returned list is the content URIs (non-owned / dupes / orphans) that need the
+     * system consent dialog. The folder sweep needs the media read permission, so the
+     * UI gates this behind [hasMediaReadPermission].
+     */
+    suspend fun deleteAllDownloads(): List<String> = withContext(Dispatchers.IO) {
+        val consent = mutableListOf<String>()
+        consent += downloadManager.deleteAllDownloads()
+        consent += urlDownloadRepository?.deleteAllReturningConsent().orEmpty()
+
+        // Sweep anything still sitting in the Vibe folders that our DB rows didn't cover:
+        // duplicate copies from prior reinstalls, and orphans. Direct-delete what we own;
+        // hand the rest to the caller for the consent dialog.
+        val scanner = mediaScanner
+        if (scanner != null) {
+            scanner.scanAll().forEach { found ->
+                if (!scanner.deleteDirect(found.uriString)) consent += found.uriString
+            }
+        }
+        refreshEpisodesWithDownloads()
+        consent.distinct()
     }
 
     suspend fun exportOpml(outputStream: OutputStream) {


### PR DESCRIPTION
## The bug
Deleting a download (single item **or** "Remove all") removed it from the app's list but left the actual audio/video file on the phone. "Remove all" also never touched the duplicate copies left behind by re-downloads across reinstalls.

## Root cause
Downloads live in shared MediaStore folders (`Podcasts/VibePodcast`, `Movies/VibePodcast`). `MediaStoreSaver.deleteByUri` calls `contentResolver.delete()`, which **silently fails for a file owned by a *previous* install** — scoped storage forbids deleting another owner's entry without user consent. This is exactly the restore/reinstall flow. The repos then fell back to `File(localPath).delete()`, but `localPath` is a `content://` URI, so `File("content://…").delete()` is a **guaranteed no-op**. Net: DB row gone, file stays on disk.

## Fix
Route non-owned deletions through the **system delete-consent dialog** (`MediaStore.createDeleteRequest` — the same mechanism the duplicate cleaner already used):

- **`DownloadManager` / `UrlDownloadRepository`**: `deleteLocalPayload` now **returns the content URI** when a direct delete fails (non-owned), instead of no-op'ing `File.delete` on a URI. `deleteEpisode` / `delete` / the new `deleteAllReturningConsent` return the list of consent-needed URIs; plain file paths (pre-Q) still delete in place.
- **`MediaStoreScanner.deleteDirect`**: direct-delete-by-URI helper used by the sweep.
- **`PodcastViewModel.deleteAllDownloads`**: clears RSS + URL rows, direct-deletes owned files, then **sweeps both Vibe folders and batches every remaining file — orphans and the `(1)` duplicate copies from prior reinstalls — for deletion**. `deleteDownload` / `deleteUrlDownload` return consent URIs too.
- **Downloads screen (`PodcastNavHost`)**: single delete and Remove all feed any consent URIs into the batched system consent dialog. Remove all requests the media read permission so the sweep can see prior-install duplicates, but **proceeds even if declined** (owned + tracked files are still removed; only the dupe sweep needs access). Owned same-install files still delete silently — no dialog.

## Behavior summary
| Case | Before | After |
|---|---|---|
| Delete own-install download | row gone, file **stayed** on some devices | file deleted silently |
| Delete restored (prior-install) download | row gone, file **stayed** | system consent dialog → file deleted |
| Remove all | rows gone, files stayed, dupes untouched | owned deleted; non-owned + **dupes/orphans** batched into one consent dialog |

## Not unit-tested
The delete path is entirely `ContentResolver`/MediaStore/permission-bound and this project has no Robolectric/instrumented harness (same as PR #54's restore code — only the pure `MediaNaming` was testable). Verified by code trace; manual steps below.

## Test plan
- [ ] Download an episode this install → delete it → confirm the file is gone from `Podcasts/VibePodcast` in Files/VLC (no dialog).
- [ ] Reinstall + restore, then delete a restored download → system consent dialog appears → file removed.
- [ ] Create duplicates (download, reinstall, re-download) → "Remove all" → grant media access → consent dialog lists the dupes → all Vibe files gone afterward.
- [ ] Deny media access on "Remove all" → owned/tracked downloads still cleared; message explains dupes need access.
- [ ] `./gradlew test` still green (no test changes; existing suites unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_