### PR TITLE
feat: Remove all can keep media files on phone so Restore still works

### DIFF
--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -227,6 +227,15 @@ class DownloadManager(private val context: Context) {
         }
     }
 
+    /**
+     * Forget every RSS download WITHOUT touching the media files. The files stay in
+     * the shared Vibe folders, where the restore flow (and just-in-time download
+     * reuse) can relink them later with zero network traffic.
+     */
+    suspend fun clearAllRowsKeepingFiles(): Unit = withContext(Dispatchers.IO) {
+        dao.deleteAll()
+    }
+
     /** Same as [deleteEpisode] but for every RSS download; returns all consent-needed URIs. */
     suspend fun deleteAllDownloads(): List<String> = withContext(Dispatchers.IO) {
         try {

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -268,6 +268,14 @@ class UrlDownloadRepository(private val context: Context) {
         }
     }
 
+    /**
+     * Forget every URL download WITHOUT touching the media files — counterpart of
+     * [DownloadManager.clearAllRowsKeepingFiles] for the keep-files "Remove all".
+     */
+    suspend fun clearAllRowsKeepingFiles(): Unit = withContext(Dispatchers.IO) {
+        dao.deleteAll()
+    }
+
     /** Delete every URL download (rows + files); returns all consent-needed URIs. */
     suspend fun deleteAllReturningConsent(): List<String> = withContext(Dispatchers.IO) {
         try {

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.outlined.Podcasts
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -107,7 +108,13 @@ fun DownloadsScreen(
     onDelete: (DownloadEntryUi) -> Unit,
     onRetryUrlDownload: (String) -> Unit = {},
     onDeleteUrlDownload: (String) -> Unit = {},
-    onDeleteAll: () -> Unit,
+    /**
+     * Remove every download from the app's list. [deleteFiles] = true also deletes
+     * the media files from the phone (including prior-install duplicates); false
+     * keeps the files on disk so "Restore previous downloads" can relink them later
+     * without any re-downloading.
+     */
+    onDeleteAll: (deleteFiles: Boolean) -> Unit,
     onRestoreDownloads: () -> Unit = {},
     onCleanupDuplicates: () -> Unit = {},
     onDismissRestoreResult: () -> Unit = {},
@@ -273,16 +280,51 @@ fun DownloadsScreen(
     }
 
     if (showDeleteAllDialog) {
+        // remember{} inside the conditional resets the checkbox to the safe default
+        // (really delete) every time the dialog is opened.
+        var deleteFilesToo by remember { mutableStateOf(true) }
         AlertDialog(
             onDismissRequest = { showDeleteAllDialog = false },
             title = { Text("Remove all downloads") },
-            text = { Text("This will delete every downloaded file from this device.") },
+            text = {
+                Column {
+                    Text(
+                        if (deleteFilesToo) {
+                            "Every download is removed from the list and its media file is " +
+                                "deleted from this phone, including leftover duplicates."
+                        } else {
+                            "Downloads are removed from the list, but the media files stay " +
+                                "on this phone — use \"Restore previous downloads\" to bring " +
+                                "them back later without re-downloading."
+                        }
+                    )
+                    Spacer(Modifier.height(10.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { deleteFilesToo = !deleteFilesToo },
+                    ) {
+                        Checkbox(
+                            checked = deleteFilesToo,
+                            onCheckedChange = { deleteFilesToo = it },
+                        )
+                        Text(
+                            text = "Also delete media files from phone",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            },
             confirmButton = {
                 TextButton(onClick = {
-                    onDeleteAll()
+                    onDeleteAll(deleteFilesToo)
                     showDeleteAllDialog = false
                 }) {
-                    Text("Remove all", fontWeight = FontWeight.SemiBold)
+                    Text(
+                        if (deleteFilesToo) "Remove all" else "Remove, keep files",
+                        fontWeight = FontWeight.SemiBold,
+                    )
                 }
             },
             dismissButton = {
@@ -492,7 +534,7 @@ private fun RestoreDownloadsCard(
             Column(modifier = Modifier.weight(1f)) {
                 val (title, subtitle) = when (state) {
                     is RestoreDownloadsState.Idle ->
-                        "Reinstalled the app?" to
+                        "Reinstalled or cleared your list?" to
                             "Relink downloads already on this device instead of re-downloading them."
                     is RestoreDownloadsState.Running ->
                         "Restoring downloads…" to

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -523,10 +523,10 @@ fun PodcastNavHost(
                         }
                     }
 
-                    // Restore/cleanup both need the media read permission to see files a
-                    // previous install owned; route the intended action through the grant.
-                    // Remove-all sets [proceedOnDeny] so it still clears owned + tracked
-                    // downloads even if access is declined (only the dupe/orphan sweep needs it).
+                    // Media read permission widens restore/remove-all/cleanup to files a
+                    // previous install owned. Actions that also work on this install's own
+                    // files set [pendingMediaActionProceedsOnDeny] so declining the prompt
+                    // degrades gracefully instead of blocking them.
                     var pendingMediaAction by remember { mutableStateOf<(() -> Unit)?>(null) }
                     var pendingMediaActionProceedsOnDeny by remember { mutableStateOf(false) }
                     val permissionLauncher = rememberLauncherForActivityResult(
@@ -544,27 +544,33 @@ fun PodcastNavHost(
                         }
                     }
 
+                    // Offer the media-access prompt but run [action] even when access is
+                    // declined: restore and remove-all both work on this install's OWN
+                    // files without any permission — access only widens them to files a
+                    // previous install left behind (prior-install episodes / duplicates).
+                    fun runWithOptionalMediaAccess(action: () -> Unit) {
+                        if (podcastViewModel.hasMediaReadPermission()) {
+                            action()
+                        } else {
+                            pendingMediaAction = action
+                            pendingMediaActionProceedsOnDeny = true
+                            permissionLauncher.launch(podcastViewModel.mediaReadPermissions())
+                        }
+                    }
+
                     fun removeAllDownloads() {
-                        val run: () -> Unit = {
+                        runWithOptionalMediaAccess {
                             scope.launch {
                                 val consent = podcastViewModel.deleteAllDownloads()
                                 if (!requestConsentDelete(consent)) {
                                     maintenanceMessage = "All downloads removed."
                                 }
                             }
-                            Unit
-                        }
-                        // Owned + tracked files are removed regardless; access just lets the
-                        // sweep also catch prior-install duplicates/orphans, so proceed on deny.
-                        if (podcastViewModel.hasMediaReadPermission()) {
-                            run()
-                        } else {
-                            pendingMediaAction = run
-                            pendingMediaActionProceedsOnDeny = true
-                            permissionLauncher.launch(podcastViewModel.mediaReadPermissions())
                         }
                     }
 
+                    // Strict variant: the action is pointless without access (duplicate
+                    // cleanup must SEE non-owned files to delete them), so deny = stop.
                     fun withMediaPermission(action: () -> Unit) {
                         if (podcastViewModel.hasMediaReadPermission()) {
                             action()
@@ -647,11 +653,25 @@ fun PodcastNavHost(
                         },
                         onRetryUrlDownload = { id -> urlDownloadViewModel.retryDownload(id) },
                         onDeleteUrlDownload = { id -> urlDownloadViewModel.deleteDownload(id) },
-                        onDeleteAll = { removeAllDownloads() },
+                        onDeleteAll = { deleteFiles ->
+                            if (deleteFiles) {
+                                removeAllDownloads()
+                            } else {
+                                // Keep-files variant: clear the list only; the media stays on
+                                // the phone for Restore / instant re-download reuse.
+                                scope.launch {
+                                    podcastViewModel.removeAllDownloadsKeepingFiles()
+                                    maintenanceMessage = "List cleared — media files kept on this " +
+                                        "phone. Use \"Restore previous downloads\" to bring them back."
+                                }
+                            }
+                        },
                         restoreState = restoreState,
                         maintenanceMessage = maintenanceMessage,
                         onRestoreDownloads = {
-                            withMediaPermission { podcastViewModel.restorePreviousDownloads() }
+                            // Optional access: files kept via "Remove all → keep files" are
+                            // owned by this install and restore without any permission.
+                            runWithOptionalMediaAccess { podcastViewModel.restorePreviousDownloads() }
                         },
                         onCleanupDuplicates = { withMediaPermission { startCleanup() } },
                         onDismissRestoreResult = { podcastViewModel.dismissRestoreResult() },

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -597,6 +597,19 @@ class PodcastViewModel(
     }
 
     /**
+     * Remove every download from the app's list but KEEP the media files on the
+     * phone. The Downloads list empties, while the files stay in the shared Vibe
+     * folders where "Restore previous downloads" (or a tap on any episode's
+     * download button, via just-in-time reuse) relinks them without re-downloading
+     * — the network-saving workflow for clearing the list without losing episodes.
+     */
+    suspend fun removeAllDownloadsKeepingFiles(): Unit = withContext(Dispatchers.IO) {
+        downloadManager.clearAllRowsKeepingFiles()
+        urlDownloadRepository?.clearAllRowsKeepingFiles()
+        refreshEpisodesWithDownloads()
+    }
+
+    /**
      * Remove ALL downloads and their files from the device — RSS + URL rows, and every
      * file in the Vibe MediaStore folders, INCLUDING orphans and the duplicate "(1)"
      * copies left by re-downloads across reinstalls. Owned files are deleted directly;


### PR DESCRIPTION
## Deep analysis — what actually happened to "Restore previous downloads"

The restore feature was **not removed**: the code and both UI entry points (the empty-state card and the ⋯ → "Restore previous downloads" menu item) are intact on main, byte-identical since PR #54. What #56 changed is its *source material*: "Remove all" now sweeps **every** file out of the Vibe folders — tracked downloads, orphans, and duplicates — exactly as the delete-bug report demanded. One tap destroys the entire on-phone corpus that Restore (and the just-in-time download reuse) relink from. Afterwards Restore truthfully reports "Nothing to restore," and every episode costs network again — which reads as "the feature is gone."

The two requirements collide only at Remove-all's implicit default:
- *"Deletes must really delete"* (#56 — kept, still the default)
- *"Keep good episodes on the phone; restore them without re-downloading"* (#54's workflow)

## Fix — make the choice explicit

**Remove-all dialog gets a checkbox: "Also delete media files from phone"** — checked by default (preserving #56 semantics, including the duplicate sweep). Unchecking it switches to a rows-only clear:

- The Downloads list empties; media files stay in `Podcasts/VibePodcast` / `Movies/VibePodcast`
- The "Reinstalled or cleared your list?" restore card appears on the now-empty screen; one tap relinks everything from disk with **zero network traffic**
- Re-downloading any single episode also relinks instantly via the existing JIT reuse path
- A status message after clearing points at Restore, so the loop is discoverable

**Plumbing**: `DownloadManager.clearAllRowsKeepingFiles()` + `UrlDownloadRepository.clearAllRowsKeepingFiles()` (rows only, no payload deletion), orchestrated by `PodcastViewModel.removeAllDownloadsKeepingFiles()`; `DownloadsScreen.onDeleteAll` becomes `(deleteFiles: Boolean) -> Unit`.

**Bonus fix surfaced by the analysis**: Restore was hard-gated behind the media read permission, but files kept via this flow are owned by the current install and restore fine without it. `onRestoreDownloads` now offers the permission prompt and **proceeds on deny** (shared `runWithOptionalMediaAccess` helper — the same policy Remove-all already had). Duplicate cleanup stays strict, since it's genuinely useless without access.

## Test plan
- [ ] Downloads → Remove all with checkbox **checked** (default) → list clears AND files gone from the phone (dupes included) — #56 behavior unchanged
- [ ] Remove all with checkbox **unchecked** → list clears, files remain in Files/VLC → restore card shows → Restore relinks all episodes/clips with no network traffic (airplane mode works)
- [ ] Restore with media permission **denied** → still relinks files kept by this install
- [ ] Fresh-install restore (prior-install files) still prompts for permission and works when granted
- [ ] `./gradlew test` green (no behavior change to tested pure functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1DongTr1aeBLcMC3BCdzn)_