### PR TITLE
Reliable download restore, cleanup, and retention

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,12 @@ android {
     }
 }
 
+kapt {
+    arguments {
+        arg("room.schemaLocation", "$projectDir/schemas")
+    }
+}
+
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
@@ -119,6 +125,9 @@ dependencies {
     // mockable android.jar stubs XmlPullParserFactory, so RssParserTest injects
     // a KXmlParser directly.
     testImplementation("net.sf.kxml:kxml2:2.3.0")
+
+    androidTestImplementation("androidx.test:core:1.5.0")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/schemas/com.podcastplayer.app.data.local.PodcastDatabase/4.json
+++ b/app/schemas/com.podcastplayer.app.data.local.PodcastDatabase/4.json
@@ -1,0 +1,272 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f23b2c6908eed828622436b9812f9f6c",
+    "entities": [
+      {
+        "tableName": "downloaded_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `podcastId` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT, `pubDate` INTEGER, `audioUrl` TEXT NOT NULL, `duration` INTEGER, `localPath` TEXT NOT NULL, `fileSize` INTEGER NOT NULL, `downloadDate` INTEGER NOT NULL, `origin` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcastId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pubDate",
+            "columnName": "pubDate",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "audioUrl",
+            "columnName": "audioUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadDate",
+            "columnName": "downloadDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "origin",
+            "columnName": "origin",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "playback_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeId` TEXT NOT NULL, `podcastId` TEXT NOT NULL, `positionMs` INTEGER NOT NULL, `durationMs` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `lastPlayedAtMs` INTEGER NOT NULL, `updatedAtMs` INTEGER NOT NULL, PRIMARY KEY(`episodeId`))",
+        "fields": [
+          {
+            "fieldPath": "episodeId",
+            "columnName": "episodeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcastId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAtMs",
+            "columnName": "lastPlayedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAtMs",
+            "columnName": "updatedAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "url_downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `title` TEXT NOT NULL, `uploader` TEXT, `thumbnailUrl` TEXT, `mediaType` TEXT NOT NULL, `localPath` TEXT, `durationMs` INTEGER, `fileSize` INTEGER, `status` TEXT NOT NULL, `progressPercent` REAL NOT NULL, `errorMessage` TEXT, `createdAtMs` INTEGER NOT NULL, `completedAtMs` INTEGER, `origin` TEXT NOT NULL, `podcastId` TEXT, `episodePubDateMs` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressPercent",
+            "columnName": "progressPercent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "createdAtMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAtMs",
+            "columnName": "completedAtMs",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "origin",
+            "columnName": "origin",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcastId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "episodePubDateMs",
+            "columnName": "episodePubDateMs",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f23b2c6908eed828622436b9812f9f6c')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/podcastplayer/app/data/local/PodcastDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/podcastplayer/app/data/local/PodcastDatabaseMigrationTest.kt
@@ -1,0 +1,98 @@
+package com.podcastplayer.app.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlinx.coroutines.runBlocking
+
+@RunWith(AndroidJUnit4::class)
+class PodcastDatabaseMigrationTest {
+    private val databaseName = "migration-test"
+
+    @Test
+    fun migration3To4PinsExistingRowsAndLeavesUrlEpisodeMetadataNullable() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.deleteDatabase(databaseName)
+        context.openOrCreateDatabase(databaseName, Context.MODE_PRIVATE, null).apply {
+            execSQL(
+                """
+                CREATE TABLE downloaded_episodes (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    podcastId TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    pubDate INTEGER,
+                    audioUrl TEXT NOT NULL,
+                    duration INTEGER,
+                    localPath TEXT NOT NULL,
+                    fileSize INTEGER NOT NULL,
+                    downloadDate INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            execSQL(
+                """
+                CREATE TABLE playback_progress (
+                    episodeId TEXT NOT NULL PRIMARY KEY,
+                    podcastId TEXT NOT NULL,
+                    positionMs INTEGER NOT NULL,
+                    durationMs INTEGER NOT NULL,
+                    completed INTEGER NOT NULL,
+                    lastPlayedAtMs INTEGER NOT NULL,
+                    updatedAtMs INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            execSQL(
+                """
+                CREATE TABLE url_downloads (
+                    id TEXT NOT NULL PRIMARY KEY,
+                    sourceUrl TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    uploader TEXT,
+                    thumbnailUrl TEXT,
+                    mediaType TEXT NOT NULL,
+                    localPath TEXT,
+                    durationMs INTEGER,
+                    fileSize INTEGER,
+                    status TEXT NOT NULL,
+                    progressPercent REAL NOT NULL,
+                    errorMessage TEXT,
+                    createdAtMs INTEGER NOT NULL,
+                    completedAtMs INTEGER
+                )
+                """.trimIndent()
+            )
+            execSQL(
+                "INSERT INTO downloaded_episodes VALUES " +
+                    "('episode','podcast','Title',NULL,NULL,'https://audio',NULL,'path',10,20)"
+            )
+            execSQL(
+                "INSERT INTO url_downloads VALUES " +
+                    "('url','https://video','youtube','Title',NULL,NULL,'audio','path',NULL,10," +
+                    "'COMPLETED',100,NULL,20,30)"
+            )
+            version = 3
+            close()
+        }
+
+        val database = Room.databaseBuilder(context, PodcastDatabase::class.java, databaseName)
+            .addMigrations(PodcastDatabase.MIGRATION_3_4)
+            .build()
+
+        val rss = database.downloadedEpisodeDao().getEpisodeById("episode")!!
+        val url = database.urlDownloadDao().getById("url")!!
+        assertEquals(DownloadOrigin.MANUAL.name, rss.origin)
+        assertEquals(DownloadOrigin.MANUAL.name, url.origin)
+        assertNull(url.podcastId)
+        assertNull(url.episodePubDateMs)
+        database.close()
+        Unit
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/AppSettings.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/AppSettings.kt
@@ -30,6 +30,9 @@ class AppSettings private constructor(context: Context) {
     private val _autoDownloadOnCellular = MutableStateFlow(loadAutoDlCellular())
     val autoDownloadOnCellular: StateFlow<Boolean> = _autoDownloadOnCellular.asStateFlow()
 
+    private val _autoDownloadRetentionLimit = MutableStateFlow(loadAutoDownloadRetentionLimit())
+    val autoDownloadRetentionLimit: StateFlow<Int> = _autoDownloadRetentionLimit.asStateFlow()
+
     fun setThemeMode(mode: ThemeMode) {
         prefs.edit { putString(KEY_THEME, mode.name) }
         _themeMode.value = mode
@@ -46,6 +49,12 @@ class AppSettings private constructor(context: Context) {
         _autoDownloadOnCellular.value = enabled
     }
 
+    fun setAutoDownloadRetentionLimit(limit: Int) {
+        val accepted = limit.takeIf { it in AUTO_DOWNLOAD_RETENTION_LIMITS } ?: DEFAULT_RETENTION_LIMIT
+        prefs.edit { putInt(KEY_AUTODL_RETENTION, accepted) }
+        _autoDownloadRetentionLimit.value = accepted
+    }
+
     private fun loadTheme(): ThemeMode {
         val raw = prefs.getString(KEY_THEME, null) ?: return ThemeMode.SYSTEM
         return runCatching { ThemeMode.valueOf(raw) }.getOrDefault(ThemeMode.SYSTEM)
@@ -55,15 +64,24 @@ class AppSettings private constructor(context: Context) {
 
     private fun loadAutoDlCellular(): Boolean = prefs.getBoolean(KEY_AUTODL_CELL, false)
 
+    private fun loadAutoDownloadRetentionLimit(): Int {
+        val value = prefs.getInt(KEY_AUTODL_RETENTION, DEFAULT_RETENTION_LIMIT)
+        return value.takeIf { it in AUTO_DOWNLOAD_RETENTION_LIMITS } ?: DEFAULT_RETENTION_LIMIT
+    }
+
     companion object {
         const val MIN_SPEED = 0.5f
         const val MAX_SPEED = 3.0f
         val PLAYBACK_SPEEDS = floatArrayOf(0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+        const val UNLIMITED_RETENTION = -1
+        const val DEFAULT_RETENTION_LIMIT = 3
+        val AUTO_DOWNLOAD_RETENTION_LIMITS = intArrayOf(1, 3, 5, 10, UNLIMITED_RETENTION)
 
         private const val PREFS_NAME = "app_settings"
         private const val KEY_THEME = "theme_mode"
         private const val KEY_SPEED = "default_playback_speed"
         private const val KEY_AUTODL_CELL = "autodownload_cellular"
+        private const val KEY_AUTODL_RETENTION = "autodownload_retention_limit"
 
         @Volatile
         private var instance: AppSettings? = null

--- a/app/src/main/java/com/podcastplayer/app/data/local/DatabaseProvider.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DatabaseProvider.kt
@@ -19,6 +19,7 @@ object DatabaseProvider {
                 .addMigrations(
                     PodcastDatabase.MIGRATION_1_2,
                     PodcastDatabase.MIGRATION_2_3,
+                    PodcastDatabase.MIGRATION_3_4,
                 )
                 .build()
                 .also { instance = it }

--- a/app/src/main/java/com/podcastplayer/app/data/local/DownloadOrigin.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DownloadOrigin.kt
@@ -1,0 +1,7 @@
+package com.podcastplayer.app.data.local
+
+/** Whether a download is pinned by the user or managed by auto-download retention. */
+enum class DownloadOrigin {
+    MANUAL,
+    AUTO,
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/DownloadPlanners.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DownloadPlanners.kt
@@ -1,0 +1,219 @@
+package com.podcastplayer.app.data.local
+
+/** JVM-safe representation of a scanned shared-media item. */
+data class MediaFileCandidate(
+    val uriString: String,
+    val displayName: String,
+    val sizeBytes: Long,
+    val dateAddedSec: Long,
+    val isVideo: Boolean,
+    val identity: MediaIdentity? = MediaIdentity.parse(displayName),
+    val sha256: String? = null,
+    val isProtected: Boolean = false,
+)
+
+data class RestoreEpisodeCandidate(
+    val episodeId: String,
+    val identity: MediaIdentity,
+    val legacyMatchKey: String,
+)
+
+data class LegacyRestoreSuggestion(
+    val episodeId: String,
+    val file: MediaFileCandidate,
+)
+
+data class RestorePlan(
+    val exactMatches: Map<String, MediaFileCandidate>,
+    val legacySuggestions: List<LegacyRestoreSuggestion>,
+    val unidentified: List<MediaFileCandidate>,
+)
+
+object RestorePlanner {
+    fun plan(
+        episodes: List<RestoreEpisodeCandidate>,
+        files: List<MediaFileCandidate>,
+    ): RestorePlan {
+        val available = files.filter { it.sizeBytes > 0L }.toMutableList()
+        val exact = linkedMapOf<String, MediaFileCandidate>()
+
+        episodes.forEach { episode ->
+            val matching = available.filter { it.identity == episode.identity }
+            val pick = matching.maxWithOrNull(stableKeepComparator()) ?: return@forEach
+            exact[episode.episodeId] = pick
+            available.removeAll(matching.toSet())
+        }
+
+        val suggestions = mutableListOf<LegacyRestoreSuggestion>()
+        episodes.filterNot { it.episodeId in exact }.forEach { episode ->
+            val legacy = available.filter {
+                it.identity == null && !it.isVideo && MediaNaming.matchKey(it.displayName) == episode.legacyMatchKey
+            }
+            // Repeated titles or multiple legacy copies are ambiguous: a suggestion is
+            // only made when both sides resolve one-to-one.
+            if (legacy.size == 1 && episodes.count { it.legacyMatchKey == episode.legacyMatchKey } == 1) {
+                suggestions += LegacyRestoreSuggestion(episode.episodeId, legacy.single())
+                available.remove(legacy.single())
+            }
+        }
+
+        return RestorePlan(exact, suggestions, available)
+    }
+}
+
+data class DuplicateReviewItem(
+    val file: MediaFileCandidate,
+    val selectedByDefault: Boolean,
+    val enabled: Boolean = !file.isProtected,
+)
+
+data class ConfirmedDuplicateGroup(
+    val reason: Reason,
+    val keep: MediaFileCandidate,
+    val items: List<DuplicateReviewItem>,
+) {
+    enum class Reason { STABLE_ID, IDENTICAL_CONTENT }
+}
+
+data class AmbiguousLegacyGroup(
+    val normalizedTitle: String,
+    val items: List<DuplicateReviewItem>,
+)
+
+data class DuplicateCleanupPlan(
+    val confirmed: List<ConfirmedDuplicateGroup>,
+    val ambiguous: List<AmbiguousLegacyGroup>,
+) {
+    val defaultDeleteUris: List<String>
+        get() = confirmed.flatMap { group ->
+            group.items.filter { it.selectedByDefault && it.enabled }.map { it.file.uriString }
+        }
+}
+
+object DuplicateCleanupPlanner {
+    fun plan(files: List<MediaFileCandidate>): DuplicateCleanupPlan {
+        val valid = files.filter { it.sizeBytes > 0L }
+        val parent = IntArray(valid.size) { it }
+        val reasonByRoot = mutableMapOf<Int, ConfirmedDuplicateGroup.Reason>()
+
+        fun root(index: Int): Int {
+            var current = index
+            while (parent[current] != current) {
+                parent[current] = parent[parent[current]]
+                current = parent[current]
+            }
+            return current
+        }
+
+        fun union(a: Int, b: Int, reason: ConfirmedDuplicateGroup.Reason) {
+            val ra = root(a)
+            val rb = root(b)
+            if (ra == rb) return
+            parent[rb] = ra
+            val existing = reasonByRoot.remove(rb) ?: reasonByRoot[ra]
+            reasonByRoot[ra] = if (existing == ConfirmedDuplicateGroup.Reason.STABLE_ID ||
+                reason == ConfirmedDuplicateGroup.Reason.STABLE_ID
+            ) ConfirmedDuplicateGroup.Reason.STABLE_ID else reason
+        }
+
+        valid.indices.forEach { a ->
+            for (b in a + 1 until valid.size) {
+                val left = valid[a]
+                val right = valid[b]
+                when {
+                    left.identity != null && left.identity == right.identity ->
+                        union(a, b, ConfirmedDuplicateGroup.Reason.STABLE_ID)
+                    left.sizeBytes == right.sizeBytes && left.sha256 != null && left.sha256 == right.sha256 ->
+                        union(a, b, ConfirmedDuplicateGroup.Reason.IDENTICAL_CONTENT)
+                }
+            }
+        }
+
+        val confirmed = valid.indices.groupBy(::root).values
+            .filter { it.size > 1 }
+            .map { indices ->
+                val members = indices.map(valid::get)
+                val keep = members.maxWithOrNull(stableKeepComparator())!!
+                val protectedExist = members.any { it.isProtected }
+                val items = members.map { file ->
+                    DuplicateReviewItem(
+                        file = file,
+                        selectedByDefault = !file.isProtected && file != keep &&
+                            (!protectedExist || file.isProtected.not()),
+                        enabled = !file.isProtected && file != keep,
+                    )
+                }
+                ConfirmedDuplicateGroup(
+                    reason = reasonByRoot[root(indices.first())]
+                        ?: ConfirmedDuplicateGroup.Reason.IDENTICAL_CONTENT,
+                    keep = keep,
+                    items = items,
+                )
+            }
+
+        val claimedUris = confirmed.flatMap { it.items }.map { it.file.uriString }.toSet()
+        val ambiguous = valid.filter { it.uriString !in claimedUris && it.identity == null }
+            .groupBy { it.isVideo to MediaNaming.matchKey(it.displayName) }
+            .values
+            .filter { group -> group.size > 1 && group.map { it.sha256 to it.sizeBytes }.distinct().size > 1 }
+            .map { group ->
+                AmbiguousLegacyGroup(
+                    normalizedTitle = MediaNaming.matchKey(group.first().displayName),
+                    items = group.map { DuplicateReviewItem(it, selectedByDefault = false) },
+                )
+            }
+
+        return DuplicateCleanupPlan(confirmed, ambiguous)
+    }
+}
+
+/** Prefer protected references, then the largest valid copy, un-suffixed, then oldest. */
+private fun stableKeepComparator(): Comparator<MediaFileCandidate> = compareBy<MediaFileCandidate>(
+    { it.isProtected },
+    { it.sizeBytes },
+    { !MediaNaming.hasDuplicateSuffix(it.displayName) },
+    { -it.dateAddedSec },
+    { it.uriString },
+)
+
+data class RetentionCandidate(
+    val id: String,
+    val podcastId: String,
+    val publicationTimeMs: Long?,
+    val completedTimeMs: Long,
+    val isPinned: Boolean,
+    val source: Source,
+) {
+    enum class Source { RSS, URL }
+}
+
+object AutoDownloadRetentionPlanner {
+    const val UNLIMITED = -1
+
+    fun selectEligibleEpisodes(
+        episodes: List<RestoreEpisodeCandidateForRetention>,
+        limit: Int,
+    ): List<RestoreEpisodeCandidateForRetention> {
+        val ordered = episodes.sortedWith(
+            compareByDescending<RestoreEpisodeCandidateForRetention> { it.publicationTimeMs }
+                .thenBy { it.id },
+        )
+        return if (limit == UNLIMITED) ordered else ordered.take(limit.coerceAtLeast(0))
+    }
+
+    fun itemsToPrune(items: List<RetentionCandidate>, limit: Int): List<RetentionCandidate> {
+        if (limit == UNLIMITED) return emptyList()
+        return items.filterNot { it.isPinned }
+            .sortedWith(
+                compareByDescending<RetentionCandidate> { it.publicationTimeMs ?: Long.MIN_VALUE }
+                    .thenByDescending { it.completedTimeMs }
+                    .thenBy { it.id },
+            )
+            .drop(limit.coerceAtLeast(0))
+    }
+}
+
+data class RestoreEpisodeCandidateForRetention(
+    val id: String,
+    val publicationTimeMs: Long,
+)

--- a/app/src/main/java/com/podcastplayer/app/data/local/DownloadedEpisodeDao.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DownloadedEpisodeDao.kt
@@ -12,6 +12,15 @@ interface DownloadedEpisodeDao {
     @Query("SELECT * FROM downloaded_episodes ORDER BY downloadDate DESC")
     fun getAllEpisodes(): Flow<List<DownloadedEpisodeEntity>>
 
+    @Query("SELECT * FROM downloaded_episodes")
+    suspend fun getAllEpisodesOnce(): List<DownloadedEpisodeEntity>
+
+    @Query("SELECT * FROM downloaded_episodes WHERE podcastId = :podcastId AND origin = 'AUTO'")
+    suspend fun getAutoEpisodesByPodcast(podcastId: String): List<DownloadedEpisodeEntity>
+
+    @Query("SELECT DISTINCT podcastId FROM downloaded_episodes WHERE origin = 'AUTO'")
+    suspend fun getAutoPodcastIds(): List<String>
+
     @Query("SELECT * FROM downloaded_episodes WHERE id = :episodeId")
     suspend fun getEpisodeById(episodeId: String): DownloadedEpisodeEntity?
 

--- a/app/src/main/java/com/podcastplayer/app/data/local/DownloadedEpisodeEntity.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/DownloadedEpisodeEntity.kt
@@ -15,5 +15,6 @@ data class DownloadedEpisodeEntity(
     val duration: Long?,
     val localPath: String,
     val fileSize: Long,
-    val downloadDate: Long
+    val downloadDate: Long,
+    val origin: String = DownloadOrigin.MANUAL.name,
 )

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaIdentity.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaIdentity.kt
@@ -1,0 +1,47 @@
+package com.podcastplayer.app.data.local
+
+import java.security.MessageDigest
+
+/** Stable, versioned identity embedded in MediaStore display names. */
+data class MediaIdentity(
+    val kind: Kind,
+    val sha256: String,
+) {
+    enum class Kind(val marker: Char) {
+        RSS('r'),
+        URL('u'),
+    }
+
+    init {
+        require(sha256.length == SHA_256_HEX_LENGTH && sha256.all { it in "0123456789abcdef" })
+    }
+
+    val suffix: String get() = "[vibe1-${kind.marker}-$sha256]"
+
+    companion object {
+        private const val SHA_256_HEX_LENGTH = 64
+        private val SUFFIX_REGEX = Regex("\\[vibe1-([ru])-([0-9a-f]{64})](?: \\(\\d+\\))?$")
+
+        fun rss(stableEpisodeId: String): MediaIdentity = from(Kind.RSS, stableEpisodeId)
+
+        fun url(canonicalUrlMediaId: String): MediaIdentity = from(Kind.URL, canonicalUrlMediaId)
+
+        fun parse(displayName: String): MediaIdentity? {
+            val base = MediaNaming.baseName(displayName)
+            val match = SUFFIX_REGEX.find(base) ?: return null
+            val kind = when (match.groupValues[1]) {
+                "r" -> Kind.RSS
+                "u" -> Kind.URL
+                else -> return null
+            }
+            return MediaIdentity(kind, match.groupValues[2])
+        }
+
+        private fun from(kind: Kind, source: String): MediaIdentity {
+            val digest = MessageDigest.getInstance("SHA-256")
+                .digest(source.toByteArray(Charsets.UTF_8))
+                .joinToString("") { "%02x".format(it) }
+            return MediaIdentity(kind, digest)
+        }
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaNaming.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaNaming.kt
@@ -11,6 +11,8 @@ package com.podcastplayer.app.data.local
  */
 object MediaNaming {
 
+    const val MAX_DISPLAY_NAME_LENGTH = 120
+
     private val ILLEGAL_CHARS = Regex("[\\\\/:*?\"<>|]")
 
     /**
@@ -21,13 +23,18 @@ object MediaNaming {
 
     /** Mirrors the historical MediaStoreSaver sanitization exactly. */
     fun sanitize(name: String): String =
-        name.replace(ILLEGAL_CHARS, "_").take(120).ifBlank { "vibe-media" }
+        name.replace(ILLEGAL_CHARS, "_").take(MAX_DISPLAY_NAME_LENGTH).ifBlank { "vibe-media" }
 
     /**
      * Display name for an RSS episode download: "<podcast> - <episode>.<ext>".
      * Same fallbacks as the historical DownloadManager implementation.
      */
-    fun episodeDisplayName(podcastTitle: String?, episodeTitle: String, extension: String): String {
+    fun episodeDisplayName(
+        podcastTitle: String?,
+        episodeTitle: String,
+        extension: String,
+        identity: MediaIdentity? = null,
+    ): String {
         val rawTitle = episodeTitle.trim()
         val base = when {
             podcastTitle.isNullOrBlank() && rawTitle.isBlank() -> "episode"
@@ -35,14 +42,19 @@ object MediaNaming {
             rawTitle.isBlank() -> podcastTitle
             else -> "$podcastTitle - $rawTitle"
         }
-        return sanitize("$base.${extension.ifBlank { "mp3" }}")
+        return identifiedName(base, extension.ifBlank { "mp3" }, identity)
     }
 
     /**
      * Display name for a URL (yt-dlp) download: "<uploader> - <title>.<ext>".
      * Same fallbacks as the historical UrlDownloadService implementation.
      */
-    fun urlDisplayName(uploader: String?, title: String, extension: String): String {
+    fun urlDisplayName(
+        uploader: String?,
+        title: String,
+        extension: String,
+        identity: MediaIdentity? = null,
+    ): String {
         val rawTitle = title.trim()
         val rawUploader = uploader?.trim()?.removePrefix("@")?.trim()
         val base = when {
@@ -51,7 +63,22 @@ object MediaNaming {
             rawTitle.isBlank() -> rawUploader
             else -> "$rawUploader - $rawTitle"
         }
-        return sanitize("$base.${extension.ifBlank { "mp4" }}")
+        return identifiedName(base, extension.ifBlank { "mp4" }, identity)
+    }
+
+    fun addIdentity(displayName: String, identity: MediaIdentity): String {
+        val extension = displayName.substringAfterLast('.', "")
+        val title = titleFromDisplayName(displayName)
+        return identifiedName(title, extension.ifBlank { "mp3" }, identity)
+    }
+
+    private fun identifiedName(base: String, extension: String, identity: MediaIdentity?): String {
+        if (identity == null) return sanitize("$base.$extension")
+        val safeExtension = sanitize(extension).take(10).ifBlank { "mp3" }
+        val fixedLength = identity.suffix.length + safeExtension.length + 1
+        val titleLimit = (MAX_DISPLAY_NAME_LENGTH - fixedLength).coerceAtLeast(1)
+        val safeBase = base.replace(ILLEGAL_CHARS, "_").trim().ifBlank { "vibe-media" }.take(titleLimit)
+        return "$safeBase${identity.suffix}.$safeExtension"
     }
 
     /**
@@ -61,25 +88,31 @@ object MediaNaming {
      * that would produce "episode.m4a" still matches an existing "episode.mp3".
      */
     fun matchKey(displayName: String): String {
+        return baseName(displayName).replace(DUPLICATE_SUFFIX, "").lowercase()
+    }
+
+    internal fun baseName(displayName: String): String {
         val trimmed = displayName.trim()
         val dot = trimmed.lastIndexOf('.')
-        val base = if (dot > 0) trimmed.substring(0, dot) else trimmed
-        return base.replace(DUPLICATE_SUFFIX, "").lowercase()
+        return if (dot > 0) trimmed.substring(0, dot) else trimmed
     }
 
     /** True when the name carries a MediaStore collision suffix like "title (2).mp3". */
     fun hasDuplicateSuffix(displayName: String): Boolean {
-        val trimmed = displayName.trim()
-        val dot = trimmed.lastIndexOf('.')
-        val base = if (dot > 0) trimmed.substring(0, dot) else trimmed
+        val base = baseName(displayName)
         return DUPLICATE_SUFFIX.containsMatchIn(base)
     }
 
     /** Display title recovered from a file name: extension and " (n)" suffix stripped. */
     fun titleFromDisplayName(displayName: String): String {
         val trimmed = displayName.trim()
-        val dot = trimmed.lastIndexOf('.')
-        val base = if (dot > 0) trimmed.substring(0, dot) else trimmed
-        return base.replace(DUPLICATE_SUFFIX, "").ifBlank { trimmed }
+        val base = baseName(displayName)
+        val withoutCollision = base.replace(DUPLICATE_SUFFIX, "")
+        val identity = MediaIdentity.parse(displayName)
+        return if (identity == null) {
+            withoutCollision.ifBlank { trimmed }
+        } else {
+            withoutCollision.removeSuffix(identity.suffix).ifBlank { trimmed }
+        }
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreScanner.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/MediaStoreScanner.kt
@@ -2,13 +2,17 @@ package com.podcastplayer.app.data.local
 
 import android.Manifest
 import android.app.PendingIntent
+import android.app.RecoverableSecurityException
 import android.content.ContentUris
+import android.content.ContentValues
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import androidx.core.content.ContextCompat
+import androidx.annotation.RequiresApi
+import java.security.MessageDigest
 
 /**
  * Reads back the media this app (or a previous install of it) wrote into the
@@ -48,9 +52,9 @@ class MediaStoreScanner(private val context: Context) {
      * copy — so a reused link points at the original, not a "(2)" duplicate.
      */
     fun findExisting(isVideo: Boolean, expectedDisplayName: String): FoundMedia? {
-        val key = MediaNaming.matchKey(expectedDisplayName)
+        val expectedIdentity = MediaIdentity.parse(expectedDisplayName) ?: return null
         return scanCollection(isVideo)
-            .filter { it.sizeBytes > 0L && MediaNaming.matchKey(it.displayName) == key }
+            .filter { it.sizeBytes > 0L && MediaIdentity.parse(it.displayName) == expectedIdentity }
             .minWithOrNull(
                 compareBy(
                     { it.displayName != expectedDisplayName },
@@ -68,6 +72,90 @@ class MediaStoreScanner(private val context: Context) {
     fun createDeleteRequest(uris: List<Uri>): PendingIntent? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || uris.isEmpty()) return null
         return MediaStore.createDeleteRequest(context.contentResolver, uris)
+    }
+
+    fun createWriteRequest(uris: List<Uri>): PendingIntent? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || uris.isEmpty()) return null
+        return MediaStore.createWriteRequest(context.contentResolver, uris)
+    }
+
+    sealed interface MutationResult {
+        data object Success : MutationResult
+        data class NeedsConsent(val pendingIntent: PendingIntent) : MutationResult
+        data object Failed : MutationResult
+    }
+
+    /** Delete one row, surfacing Android 10's per-item recoverable consent request. */
+    fun delete(uriString: String): MutationResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return try {
+                if (context.contentResolver.delete(Uri.parse(uriString), null, null) > 0) {
+                    MutationResult.Success
+                } else {
+                    MutationResult.Failed
+                }
+            } catch (_: Throwable) {
+                MutationResult.Failed
+            }
+        }
+        return deleteScoped(uriString)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun deleteScoped(uriString: String): MutationResult {
+        return try {
+            if (context.contentResolver.delete(Uri.parse(uriString), null, null) > 0) {
+                MutationResult.Success
+            } else {
+                MutationResult.Failed
+            }
+        } catch (error: RecoverableSecurityException) {
+            MutationResult.NeedsConsent(error.userAction.actionIntent)
+        } catch (_: Throwable) {
+            MutationResult.Failed
+        }
+    }
+
+    /** Rename a MediaStore row without changing its content or relative folder. */
+    fun rename(uriString: String, displayName: String): MutationResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return MutationResult.Failed
+        return renameScoped(uriString, displayName)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun renameScoped(uriString: String, displayName: String): MutationResult {
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, MediaNaming.sanitize(displayName))
+        }
+        return try {
+            if (context.contentResolver.update(Uri.parse(uriString), values, null, null) > 0) {
+                MutationResult.Success
+            } else {
+                MutationResult.Failed
+            }
+        } catch (error: RecoverableSecurityException) {
+            MutationResult.NeedsConsent(error.userAction.actionIntent)
+        } catch (_: Throwable) {
+            MutationResult.Failed
+        }
+    }
+
+    /** SHA-256 of a scanned item; callers limit this to same-size candidate sets. */
+    fun sha256(uriString: String): String? {
+        return try {
+            val digest = MessageDigest.getInstance("SHA-256")
+            context.contentResolver.openInputStream(Uri.parse(uriString))?.use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                while (true) {
+                    val count = input.read(buffer)
+                    if (count < 0) break
+                    digest.update(buffer, 0, count)
+                }
+            } ?: return null
+            digest.digest().joinToString("") { "%02x".format(it) }
+        } catch (_: Throwable) {
+            null
+        }
     }
 
     /**

--- a/app/src/main/java/com/podcastplayer/app/data/local/PodcastDatabase.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/PodcastDatabase.kt
@@ -11,10 +11,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PlaybackProgressEntity::class,
         UrlDownloadEntity::class,
     ],
-    version = 3,
-    // We don't use Room migrations testing yet, and `room.schemaLocation` isn't
-    // wired up; turn off schema export to silence the kapt warning.
-    exportSchema = false,
+    version = 4,
+    exportSchema = true,
 )
 abstract class PodcastDatabase : RoomDatabase() {
     abstract fun downloadedEpisodeDao(): DownloadedEpisodeDao
@@ -69,6 +67,20 @@ abstract class PodcastDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        /** Existing downloads are deliberately grandfathered as pinned/manual. */
+        val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE downloaded_episodes ADD COLUMN origin TEXT NOT NULL DEFAULT 'MANUAL'"
+                )
+                db.execSQL(
+                    "ALTER TABLE url_downloads ADD COLUMN origin TEXT NOT NULL DEFAULT 'MANUAL'"
+                )
+                db.execSQL("ALTER TABLE url_downloads ADD COLUMN podcastId TEXT")
+                db.execSQL("ALTER TABLE url_downloads ADD COLUMN episodePubDateMs INTEGER")
             }
         }
     }

--- a/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadDao.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadDao.kt
@@ -21,6 +21,15 @@ interface UrlDownloadDao {
     @Query("SELECT * FROM url_downloads WHERE id = :id")
     fun observeById(id: String): Flow<UrlDownloadEntity?>
 
+    @Query("SELECT * FROM url_downloads")
+    suspend fun getAllOnce(): List<UrlDownloadEntity>
+
+    @Query("SELECT * FROM url_downloads WHERE podcastId = :podcastId AND origin = 'AUTO' AND status = 'COMPLETED'")
+    suspend fun getCompletedAutoByPodcast(podcastId: String): List<UrlDownloadEntity>
+
+    @Query("SELECT DISTINCT podcastId FROM url_downloads WHERE origin = 'AUTO' AND podcastId IS NOT NULL")
+    suspend fun getAutoPodcastIds(): List<String>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: UrlDownloadEntity)
 

--- a/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadEntity.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/local/UrlDownloadEntity.kt
@@ -44,4 +44,10 @@ data class UrlDownloadEntity(
     val createdAtMs: Long,
     /** epoch millis; null while pending/in-progress. */
     val completedAtMs: Long?,
+    /** Manual items are pinned; only AUTO items participate in retention. */
+    val origin: String = DownloadOrigin.MANUAL.name,
+    /** RSS podcast that routed this episode through yt-dlp, if any. */
+    val podcastId: String? = null,
+    /** Original episode publication time for per-podcast ordering, if any. */
+    val episodePubDateMs: Long? = null,
 )

--- a/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/DownloadManager.kt
@@ -6,6 +6,8 @@ import android.os.Environment
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.DownloadedEpisodeDao
 import com.podcastplayer.app.data.local.DownloadedEpisodeEntity
+import com.podcastplayer.app.data.local.DownloadOrigin
+import com.podcastplayer.app.data.local.MediaIdentity
 import com.podcastplayer.app.data.local.MediaNaming
 import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.data.local.MediaStoreScanner
@@ -35,7 +37,8 @@ class DownloadManager(private val context: Context) {
     suspend fun downloadEpisode(
         episode: Episode,
         podcastTitle: String? = null,
-        onProgress: (Float) -> Unit = {}
+        origin: DownloadOrigin = DownloadOrigin.MANUAL,
+        onProgress: (Float) -> Unit = {},
     ): Result<String> = withContext(Dispatchers.IO) {
         try {
             // Path-on-disk name still uses a hash for the legacy app-private path
@@ -67,6 +70,7 @@ class DownloadManager(private val context: Context) {
                     val entity = episode.toEntity(
                         localPath = reusable.uriString,
                         fileSize = reusable.sizeBytes,
+                        origin = origin,
                     )
                     dao.insertEpisode(entity)
                     return@withContext Result.success(reusable.uriString)
@@ -76,7 +80,11 @@ class DownloadManager(private val context: Context) {
                     ?: return@withContext Result.failure(
                         java.io.IOException("Could not save audio to MediaStore"),
                     )
-                val entity = episode.toEntity(localPath = saved.uri.toString(), fileSize = saved.sizeBytes)
+                val entity = episode.toEntity(
+                    localPath = saved.uri.toString(),
+                    fileSize = saved.sizeBytes,
+                    origin = origin,
+                )
                 dao.insertEpisode(entity)
                 Result.success(saved.uri.toString())
             } else {
@@ -84,11 +92,21 @@ class DownloadManager(private val context: Context) {
                 // Files won't be visible to other apps, but neither would they without
                 // the legacy WRITE_EXTERNAL_STORAGE permission flow.
                 val localFile = File(downloadDir, legacyFileName)
-                if (localFile.exists()) return@withContext Result.success(localFile.absolutePath)
+                if (localFile.exists()) {
+                    dao.insertEpisode(
+                        episode.toEntity(
+                            localPath = localFile.absolutePath,
+                            fileSize = localFile.length(),
+                            origin = origin,
+                        )
+                    )
+                    return@withContext Result.success(localFile.absolutePath)
+                }
                 downloadIntoFile(episode, localFile, onProgress)
                 val entity = episode.toEntity(
                     localPath = localFile.absolutePath,
                     fileSize = localFile.length(),
+                    origin = origin,
                 )
                 dao.insertEpisode(entity)
                 Result.success(localFile.absolutePath)
@@ -211,6 +229,8 @@ class DownloadManager(private val context: Context) {
      *  the domain [Episode] doesn't carry. */
     fun getAllDownloadedEntitiesFlow(): Flow<List<DownloadedEpisodeEntity>> = dao.getAllEpisodes()
 
+    suspend fun getAllDownloadedEntities(): List<DownloadedEpisodeEntity> = dao.getAllEpisodesOnce()
+
     /**
      * Delete one downloaded episode (row + file). Returns the content URI that
      * couldn't be deleted directly (a MediaStore entry owned by a previous install)
@@ -286,7 +306,12 @@ class DownloadManager(private val context: Context) {
      */
     private fun buildDisplayName(episode: Episode, podcastTitle: String?): String {
         val extension = guessExtension(episode.audioUrl) ?: "mp3"
-        return MediaNaming.episodeDisplayName(podcastTitle, episode.title, extension)
+        return MediaNaming.episodeDisplayName(
+            podcastTitle = podcastTitle,
+            episodeTitle = episode.title,
+            extension = extension,
+            identity = MediaIdentity.rss(episode.id),
+        )
     }
 
     /**
@@ -298,7 +323,13 @@ class DownloadManager(private val context: Context) {
         localPath: String,
         fileSize: Long,
     ): Unit = withContext(Dispatchers.IO) {
-        dao.insertEpisode(episode.toEntity(localPath = localPath, fileSize = fileSize))
+        dao.insertEpisode(
+            episode.toEntity(
+                localPath = localPath,
+                fileSize = fileSize,
+                origin = DownloadOrigin.MANUAL,
+            )
+        )
     }
 
     private fun guessExtension(url: String): String? {
@@ -311,7 +342,11 @@ class DownloadManager(private val context: Context) {
         }
     }
 
-    private fun Episode.toEntity(localPath: String, fileSize: Long): DownloadedEpisodeEntity {
+    private fun Episode.toEntity(
+        localPath: String,
+        fileSize: Long,
+        origin: DownloadOrigin,
+    ): DownloadedEpisodeEntity {
         return DownloadedEpisodeEntity(
             id = id,
             podcastId = podcastId,
@@ -322,7 +357,8 @@ class DownloadManager(private val context: Context) {
             duration = duration,
             localPath = localPath,
             fileSize = fileSize,
-            downloadDate = System.currentTimeMillis()
+            downloadDate = System.currentTimeMillis(),
+            origin = origin.name,
         )
     }
 

--- a/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
+++ b/app/src/main/java/com/podcastplayer/app/data/repository/UrlDownloadRepository.kt
@@ -3,6 +3,7 @@ package com.podcastplayer.app.data.repository
 import android.content.Context
 import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.DownloadOrigin
 import com.podcastplayer.app.data.local.MediaNaming
 import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.data.local.UrlDownloadDao
@@ -10,6 +11,7 @@ import com.podcastplayer.app.data.local.UrlDownloadEntity
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.domain.model.MediaType
 import com.podcastplayer.app.service.UrlDownloadService
+import com.podcastplayer.app.service.AutoDownloadRetentionManager
 import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLException
 import com.yausername.youtubedl_android.YoutubeDLRequest
@@ -108,6 +110,9 @@ class UrlDownloadRepository(private val context: Context) {
         rawUrl: String,
         mediaType: MediaType,
         prefetchedMetadata: UrlMetadata? = null,
+        origin: DownloadOrigin = DownloadOrigin.MANUAL,
+        podcastId: String? = null,
+        episodePubDateMs: Long? = null,
     ): String = withContext(Dispatchers.IO) {
         val mediaTag = mediaType.tag
         val id = UrlValidator.stableId(rawUrl, mediaTag)
@@ -135,6 +140,9 @@ class UrlDownloadRepository(private val context: Context) {
             errorMessage = null,
             createdAtMs = System.currentTimeMillis(),
             completedAtMs = null,
+            origin = origin.name,
+            podcastId = podcastId,
+            episodePubDateMs = episodePubDateMs,
         )
         dao.upsert(entity)
         id
@@ -185,6 +193,7 @@ class UrlDownloadRepository(private val context: Context) {
     }
 
     suspend fun markCompleted(id: String, localPath: String, fileSize: Long) {
+        val entity = dao.getById(id)
         dao.markCompleted(
             id = id,
             status = UrlDownloadStatus.COMPLETED.name,
@@ -192,6 +201,9 @@ class UrlDownloadRepository(private val context: Context) {
             fileSize = fileSize,
             completedAtMs = System.currentTimeMillis(),
         )
+        if (entity?.origin == DownloadOrigin.AUTO.name && entity.podcastId != null) {
+            AutoDownloadRetentionManager(context).trimPodcast(entity.podcastId)
+        }
     }
 
     /**

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/DownloadsScreen.kt
@@ -54,9 +54,11 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.podcastplayer.app.R
 import com.podcastplayer.app.data.local.UrlDownloadEntity
+import com.podcastplayer.app.data.local.DuplicateCleanupPlan
 import com.podcastplayer.app.data.repository.UrlSource
 import com.podcastplayer.app.domain.model.Episode
 import com.podcastplayer.app.presentation.viewmodel.RestoreDownloadsState
+import com.podcastplayer.app.presentation.viewmodel.LegacyRestoreMatch
 import com.podcastplayer.app.ui.theme.JetBrainsMono
 
 /**
@@ -116,6 +118,7 @@ fun DownloadsScreen(
      */
     onDeleteAll: (deleteFiles: Boolean) -> Unit,
     onRestoreDownloads: () -> Unit = {},
+    onReviewLegacyMatches: () -> Unit = {},
     onCleanupDuplicates: () -> Unit = {},
     onDismissRestoreResult: () -> Unit = {},
     onDismissMaintenanceMessage: () -> Unit = {},
@@ -188,6 +191,7 @@ fun DownloadsScreen(
                     RestoreDownloadsCard(
                         state = restoreState,
                         onRestore = onRestoreDownloads,
+                        onReviewLegacy = onReviewLegacyMatches,
                         onDismiss = onDismissRestoreResult,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     )
@@ -220,6 +224,7 @@ fun DownloadsScreen(
                             RestoreDownloadsCard(
                                 state = restoreState,
                                 onRestore = onRestoreDownloads,
+                                onReviewLegacy = onReviewLegacyMatches,
                                 onDismiss = onDismissRestoreResult,
                             )
                         }
@@ -503,6 +508,7 @@ private fun DownloadRow(
 private fun RestoreDownloadsCard(
     state: RestoreDownloadsState,
     onRestore: () -> Unit,
+    onReviewLegacy: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -539,6 +545,11 @@ private fun RestoreDownloadsCard(
                     is RestoreDownloadsState.Running ->
                         "Restoring downloads…" to
                             "Scanning your media folders and matching episodes."
+                    is RestoreDownloadsState.ReviewLegacy ->
+                        "Legacy matches need review" to
+                            "${state.suggestions.size} title-based suggestion" +
+                                (if (state.suggestions.size == 1) "" else "s") +
+                                " found. Nothing is linked without your confirmation."
                     is RestoreDownloadsState.Done ->
                         if (state.restoredEpisodes == 0 && state.importedClips == 0) {
                             "Nothing to restore" to "No previously downloaded files were found."
@@ -576,6 +587,8 @@ private fun RestoreDownloadsCard(
             when (state) {
                 is RestoreDownloadsState.Idle -> VibeChip(label = "Restore", onClick = onRestore)
                 is RestoreDownloadsState.Running -> Unit
+                is RestoreDownloadsState.ReviewLegacy ->
+                    VibeChip(label = "Review", onClick = onReviewLegacy)
                 is RestoreDownloadsState.Done,
                 is RestoreDownloadsState.Failed -> VibeChip(label = "Dismiss", onClick = onDismiss)
             }
@@ -644,5 +657,154 @@ private fun KindBadge(kind: DownloadEntryUi.Kind) {
             letterSpacing = 1.2.sp,
             color = colors.onSurfaceVariant,
         )
+    }
+}
+
+@Composable
+fun LegacyRestoreReviewDialog(
+    matches: List<LegacyRestoreMatch>,
+    onConfirm: (List<LegacyRestoreMatch>) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var selected by remember(matches) { mutableStateOf(emptySet<String>()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Review legacy matches") },
+        text = {
+            LazyColumn(modifier = Modifier.height(360.dp)) {
+                item {
+                    Text(
+                        "These files have no stable identity. Select only matches you recognize; " +
+                            "confirmed files will be renamed before they are linked.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                }
+                items(matches, key = { it.file.uriString }) { match ->
+                    val checked = match.file.uriString in selected
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                selected = if (checked) selected - match.file.uriString
+                                else selected + match.file.uriString
+                            }
+                            .padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = checked,
+                            onCheckedChange = {
+                                selected = if (checked) selected - match.file.uriString
+                                else selected + match.file.uriString
+                            },
+                        )
+                        Column {
+                            Text(match.episode.title, style = MaterialTheme.typography.titleSmall)
+                            Text(
+                                "${match.file.displayName} · ${formatBytes(match.file.sizeBytes)}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = selected.isNotEmpty(),
+                onClick = { onConfirm(matches.filter { it.file.uriString in selected }) },
+            ) { Text("Confirm selected") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Keep unidentified") } },
+    )
+}
+
+@Composable
+fun DuplicateCleanupDialog(
+    plan: DuplicateCleanupPlan,
+    onConfirm: (List<String>) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val allItems = remember(plan) {
+        plan.confirmed.flatMap { it.items } + plan.ambiguous.flatMap { it.items }
+    }
+    var selected by remember(plan) { mutableStateOf(plan.defaultDeleteUris.toSet()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Review duplicate files") },
+        text = {
+            LazyColumn(modifier = Modifier.height(420.dp)) {
+                if (plan.confirmed.isNotEmpty()) {
+                    item { Text("Confirmed duplicates", fontWeight = FontWeight.SemiBold) }
+                    plan.confirmed.forEach { group ->
+                        items(group.items, key = { "confirmed:${it.file.uriString}" }) { item ->
+                            DuplicateChoiceRow(item, item.file.uriString in selected) { checked ->
+                                selected = if (checked) selected + item.file.uriString
+                                else selected - item.file.uriString
+                            }
+                        }
+                    }
+                }
+                if (plan.ambiguous.isNotEmpty()) {
+                    item {
+                        Spacer(Modifier.height(10.dp))
+                        Text("Ambiguous legacy groups", fontWeight = FontWeight.SemiBold)
+                        Text(
+                            "Same title, different content. Nothing here is selected automatically.",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                    plan.ambiguous.forEach { group ->
+                        item { Text(group.normalizedTitle, style = MaterialTheme.typography.labelMedium) }
+                        items(group.items, key = { "ambiguous:${it.file.uriString}" }) { item ->
+                            DuplicateChoiceRow(item, item.file.uriString in selected) { checked ->
+                                selected = if (checked) selected + item.file.uriString
+                                else selected - item.file.uriString
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = selected.isNotEmpty(),
+                onClick = { onConfirm(allItems.map { it.file.uriString }.filter { it in selected }) },
+            ) { Text("Delete selected") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun DuplicateChoiceRow(
+    item: com.podcastplayer.app.data.local.DuplicateReviewItem,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = item.enabled) { onCheckedChange(!checked) }
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(checked = checked, enabled = item.enabled, onCheckedChange = onCheckedChange)
+        Column {
+            Text(item.file.displayName, style = MaterialTheme.typography.bodySmall)
+            val date = java.text.DateFormat.getDateInstance().format(java.util.Date(item.file.dateAddedSec * 1000L))
+            val status = when {
+                item.file.isProtected -> " · In use"
+                !item.enabled -> " · Kept copy"
+                else -> ""
+            }
+            Text(
+                "${formatBytes(item.file.sizeBytes)} · $date$status",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/PodcastNavHost.kt
@@ -32,6 +32,7 @@ import com.podcastplayer.app.BuildConfig
 import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.data.local.DatabaseProvider
 import com.podcastplayer.app.data.local.QueueStorage
+import com.podcastplayer.app.data.local.MediaStoreScanner
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
 import com.podcastplayer.app.data.remote.RssParser
 import com.podcastplayer.app.data.remote.iTunesApi
@@ -481,45 +482,176 @@ fun PodcastNavHost(
                     val failedUrlDownloads by urlDownloadViewModel.needsAttentionDownloads.collectAsState()
                     val restoreState by podcastViewModel.restoreState.collectAsState()
                     var maintenanceMessage by remember { mutableStateOf<String?>(null) }
-                    var pendingDeleteCount by remember { mutableStateOf(0) }
+                    var duplicatePlan by remember {
+                        mutableStateOf<com.podcastplayer.app.data.local.DuplicateCleanupPlan?>(null)
+                    }
+                    var showLegacyReview by remember { mutableStateOf(false) }
+                    var pendingDeleteContinuation by remember {
+                        mutableStateOf<((Boolean) -> Unit)?>(null)
+                    }
+                    var pendingWriteContinuation by remember {
+                        mutableStateOf<((Boolean) -> Unit)?>(null)
+                    }
 
                     // Receives the outcome of the system batch-delete consent dialog
                     // (used by single delete, remove-all, and duplicate cleanup).
                     val deleteLauncher = rememberLauncherForActivityResult(
                         ActivityResultContracts.StartIntentSenderForResult()
                     ) { result ->
-                        maintenanceMessage = if (result.resultCode == android.app.Activity.RESULT_OK) {
-                            "Removed $pendingDeleteCount file" + (if (pendingDeleteCount == 1) "." else "s.")
-                        } else {
-                            "Canceled — those files were kept."
+                        val continuation = pendingDeleteContinuation
+                        pendingDeleteContinuation = null
+                        continuation?.invoke(result.resultCode == android.app.Activity.RESULT_OK)
+                    }
+                    val writeLauncher = rememberLauncherForActivityResult(
+                        ActivityResultContracts.StartIntentSenderForResult()
+                    ) { result ->
+                        val continuation = pendingWriteContinuation
+                        pendingWriteContinuation = null
+                        continuation?.invoke(result.resultCode == android.app.Activity.RESULT_OK)
+                    }
+
+                    fun reportActualDeletion(targetUris: List<String>) {
+                        scope.launch {
+                            val remaining = mediaScanner.scanAll().mapTo(hashSetOf()) { it.uriString }
+                            val actual = targetUris.count { it !in remaining }
+                            maintenanceMessage = "Removed $actual file" + if (actual == 1) "." else "s."
                         }
                     }
 
-                    // Route content URIs that couldn't be deleted directly (owned by a
-                    // previous install) through the system consent dialog. Returns whether
-                    // a dialog was shown.
-                    fun requestConsentDelete(uris: List<String>): Boolean {
-                        if (uris.isEmpty()) return false
-                        val request = mediaScanner.createDeleteRequest(uris.map(Uri::parse))
-                        if (request == null) {
-                            maintenanceMessage = "Deleting files from a previous install needs Android 11 or newer."
-                            return false
+                    fun requestConsentDelete(uris: List<String>) {
+                        val targets = uris.distinct()
+                        if (targets.isEmpty()) return
+
+                        fun deleteSequential(remaining: List<String>) {
+                            val uri = remaining.firstOrNull() ?: run {
+                                reportActualDeletion(targets)
+                                return
+                            }
+                            when (val result = mediaScanner.delete(uri)) {
+                                MediaStoreScanner.MutationResult.Success -> deleteSequential(remaining.drop(1))
+                                MediaStoreScanner.MutationResult.Failed -> deleteSequential(remaining.drop(1))
+                                is MediaStoreScanner.MutationResult.NeedsConsent -> {
+                                    pendingDeleteContinuation = { granted ->
+                                        if (granted) deleteSequential(remaining)
+                                        else {
+                                            maintenanceMessage = "Canceled — remaining files were kept."
+                                            reportActualDeletion(targets)
+                                        }
+                                    }
+                                    deleteLauncher.launch(
+                                        androidx.activity.result.IntentSenderRequest.Builder(
+                                            result.pendingIntent.intentSender
+                                        ).build()
+                                    )
+                                }
+                            }
                         }
-                        pendingDeleteCount = uris.size
+
+                        if (android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.Q) {
+                            deleteSequential(targets)
+                            return
+                        }
+
+                        val needsConsent = targets.filter { uri ->
+                            mediaScanner.delete(uri) !is MediaStoreScanner.MutationResult.Success
+                        }
+                        if (needsConsent.isEmpty()) {
+                            reportActualDeletion(targets)
+                            return
+                        }
+                        val request = mediaScanner.createDeleteRequest(needsConsent.map(Uri::parse))
+                        if (request == null) {
+                            maintenanceMessage = "Some files could not be deleted."
+                            reportActualDeletion(targets)
+                            return
+                        }
+                        pendingDeleteContinuation = { granted ->
+                            if (!granted) maintenanceMessage = "Canceled — remaining files were kept."
+                            reportActualDeletion(targets)
+                        }
                         deleteLauncher.launch(
                             androidx.activity.result.IntentSenderRequest.Builder(request.intentSender).build()
                         )
-                        return true
                     }
 
                     fun startCleanup() {
                         scope.launch {
-                            val uris = podcastViewModel.planDuplicateCleanup()
-                            if (uris.isEmpty()) {
+                            val plan = podcastViewModel.planDuplicateCleanup()
+                            if (plan.confirmed.isEmpty() && plan.ambiguous.isEmpty()) {
                                 maintenanceMessage = "No duplicate files found."
-                                return@launch
+                            } else {
+                                duplicatePlan = plan
                             }
-                            requestConsentDelete(uris)
+                        }
+                    }
+
+                    fun applyLegacyBatch(
+                        matches: List<com.podcastplayer.app.presentation.viewmodel.LegacyRestoreMatch>,
+                    ) {
+                        scope.launch {
+                            var confirmed = 0
+                            matches.forEach { match ->
+                                if (podcastViewModel.applyLegacyRestoreMatch(match) ==
+                                    MediaStoreScanner.MutationResult.Success
+                                ) confirmed++
+                            }
+                            podcastViewModel.finishLegacyRestoreReview(confirmed)
+                            showLegacyReview = false
+                            maintenanceMessage = "Linked $confirmed confirmed legacy file" +
+                                if (confirmed == 1) "." else "s."
+                        }
+                    }
+
+                    fun applyLegacySequential(
+                        matches: List<com.podcastplayer.app.presentation.viewmodel.LegacyRestoreMatch>,
+                        confirmedSoFar: Int = 0,
+                    ) {
+                        val match = matches.firstOrNull() ?: run {
+                            podcastViewModel.finishLegacyRestoreReview(confirmedSoFar)
+                            showLegacyReview = false
+                            maintenanceMessage = "Linked $confirmedSoFar confirmed legacy file" +
+                                if (confirmedSoFar == 1) "." else "s."
+                            return
+                        }
+                        scope.launch {
+                            when (val result = podcastViewModel.applyLegacyRestoreMatch(match)) {
+                                MediaStoreScanner.MutationResult.Success ->
+                                    applyLegacySequential(matches.drop(1), confirmedSoFar + 1)
+                                MediaStoreScanner.MutationResult.Failed ->
+                                    applyLegacySequential(matches.drop(1), confirmedSoFar)
+                                is MediaStoreScanner.MutationResult.NeedsConsent -> {
+                                    pendingWriteContinuation = { granted ->
+                                        if (granted) applyLegacySequential(matches, confirmedSoFar)
+                                        else applyLegacySequential(matches.drop(1), confirmedSoFar)
+                                    }
+                                    writeLauncher.launch(
+                                        androidx.activity.result.IntentSenderRequest.Builder(
+                                            result.pendingIntent.intentSender
+                                        ).build()
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    fun startLegacyRestore(
+                        matches: List<com.podcastplayer.app.presentation.viewmodel.LegacyRestoreMatch>,
+                    ) {
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                            val request = mediaScanner.createWriteRequest(matches.map { Uri.parse(it.file.uriString) })
+                            if (request == null) {
+                                applyLegacyBatch(matches)
+                            } else {
+                                pendingWriteContinuation = { granted ->
+                                    if (granted) applyLegacyBatch(matches)
+                                    else maintenanceMessage = "Canceled — files stayed unidentified."
+                                }
+                                writeLauncher.launch(
+                                    androidx.activity.result.IntentSenderRequest.Builder(request.intentSender).build()
+                                )
+                            }
+                        } else {
+                            applyLegacySequential(matches)
                         }
                     }
 
@@ -562,8 +694,10 @@ fun PodcastNavHost(
                         runWithOptionalMediaAccess {
                             scope.launch {
                                 val consent = podcastViewModel.deleteAllDownloads()
-                                if (!requestConsentDelete(consent)) {
+                                if (consent.isEmpty()) {
                                     maintenanceMessage = "All downloads removed."
+                                } else {
+                                    requestConsentDelete(consent)
                                 }
                             }
                         }
@@ -673,22 +807,51 @@ fun PodcastNavHost(
                             // owned by this install and restore without any permission.
                             runWithOptionalMediaAccess { podcastViewModel.restorePreviousDownloads() }
                         },
+                        onReviewLegacyMatches = { showLegacyReview = true },
                         onCleanupDuplicates = { withMediaPermission { startCleanup() } },
                         onDismissRestoreResult = { podcastViewModel.dismissRestoreResult() },
                         onDismissMaintenanceMessage = { maintenanceMessage = null },
                         onBack = { navController.popBackStack(route = Routes.Home, inclusive = false) }
                     )
+
+                    val legacyState = restoreState as? com.podcastplayer.app.presentation.viewmodel.RestoreDownloadsState.ReviewLegacy
+                    if (showLegacyReview && legacyState != null) {
+                        LegacyRestoreReviewDialog(
+                            matches = legacyState.suggestions,
+                            onConfirm = ::startLegacyRestore,
+                            onDismiss = {
+                                showLegacyReview = false
+                                podcastViewModel.finishLegacyRestoreReview(0)
+                            },
+                        )
+                    }
+
+                    duplicatePlan?.let { plan ->
+                        DuplicateCleanupDialog(
+                            plan = plan,
+                            onConfirm = { uris ->
+                                duplicatePlan = null
+                                requestConsentDelete(uris)
+                            },
+                            onDismiss = { duplicatePlan = null },
+                        )
+                    }
                 }
 
                 composable(Routes.Settings) {
+                    val scope = rememberCoroutineScope()
                     val themeMode by appSettings.themeMode.collectAsState()
                     val defaultSpeed by appSettings.defaultPlaybackSpeed.collectAsState()
                     val autoDownloadOnCellular by appSettings.autoDownloadOnCellular.collectAsState()
+                    val retentionLimit by appSettings.autoDownloadRetentionLimit.collectAsState()
+                    var pendingRetentionLimit by remember { mutableStateOf<Int?>(null) }
+                    var pendingRetentionTrimCount by remember { mutableStateOf(0) }
 
                     SettingsScreen(
                         themeMode = themeMode,
                         defaultPlaybackSpeed = defaultSpeed,
                         autoDownloadOnCellular = autoDownloadOnCellular,
+                        autoDownloadRetentionLimit = retentionLimit,
                         appVersion = BuildConfig.VERSION_NAME,
                         onThemeChange = appSettings::setThemeMode,
                         onPlaybackSpeedChange = appSettings::setDefaultPlaybackSpeed,
@@ -699,8 +862,54 @@ fun PodcastNavHost(
                                 context, allowCellular = enabled,
                             )
                         },
+                        onAutoDownloadRetentionChange = { requested ->
+                            val lowering = retentionLimit == AppSettings.UNLIMITED_RETENTION ||
+                                (requested != AppSettings.UNLIMITED_RETENTION && requested < retentionLimit)
+                            if (!lowering) {
+                                appSettings.setAutoDownloadRetentionLimit(requested)
+                            } else {
+                                scope.launch {
+                                    pendingRetentionTrimCount =
+                                        com.podcastplayer.app.service.AutoDownloadRetentionManager(context)
+                                            .previewTrimCount(requested)
+                                    pendingRetentionLimit = requested
+                                }
+                            }
+                        },
                         onBack = { navController.popBackStack() },
                     )
+
+                    val proposedLimit = pendingRetentionLimit
+                    if (proposedLimit != null) {
+                        androidx.compose.material3.AlertDialog(
+                            onDismissRequest = { pendingRetentionLimit = null },
+                            title = { androidx.compose.material3.Text("Lower auto-download limit?") },
+                            text = {
+                                androidx.compose.material3.Text(
+                                    "$pendingRetentionTrimCount older automatic file" +
+                                        (if (pendingRetentionTrimCount == 1) " is" else "s are") +
+                                        " eligible for removal. Manual and restored downloads stay pinned."
+                                )
+                            },
+                            confirmButton = {
+                                androidx.compose.material3.TextButton(
+                                    onClick = {
+                                        appSettings.setAutoDownloadRetentionLimit(proposedLimit)
+                                        pendingRetentionLimit = null
+                                        scope.launch {
+                                            com.podcastplayer.app.service.AutoDownloadRetentionManager(context)
+                                                .trimAll(proposedLimit)
+                                        }
+                                    },
+                                ) { androidx.compose.material3.Text("Apply and trim") }
+                            },
+                            dismissButton = {
+                                androidx.compose.material3.TextButton(
+                                    onClick = { pendingRetentionLimit = null },
+                                ) { androidx.compose.material3.Text("Cancel") }
+                            },
+                        )
+                    }
                 }
 
                 composable(Routes.Player) {

--- a/app/src/main/java/com/podcastplayer/app/presentation/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/ui/SettingsScreen.kt
@@ -47,10 +47,12 @@ fun SettingsScreen(
     themeMode: ThemeMode,
     defaultPlaybackSpeed: Float,
     autoDownloadOnCellular: Boolean,
+    autoDownloadRetentionLimit: Int,
     appVersion: String,
     onThemeChange: (ThemeMode) -> Unit,
     onPlaybackSpeedChange: (Float) -> Unit,
     onAutoDownloadCellularChange: (Boolean) -> Unit,
+    onAutoDownloadRetentionChange: (Int) -> Unit,
     onBack: () -> Unit,
 ) {
     Column(
@@ -81,6 +83,11 @@ fun SettingsScreen(
                 checked = autoDownloadOnCellular,
                 onCheckedChange = onAutoDownloadCellularChange,
             )
+            DividerHairline()
+            AutoDownloadRetentionPicker(
+                current = autoDownloadRetentionLimit,
+                onSelect = onAutoDownloadRetentionChange,
+            )
         }
 
         SettingsGroup(label = "About") {
@@ -92,6 +99,34 @@ fun SettingsScreen(
         }
 
         Spacer(Modifier.height(120.dp))
+    }
+}
+
+@Composable
+private fun AutoDownloadRetentionPicker(current: Int, onSelect: (Int) -> Unit) {
+    Column(modifier = Modifier.padding(vertical = 6.dp)) {
+        Text(
+            text = "Auto-downloads kept per podcast",
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
+        )
+        Text(
+            text = "Manual and restored downloads are always pinned.",
+            fontSize = 11.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 14.dp).padding(bottom = 4.dp),
+        )
+        AppSettings.AUTO_DOWNLOAD_RETENTION_LIMITS.forEach { limit ->
+            val label = if (limit == AppSettings.UNLIMITED_RETENTION) "Unlimited" else limit.toString()
+            SelectableRow(
+                icon = Icons.Outlined.CloudDownload,
+                title = label,
+                selected = current == limit,
+                onClick = { onSelect(limit) },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
+++ b/app/src/main/java/com/podcastplayer/app/presentation/viewmodel/PodcastViewModel.kt
@@ -3,7 +3,13 @@ package com.podcastplayer.app.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.podcastplayer.app.data.local.MediaNaming
+import com.podcastplayer.app.data.local.MediaIdentity
+import com.podcastplayer.app.data.local.MediaFileCandidate
 import com.podcastplayer.app.data.local.MediaStoreScanner
+import com.podcastplayer.app.data.local.RestoreEpisodeCandidate
+import com.podcastplayer.app.data.local.RestorePlanner
+import com.podcastplayer.app.data.local.DuplicateCleanupPlan
+import com.podcastplayer.app.data.local.DuplicateCleanupPlanner
 import com.podcastplayer.app.data.local.OpmlExportSummary
 import com.podcastplayer.app.data.local.OpmlImportData
 import com.podcastplayer.app.data.local.OpmlManager
@@ -321,17 +327,7 @@ class PodcastViewModel(
 
     fun hasMediaReadPermission(): Boolean = mediaScanner?.hasReadPermission() == true
 
-    /**
-     * Relink media files already on disk (typically left behind by a previous
-     * install) instead of forcing the user to re-download everything.
-     *
-     * Pass 1 — for each subscribed podcast, fetch its feed and match episodes
-     * against the scanned files by [MediaNaming.matchKey]; hits are registered
-     * as downloads pointing at the existing file. Pass 2 — files that matched
-     * nothing (yt-dlp clips, episodes of not-yet-resubscribed shows) are
-     * imported as playable orphan entries, one per name key so "(1)"-style
-     * duplicate copies aren't imported alongside their original.
-     */
+    /** Exact stable identities restore automatically; legacy title guesses require confirmation. */
     fun restorePreviousDownloads() {
         val scanner = mediaScanner ?: return
         if (_restoreState.value is RestoreDownloadsState.Running) return
@@ -345,82 +341,98 @@ class PodcastViewModel(
                     return@launch
                 }
 
-                // Files already referenced by either downloads table are not
-                // candidates — and neither is any same-named duplicate of them.
                 val referencedUris = buildSet {
                     downloadManager.getAllDownloadedEntitiesFlow().first().forEach { add(it.localPath) }
                     urlDownloadRepository?.observeAll()?.first()?.forEach { it.localPath?.let(::add) }
                 }
-                val claimedUris = referencedUris.toMutableSet()
-                val claimedKeys = found
-                    .filter { it.uriString in referencedUris }
-                    .map { MediaNaming.matchKey(it.displayName) }
-                    .toMutableSet()
-
-                val audioByKey = found.filter { !it.isVideo }
-                    .groupBy { MediaNaming.matchKey(it.displayName) }
-
-                var restoredEpisodes = 0
+                val candidates = found.filterNot { it.uriString in referencedUris }.map { it.toCandidate() }
+                val episodeById = linkedMapOf<String, Episode>()
+                val restoreEpisodes = mutableListOf<RestoreEpisodeCandidate>()
                 for (podcast in savedPodcastsStorage.savedPodcasts.value) {
                     val feedUrl = podcast.feedUrl ?: continue
                     val episodes = repository.getEpisodes(feedUrl, podcast.id).getOrNull() ?: continue
                     for (episode in episodes) {
                         if (downloadManager.isEpisodeDownloaded(episode.id)) continue
-                        val key = MediaNaming.matchKey(
-                            MediaNaming.episodeDisplayName(podcast.title, episode.title, "mp3"),
+                        episodeById[episode.id] = episode
+                        restoreEpisodes += RestoreEpisodeCandidate(
+                            episodeId = episode.id,
+                            identity = MediaIdentity.rss(episode.id),
+                            legacyMatchKey = MediaNaming.matchKey(
+                                MediaNaming.episodeDisplayName(podcast.title, episode.title, "mp3"),
+                            ),
                         )
-                        val pick = audioByKey[key]
-                            ?.filter { it.uriString !in claimedUris }
-                            ?.minWithOrNull(
-                                compareBy(
-                                    { MediaNaming.hasDuplicateSuffix(it.displayName) },
-                                    { it.dateAddedSec },
-                                ),
-                            ) ?: continue
-                        claimedUris += pick.uriString
-                        claimedKeys += key
-                        downloadManager.registerExistingDownload(
-                            episode = episode,
-                            localPath = pick.uriString,
-                            fileSize = pick.sizeBytes,
-                        )
-                        // If an earlier restore imported this file as an orphan clip,
-                        // drop that row now that it has a proper episode identity.
-                        urlDownloadRepository?.removeRestoredFor(pick.uriString)
-                        restoredEpisodes++
                     }
                 }
 
-                // Orphans: at most one import per name key, skipping keys already
-                // represented in the library (their extra copies are duplicates
-                // for the cleaner, not new content).
+                val plan = RestorePlanner.plan(restoreEpisodes, candidates)
+                var restoredEpisodes = 0
+                plan.exactMatches.forEach { (episodeId, file) ->
+                    val episode = episodeById[episodeId] ?: return@forEach
+                    downloadManager.registerExistingDownload(episode, file.uriString, file.sizeBytes)
+                    urlDownloadRepository?.removeRestoredFor(file.uriString)
+                    restoredEpisodes++
+                }
+
                 var importedClips = 0
-                val orphanGroups = found
-                    .filter { it.uriString !in claimedUris }
-                    .groupBy { it.isVideo to MediaNaming.matchKey(it.displayName) }
-                for ((groupKey, candidates) in orphanGroups) {
-                    if (groupKey.second in claimedKeys) continue
-                    val pick = candidates.minWithOrNull(
-                        compareBy(
-                            { MediaNaming.hasDuplicateSuffix(it.displayName) },
-                            { it.dateAddedSec },
-                        ),
-                    ) ?: continue
+                val unidentified = plan.unidentified + plan.legacySuggestions.map { it.file }
+                for (file in unidentified.distinctBy { it.uriString }) {
                     val imported = urlDownloadRepository?.importRestored(
-                        displayName = pick.displayName,
-                        uriString = pick.uriString,
-                        sizeBytes = pick.sizeBytes,
-                        isVideo = pick.isVideo,
+                        displayName = "Unidentified - ${MediaNaming.titleFromDisplayName(file.displayName)}",
+                        uriString = file.uriString,
+                        sizeBytes = file.sizeBytes,
+                        isVideo = file.isVideo,
                     ) == true
                     if (imported) importedClips++
                 }
 
                 refreshEpisodesWithDownloads()
-                _restoreState.value = RestoreDownloadsState.Done(restoredEpisodes, importedClips)
+                val suggestions = plan.legacySuggestions.mapNotNull { suggestion ->
+                    episodeById[suggestion.episodeId]?.let { episode ->
+                        LegacyRestoreMatch(
+                            episode = episode,
+                            file = suggestion.file,
+                            identifiedDisplayName = MediaNaming.addIdentity(
+                                suggestion.file.displayName,
+                                MediaIdentity.rss(episode.id),
+                            ),
+                        )
+                    }
+                }
+                _restoreState.value = if (suggestions.isEmpty()) {
+                    RestoreDownloadsState.Done(restoredEpisodes, importedClips)
+                } else {
+                    RestoreDownloadsState.ReviewLegacy(restoredEpisodes, importedClips, suggestions)
+                }
             } catch (t: Throwable) {
                 _restoreState.value = RestoreDownloadsState.Failed(t.message ?: "Restore failed")
             }
         }
+    }
+
+    suspend fun applyLegacyRestoreMatch(match: LegacyRestoreMatch): MediaStoreScanner.MutationResult =
+        withContext(Dispatchers.IO) {
+            val scanner = mediaScanner ?: return@withContext MediaStoreScanner.MutationResult.Failed
+            when (val result = scanner.rename(match.file.uriString, match.identifiedDisplayName)) {
+                MediaStoreScanner.MutationResult.Success -> {
+                    downloadManager.registerExistingDownload(
+                        episode = match.episode,
+                        localPath = match.file.uriString,
+                        fileSize = match.file.sizeBytes,
+                    )
+                    urlDownloadRepository?.removeRestoredFor(match.file.uriString)
+                    refreshEpisodesWithDownloads()
+                    result
+                }
+                else -> result
+            }
+        }
+
+    fun finishLegacyRestoreReview(confirmedCount: Int) {
+        val state = _restoreState.value as? RestoreDownloadsState.ReviewLegacy ?: return
+        _restoreState.value = RestoreDownloadsState.Done(
+            restoredEpisodes = state.restoredEpisodes + confirmedCount,
+            importedClips = (state.importedClips - confirmedCount).coerceAtLeast(0),
+        )
     }
 
     /**
@@ -429,28 +441,21 @@ class PodcastViewModel(
      * keeping one copy per name key. The UI feeds these into the system's
      * batch-delete consent dialog.
      */
-    suspend fun planDuplicateCleanup(): List<String> = withContext(Dispatchers.IO) {
-        val scanner = mediaScanner ?: return@withContext emptyList()
+    suspend fun planDuplicateCleanup(): DuplicateCleanupPlan = withContext(Dispatchers.IO) {
+        val scanner = mediaScanner ?: return@withContext DuplicateCleanupPlan(emptyList(), emptyList())
         val found = scanner.scanAll()
         val referencedUris = buildSet {
             downloadManager.getAllDownloadedEntitiesFlow().first().forEach { add(it.localPath) }
             urlDownloadRepository?.observeAll()?.first()?.forEach { it.localPath?.let(::add) }
         }
-        found
-            .groupBy { it.isVideo to MediaNaming.matchKey(it.displayName) }
-            .values
-            .filter { it.size > 1 }
-            .flatMap { group ->
-                val keep = group.firstOrNull { it.uriString in referencedUris }
-                    ?: group.minWithOrNull(
-                        compareBy(
-                            { MediaNaming.hasDuplicateSuffix(it.displayName) },
-                            { it.dateAddedSec },
-                        ),
-                    )
-                group.filter { it !== keep && it.uriString !in referencedUris }
-                    .map { it.uriString }
-            }
+        val hashableSizes = found.groupBy { it.sizeBytes }.filterValues { it.size > 1 }.keys
+        val candidates = found.map { media ->
+            media.toCandidate(
+                isProtected = media.uriString in referencedUris,
+                sha256 = if (media.sizeBytes in hashableSizes) scanner.sha256(media.uriString) else null,
+            )
+        }
+        DuplicateCleanupPlanner.plan(candidates)
     }
 
     /**
@@ -732,10 +737,35 @@ sealed class RestoreDownloadsState {
     data object Idle : RestoreDownloadsState()
     data object Running : RestoreDownloadsState()
 
+    data class ReviewLegacy(
+        val restoredEpisodes: Int,
+        val importedClips: Int,
+        val suggestions: List<LegacyRestoreMatch>,
+    ) : RestoreDownloadsState()
+
     /** [restoredEpisodes] relinked to subscriptions; [importedClips] kept as orphan entries. */
     data class Done(val restoredEpisodes: Int, val importedClips: Int) : RestoreDownloadsState()
     data class Failed(val message: String) : RestoreDownloadsState()
 }
+
+data class LegacyRestoreMatch(
+    val episode: Episode,
+    val file: MediaFileCandidate,
+    val identifiedDisplayName: String,
+)
+
+private fun MediaStoreScanner.FoundMedia.toCandidate(
+    isProtected: Boolean = false,
+    sha256: String? = null,
+): MediaFileCandidate = MediaFileCandidate(
+    uriString = uriString,
+    displayName = displayName,
+    sizeBytes = sizeBytes,
+    dateAddedSec = dateAddedSec,
+    isVideo = isVideo,
+    sha256 = sha256,
+    isProtected = isProtected,
+)
 
 /** Bound on simultaneous RSS feed fetches when building a queue playlist. */
 private const val MAX_CONCURRENT_QUEUE_FEED_FETCHES = 4

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadRetentionManager.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadRetentionManager.kt
@@ -1,0 +1,81 @@
+package com.podcastplayer.app.service
+
+import android.content.Context
+import com.podcastplayer.app.data.local.AppSettings
+import com.podcastplayer.app.data.local.AutoDownloadRetentionPlanner
+import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.DownloadOrigin
+import com.podcastplayer.app.data.local.RetentionCandidate
+import com.podcastplayer.app.data.repository.DownloadManager
+import com.podcastplayer.app.data.repository.UrlDownloadRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/** Applies the global limit independently to each podcast's completed AUTO items. */
+class AutoDownloadRetentionManager(private val context: Context) {
+
+    private val database get() = DatabaseProvider.getDatabase(context)
+
+    suspend fun previewTrimCount(newLimit: Int): Int = withContext(Dispatchers.IO) {
+        autoPodcastIds().sumOf { podcastId -> candidates(podcastId, newLimit).size }
+    }
+
+    suspend fun trimAll(newLimit: Int = currentLimit()): Int = withContext(Dispatchers.IO) {
+        autoPodcastIds().sumOf { trimPodcast(it, newLimit) }
+    }
+
+    suspend fun trimPodcast(podcastId: String, limit: Int = currentLimit()): Int =
+        withContext(Dispatchers.IO) {
+            retentionMutex.withLock {
+                val prune = candidates(podcastId, limit)
+                val rss = DownloadManager(context)
+                val urls = UrlDownloadRepository(context)
+                prune.count { item ->
+                    val consent = when (item.source) {
+                        RetentionCandidate.Source.RSS -> rss.deleteEpisode(item.id)
+                        RetentionCandidate.Source.URL -> urls.delete(item.id)
+                    }
+                    // AUTO files were written by this install. If an OEM provider
+                    // unexpectedly asks for consent, do not claim it was pruned.
+                    consent.isEmpty()
+                }
+            }
+        }
+
+    private suspend fun candidates(podcastId: String, limit: Int): List<RetentionCandidate> {
+        val rss = database.downloadedEpisodeDao().getAutoEpisodesByPodcast(podcastId).map {
+            RetentionCandidate(
+                id = it.id,
+                podcastId = it.podcastId,
+                publicationTimeMs = it.pubDate,
+                completedTimeMs = it.downloadDate,
+                isPinned = it.origin != DownloadOrigin.AUTO.name,
+                source = RetentionCandidate.Source.RSS,
+            )
+        }
+        val url = database.urlDownloadDao().getCompletedAutoByPodcast(podcastId).map {
+            RetentionCandidate(
+                id = it.id,
+                podcastId = requireNotNull(it.podcastId),
+                publicationTimeMs = it.episodePubDateMs,
+                completedTimeMs = it.completedAtMs ?: it.createdAtMs,
+                isPinned = it.origin != DownloadOrigin.AUTO.name,
+                source = RetentionCandidate.Source.URL,
+            )
+        }
+        return AutoDownloadRetentionPlanner.itemsToPrune(rss + url, limit)
+    }
+
+    private suspend fun autoPodcastIds(): Set<String> = buildSet {
+        addAll(database.downloadedEpisodeDao().getAutoPodcastIds())
+        addAll(database.urlDownloadDao().getAutoPodcastIds())
+    }
+
+    private fun currentLimit(): Int = AppSettings.getInstance(context).autoDownloadRetentionLimit.value
+
+    companion object {
+        private val retentionMutex = Mutex()
+    }
+}

--- a/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/AutoDownloadWorker.kt
@@ -10,6 +10,9 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.podcastplayer.app.data.local.AppSettings
 import com.podcastplayer.app.data.local.DatabaseProvider
+import com.podcastplayer.app.data.local.DownloadOrigin
+import com.podcastplayer.app.data.local.AutoDownloadRetentionPlanner
+import com.podcastplayer.app.data.local.RestoreEpisodeCandidateForRetention
 import com.podcastplayer.app.data.local.QueueStorage
 import com.podcastplayer.app.data.local.SavedPodcastsStorage
 import com.podcastplayer.app.data.remote.RssParser
@@ -127,6 +130,8 @@ class AutoDownloadWorker(
             val downloadManager = DownloadManager(context)
             val urlDownloadRepository = UrlDownloadRepository(context)
             val downloadedDao = DatabaseProvider.getDatabase(context).downloadedEpisodeDao()
+            val retentionLimit = AppSettings.getInstance(context).autoDownloadRetentionLimit.value
+            val retentionManager = AutoDownloadRetentionManager(context)
 
             val cutoffMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(MAX_AGE_DAYS)
             var queuedUrlDownloads = false
@@ -145,7 +150,14 @@ class AutoDownloadWorker(
                     pubMs >= cutoffMs && progressByEpisodeId[ep.id]?.completed != true
                 }
 
-                for (episode in freshEpisodes) {
+                val selectedIds = AutoDownloadRetentionPlanner.selectEligibleEpisodes(
+                    episodes = freshEpisodes.map {
+                        RestoreEpisodeCandidateForRetention(it.id, requireNotNull(it.pubDate).time)
+                    },
+                    limit = retentionLimit,
+                ).mapTo(hashSetOf()) { it.id }
+
+                for (episode in freshEpisodes.filter { it.id in selectedIds }) {
                     if (UrlSource.classify(episode.audioUrl) == UrlSource.YOUTUBE) {
                         urlDownloadRepository.enqueue(
                             rawUrl = episode.audioUrl,
@@ -156,6 +168,9 @@ class AutoDownloadWorker(
                                 thumbnailUrl = episode.imageUrl,
                                 durationMs = episode.duration,
                             ),
+                            origin = DownloadOrigin.AUTO,
+                            podcastId = podcast.id,
+                            episodePubDateMs = episode.pubDate?.time,
                         )
                         queuedUrlDownloads = true
                         continue
@@ -163,7 +178,12 @@ class AutoDownloadWorker(
                     if (downloadedDao.isEpisodeDownloaded(episode.id)) continue
                     val withArtwork = ensureArtwork(episode, podcast)
                     // Result is ignored — periodic work; we'll try again next interval.
-                    downloadManager.downloadEpisode(withArtwork, podcastTitle = podcast.title)
+                    val result = downloadManager.downloadEpisode(
+                        episode = withArtwork,
+                        podcastTitle = podcast.title,
+                        origin = DownloadOrigin.AUTO,
+                    )
+                    if (result.isSuccess) retentionManager.trimPodcast(podcast.id, retentionLimit)
                 }
             }
             if (queuedUrlDownloads) urlDownloadRepository.startPump()

--- a/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
+++ b/app/src/main/java/com/podcastplayer/app/service/UrlDownloadService.kt
@@ -15,6 +15,7 @@ import androidx.core.app.NotificationCompat
 import com.podcastplayer.app.MainActivity
 import com.podcastplayer.app.PodcastApplication
 import com.podcastplayer.app.data.local.MediaNaming
+import com.podcastplayer.app.data.local.MediaIdentity
 import com.podcastplayer.app.data.local.MediaStoreSaver
 import com.podcastplayer.app.data.local.MediaStoreScanner
 import com.podcastplayer.app.data.repository.UrlDownloadRepository
@@ -172,6 +173,7 @@ class UrlDownloadService : Service() {
                 uploader = entity.uploader,
                 title = entity.title,
                 extension = if (requestedType == MediaType.VIDEO) "mp4" else "mp3",
+                identity = MediaIdentity.url(entity.id),
             )
             val reusable = MediaStoreScanner(applicationContext)
                 .findExisting(isVideo = requestedType == MediaType.VIDEO, expectedDisplayName = expectedName)
@@ -222,7 +224,7 @@ class UrlDownloadService : Service() {
             // Try to publish to MediaStore (Android 10+) so VLC, Files, and the
             // Gallery can discover the file. Falls back to app-private storage on
             // older devices.
-            val displayName = buildDisplayName(entity.title, entity.uploader, produced.extension)
+            val displayName = buildDisplayName(entity.id, entity.title, entity.uploader, produced.extension)
             val saved = publishToMediaStore(produced, requestedType, displayName)
 
             if (saved != null) {
@@ -308,8 +310,8 @@ class UrlDownloadService : Service() {
      * "Lex Fridman - Joe Rogan #1.mp4" rather than just the bare video title.
      * Building/sanitizing live in [MediaNaming] so reuse matching stays in sync.
      */
-    private fun buildDisplayName(title: String, uploader: String?, extension: String): String =
-        MediaNaming.urlDisplayName(uploader, title, extension)
+    private fun buildDisplayName(id: String, title: String, uploader: String?, extension: String): String =
+        MediaNaming.urlDisplayName(uploader, title, extension, MediaIdentity.url(id))
 
     private fun pickProducedFile(dir: File): File? {
         val files = dir.listFiles()?.toList().orEmpty()

--- a/app/src/test/java/com/podcastplayer/app/data/local/DownloadPlannersTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/local/DownloadPlannersTest.kt
@@ -1,0 +1,135 @@
+package com.podcastplayer.app.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadPlannersTest {
+
+    @Test
+    fun `restore uses exact identity and leaves legacy match for confirmation`() {
+        val exactIdentity = MediaIdentity.rss("exact")
+        val episodes = listOf(
+            RestoreEpisodeCandidate("exact", exactIdentity, "show - repeated"),
+            RestoreEpisodeCandidate("legacy", MediaIdentity.rss("legacy"), "show - legacy"),
+        )
+        val exact = file("exact", "Repeated${exactIdentity.suffix}.mp3")
+        val legacy = file("legacy", "Show - Legacy.mp3")
+
+        val plan = RestorePlanner.plan(episodes, listOf(exact, legacy))
+
+        assertEquals(exact, plan.exactMatches["exact"])
+        assertEquals(listOf("legacy"), plan.legacySuggestions.map { it.episodeId })
+        assertTrue(plan.unidentified.isEmpty())
+    }
+
+    @Test
+    fun `repeated legacy titles are ambiguous and never suggested`() {
+        val episodes = listOf(
+            RestoreEpisodeCandidate("one", MediaIdentity.rss("one"), "show - update"),
+            RestoreEpisodeCandidate("two", MediaIdentity.rss("two"), "show - update"),
+        )
+        val legacy = file("legacy", "Show - Update.mp3")
+
+        val plan = RestorePlanner.plan(episodes, listOf(legacy))
+
+        assertTrue(plan.legacySuggestions.isEmpty())
+        assertEquals(listOf(legacy), plan.unidentified)
+    }
+
+    @Test
+    fun `stable ID duplicates are confirmed and protected references are disabled`() {
+        val identity = MediaIdentity.rss("same")
+        val referenced = file("ref", "Episode${identity.suffix}.mp3", size = 50, protected = true)
+        val duplicate = file("dup", "Episode${identity.suffix} (1).mp3", size = 100)
+
+        val plan = DuplicateCleanupPlanner.plan(listOf(referenced, duplicate))
+
+        assertEquals(1, plan.confirmed.size)
+        assertFalse(plan.confirmed.single().items.first { it.file == referenced }.enabled)
+        assertTrue(duplicate.uriString in plan.defaultDeleteUris)
+    }
+
+    @Test
+    fun `byte identical files with different titles are confirmed`() {
+        val first = file("one", "One.mp3", hash = "abc")
+        val second = file("two", "Two.mp3", hash = "abc")
+
+        val group = DuplicateCleanupPlanner.plan(listOf(first, second)).confirmed.single()
+
+        assertEquals(ConfirmedDuplicateGroup.Reason.IDENTICAL_CONTENT, group.reason)
+        assertEquals(1, group.items.count { it.selectedByDefault })
+    }
+
+    @Test
+    fun `same legacy title with different content is ambiguous and unselected`() {
+        val first = file("one", "Episode.mp3", size = 100, hash = "aaa")
+        val second = file("two", "Episode (1).mp3", size = 100, hash = "bbb")
+
+        val plan = DuplicateCleanupPlanner.plan(listOf(first, second))
+
+        assertTrue(plan.confirmed.isEmpty())
+        assertEquals(1, plan.ambiguous.size)
+        assertTrue(plan.ambiguous.single().items.none { it.selectedByDefault })
+    }
+
+    @Test
+    fun `keep selection prefers largest then unsuffixed then oldest`() {
+        val identity = MediaIdentity.rss("same")
+        val small = file("small", "Ep${identity.suffix}.mp3", size = 50, date = 1)
+        val suffixed = file("suffix", "Ep${identity.suffix} (1).mp3", size = 100, date = 1)
+        val old = file("old", "Ep${identity.suffix}.mp3", size = 100, date = 1)
+        val new = file("new", "Ep${identity.suffix}.mp3", size = 100, date = 2)
+
+        val keep = DuplicateCleanupPlanner.plan(listOf(small, suffixed, new, old)).confirmed.single().keep
+
+        assertEquals(old, keep)
+    }
+
+    @Test
+    fun `retention is per podcast ordered by publication and preserves pinned`() {
+        val items = listOf(
+            retention("pinned", 1, pinned = true),
+            retention("new", 30),
+            retention("middle", 20, source = RetentionCandidate.Source.URL),
+            retention("old", 10),
+        )
+
+        val prune = AutoDownloadRetentionPlanner.itemsToPrune(items, limit = 2)
+
+        assertEquals(listOf("old"), prune.map { it.id })
+        assertFalse(prune.any { it.id == "pinned" })
+    }
+
+    @Test
+    fun `unlimited retention prunes nothing and eligible selection is newest first`() {
+        val items = listOf(retention("one", 1), retention("two", 2))
+        assertTrue(AutoDownloadRetentionPlanner.itemsToPrune(items, AutoDownloadRetentionPlanner.UNLIMITED).isEmpty())
+
+        val selected = AutoDownloadRetentionPlanner.selectEligibleEpisodes(
+            listOf(
+                RestoreEpisodeCandidateForRetention("old", 1),
+                RestoreEpisodeCandidateForRetention("new", 2),
+            ),
+            limit = 1,
+        )
+        assertEquals(listOf("new"), selected.map { it.id })
+    }
+
+    private fun file(
+        uri: String,
+        name: String,
+        size: Long = 100,
+        date: Long = 1,
+        hash: String? = null,
+        protected: Boolean = false,
+    ) = MediaFileCandidate(uri, name, size, date, false, sha256 = hash, isProtected = protected)
+
+    private fun retention(
+        id: String,
+        publication: Long,
+        pinned: Boolean = false,
+        source: RetentionCandidate.Source = RetentionCandidate.Source.RSS,
+    ) = RetentionCandidate(id, "podcast", publication, publication, pinned, source)
+}

--- a/app/src/test/java/com/podcastplayer/app/data/local/MediaNamingTest.kt
+++ b/app/src/test/java/com/podcastplayer/app/data/local/MediaNamingTest.kt
@@ -102,4 +102,34 @@ class MediaNamingTest {
         assertEquals(120, MediaNaming.sanitize("x".repeat(300)).length)
         assertEquals("vibe-media", MediaNaming.sanitize(""))
     }
+
+    @Test
+    fun `identified names round trip and keep suffix inside length limit`() {
+        val identity = MediaIdentity.rss("guid-123")
+        val name = MediaNaming.episodeDisplayName(
+            "Very long podcast ".repeat(20),
+            "Very long episode ".repeat(20),
+            "mp3",
+            identity,
+        )
+
+        assertTrue(name.length <= MediaNaming.MAX_DISPLAY_NAME_LENGTH)
+        assertEquals(identity, MediaIdentity.parse(name))
+        assertEquals(identity, MediaIdentity.parse(name.removeSuffix(".mp3") + " (12).mp3"))
+    }
+
+    @Test
+    fun `same title with different stable IDs gets different names`() {
+        val first = MediaNaming.episodeDisplayName("Show", "Update", "mp3", MediaIdentity.rss("one"))
+        val second = MediaNaming.episodeDisplayName("Show", "Update", "mp3", MediaIdentity.rss("two"))
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun `adding identity preserves readable legacy title`() {
+        val identity = MediaIdentity.rss("guid")
+        val renamed = MediaNaming.addIdentity("Show - Episode (2).mp3", identity)
+        assertEquals("Show - Episode", MediaNaming.titleFromDisplayName(renamed))
+        assertEquals(identity, MediaIdentity.parse(renamed))
+    }
 }


### PR DESCRIPTION
## Summary\n\n- Embed versioned SHA-256 RSS and URL identities in MediaStore names and restore only exact matches automatically.\n- Keep unmatched files playable as Unidentified, require explicit legacy-match review, and rename before registering.\n- Classify stable-ID and byte-identical duplicates with protected-file handling, deterministic keep selection, manual ambiguous review, Android 10 sequential consent, Android 11+ batch consent, and post-delete rescans.\n- Migrate Room to v4 with MANUAL and AUTO download origins plus URL podcast and publication metadata.\n- Enforce configurable per-podcast auto-download retention across RSS and URL-backed episodes while preserving pinned downloads.\n- Add JVM planner coverage and an Android Room 3-to-4 migration test.\n\n## Verification\n\n- ./gradlew testDebugUnitTest\n- ./gradlew lint\n- ./gradlew assembleDebug\n- ./gradlew compileDebugAndroidTestKotlin\n- git diff --check\n\nNo Android device or emulator was attached locally, so connected Android 10 and 11 consent tests and the migration instrumentation test were compiled but not executed. The existing pull-request workflow will rerun unit tests, build the debug APK, and upload it as an artifact.